### PR TITLE
Fix U2F login error messages

### DIFF
--- a/packages/shared/components/FormInvite/TwoFaInfo.jsx
+++ b/packages/shared/components/FormInvite/TwoFaInfo.jsx
@@ -45,7 +45,8 @@ export default function TwoFAData(props) {
         </Text>
         <Box color="text.primary">
           <Text typography="paragraph2" mb={3}>
-            Press the button on the U2F key after you press the sign up button
+            Press the button on the U2F key after you press the create account
+            button
           </Text>
           <Text typography="paragraph2" mb={3}>
             <StyledLink target="_blank" href={U2F_HELP_URL}>

--- a/packages/shared/components/FormInvite/__snapshots__/FormInvite.story.test.js.snap
+++ b/packages/shared/components/FormInvite/__snapshots__/FormInvite.story.test.js.snap
@@ -1094,7 +1094,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
           <div
             class="c13"
           >
-            Press the button on the U2F key after you press the sign up button
+            Press the button on the U2F key after you press the create account button
           </div>
           <div
             class="c13"

--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -161,11 +161,7 @@ const auth = {
 
     let message = `Please check your U2F settings, make sure it is plugged in and you are using the supported browser.\nU2F error: ${errorMsg}`;
 
-    return {
-      responseJSON: {
-        message,
-      },
-    };
+    return new Error(message);
   },
 };
 

--- a/packages/teleport/src/services/auth/auth.test.js
+++ b/packages/teleport/src/services/auth/auth.test.js
@@ -84,8 +84,9 @@ describe('services/auth', () => {
       await auth.loginWithU2f(email, password);
     } catch (err) {
       expect(window.u2f.sign).toHaveBeenCalled();
+      expect(err.message).not.toBeUndefined();
     }
-    expect.assertions(1);
+    expect.assertions(2);
   });
 
   test('resetPassword()', async () => {


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/3554

#### Definition
- Wrapped error with Error object
- Updated test to ensure error objects message is defined
- Update `sign up` to `create account` button wording

#### Screenshot
timeout error:
![Screenshot from 2020-04-16 15-11-09](https://user-images.githubusercontent.com/43280172/79511760-cdd11180-7ff4-11ea-9b27-22098df3357e.png)

badrequest error:
![Screenshot from 2020-04-16 15-11-56](https://user-images.githubusercontent.com/43280172/79511762-ce69a800-7ff4-11ea-88b5-dfb5c0b02864.png)

facet settings not set:
![Screenshot from 2020-04-16 15-12-26](https://user-images.githubusercontent.com/43280172/79511763-ce69a800-7ff4-11ea-9feb-b6e3656374de.png)

reword to match button text:
![screenshot](https://user-images.githubusercontent.com/43280172/79511764-cf023e80-7ff4-11ea-8dfb-ed7a0d61fc1e.png)

#### Related PRs
extract error message from u2f lib: https://github.com/gravitational/teleport/pull/3592