### PR TITLE
Receive auth version for Cluster interface

### DIFF
--- a/packages/teleport/src/dashboard/components/Clusters/ClusterList/ClusterList.tsx
+++ b/packages/teleport/src/dashboard/components/Clusters/ClusterList/ClusterList.tsx
@@ -96,10 +96,10 @@ export default function ClustersList(props: ClusterListProps) {
         cell={<NameCell />}
       />
       <Column
-        columnKey="version"
+        columnKey="authVersion"
         header={
           <SortHeaderCell
-            sortDir={sortDir.version}
+            sortDir={sortDir.authVersion}
             onSortChange={onSortChange}
             title="Version"
           />
@@ -136,7 +136,7 @@ export default function ClustersList(props: ClusterListProps) {
 function filter(clusters: Cluster[], searchValue = '') {
   return clusters.filter(obj =>
     isMatch(obj, searchValue, {
-      searchableProps: ['clusterId', 'version'],
+      searchableProps: ['clusterId', 'authVersion'],
       cb: filterCb,
     })
   );

--- a/packages/teleport/src/services/clusters/makeCluster.ts
+++ b/packages/teleport/src/services/clusters/makeCluster.ts
@@ -43,9 +43,9 @@ export default function makeCluster(json): Cluster {
     connectedText,
     status,
     url: cfg.getClusterRoute(clusterId),
-    version: authVersion,
-    nodeCount: nodeCount,
-    publicURL: publicURL,
+    authVersion,
+    nodeCount,
+    publicURL,
   };
 }
 

--- a/packages/teleport/src/services/clusters/types.ts
+++ b/packages/teleport/src/services/clusters/types.ts
@@ -22,5 +22,5 @@ export interface Cluster {
   url: string;
   nodeCount: number;
   publicURL: string;
-  version: string;
+  authVersion: string;
 }


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/2924

#### Description
- Receive authversion for cluster interface which will display auth version on cluster table

#### Manual Testing
teleport running on v `4.2.2-alpha.1`
![Screenshot from 2020-03-27 14-11-12](https://user-images.githubusercontent.com/43280172/77800803-d73e0e00-7034-11ea-8d49-42922b278e3d.png)


#### Related PR's
- set and retrieve teleport version: https://github.com/gravitational/teleport/pull/3484