### PR TITLE
Receive and display nodeCount and publicURL in cluster table

### DIFF
--- a/packages/teleport/src/dashboard/components/Clusters/ClusterList/ClusterList.tsx
+++ b/packages/teleport/src/dashboard/components/Clusters/ClusterList/ClusterList.tsx
@@ -118,10 +118,10 @@ export default function ClustersList(props: ClusterListProps) {
         cell={<TextCell />}
       />
       <Column
-        columnKey="publicUrl"
+        columnKey="publicURL"
         header={
           <SortHeaderCell
-            sortDir={sortDir.publicUrl}
+            sortDir={sortDir.publicURL}
             onSortChange={onSortChange}
             title="Public URL"
           />

--- a/packages/teleport/src/services/clusters/makeCluster.ts
+++ b/packages/teleport/src/services/clusters/makeCluster.ts
@@ -19,23 +19,25 @@ import { displayDateTime } from 'shared/services/loc';
 import { Cluster } from './types';
 
 export default function makeCluster(json): Cluster {
-  const [clusterId, connected, status] = at(json, [
+  const [clusterId, lastConnected, status, nodeCount, publicURL] = at(json, [
     'name',
-    'last_connected',
+    'lastConnected',
     'status',
+    'nodeCount',
+    'publicURL',
   ]);
 
-  const connectedText = displayDateTime(connected);
+  const connectedText = displayDateTime(lastConnected);
 
   return {
     clusterId,
-    connected: new Date(connected),
+    lastConnected: new Date(lastConnected),
     connectedText,
     status,
     url: cfg.getClusterRoute(clusterId),
-    publicUrl: 'not implemented',
     version: 'not implemented',
-    nodeCount: -1,
+    nodeCount: nodeCount,
+    publicURL: publicURL,
   };
 }
 

--- a/packages/teleport/src/services/clusters/types.ts
+++ b/packages/teleport/src/services/clusters/types.ts
@@ -16,11 +16,11 @@ limitations under the License.
 
 export interface Cluster {
   clusterId: string;
-  connected: Date;
+  lastConnected: Date;
   connectedText: string;
   status: string;
   url: string;
   nodeCount: number;
-  publicUrl: string;
+  publicURL: string;
   version: string;
 }


### PR DESCRIPTION
Resolves part of https://github.com/gravitational/teleport/issues/2924
Still need to display AuthVersion, mentioned in issue: https://github.com/gravitational/teleport/issues/3469

#### Definition:
- Receive and display `nodeCount` and `publicURL` from backend

In Cluster interface:
- Rename `connected` to `lastConnected`
- Rename `publicUrl` to `publicURL`



#### Manual Testing:
Look at corresponding PR for screenshots https://github.com/gravitational/teleport/pull/3476