### PR TITLE
Clean up active sessions list

### DIFF
--- a/packages/teleport/src/cluster/components/Sessions/SessionList/ActionCell.tsx
+++ b/packages/teleport/src/cluster/components/Sessions/SessionList/ActionCell.tsx
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 import React from 'react';
+import MenuAction, { MenuItem } from 'shared/components/ActionMenu';
 import { NavLink } from 'react-router-dom';
 import { Cell } from 'design/DataTable';
-import { ButtonPrimary } from 'design';
 import { Session } from 'teleport/services/ssh';
 import cfg from 'teleport/config';
 
@@ -25,15 +25,14 @@ export default function ActionCell(props: any) {
   const { rowIndex, data } = props;
   const { sid } = data[rowIndex] as Session;
   const url = cfg.getSshSessionRoute({ sid });
+
   return (
     <Cell align="right">
-      <ButtonPrimary
-        as={NavLink}
-        to={url}
-        size="small"
-        width="90px"
-        children="join"
-      />
+      <MenuAction>
+        <MenuItem as={NavLink} to={url}>
+          Join Session
+        </MenuItem>
+      </MenuAction>
     </Cell>
   );
 }

--- a/packages/teleport/src/cluster/components/Sessions/SessionList/IconCell.tsx
+++ b/packages/teleport/src/cluster/components/Sessions/SessionList/IconCell.tsx
@@ -15,13 +15,24 @@ limitations under the License.
 */
 
 import React from 'react';
+import styled from 'styled-components';
 import { Cell } from 'design/DataTable';
-import { Session } from 'teleport/services/ssh';
+import Icon, * as Icons from 'design/Icon/Icon';
 
-export default function DescCell(props: any) {
-  const { rowIndex, data, nodes } = props;
-  const { serverId, login } = data[rowIndex] as Session;
-  const server = nodes[serverId];
-  const hostname = server ? server.hostname : serverId;
-  return <Cell>Session started at {`${login}@${hostname}`}</Cell>;
+export default function TypeCell() {
+  return (
+    <Cell>
+      <StyledEventType>
+        <StyledIcon p="1" bg="bgTerminal" as={Icons.Cli} fontSize="4" />
+      </StyledEventType>
+    </Cell>
+  );
 }
+
+const StyledIcon = styled(Icon)`
+  border-radius: 50%;
+`;
+
+const StyledEventType = styled.div`
+  width: 0;
+`;

--- a/packages/teleport/src/cluster/components/Sessions/SessionList/NodeCell.tsx
+++ b/packages/teleport/src/cluster/components/Sessions/SessionList/NodeCell.tsx
@@ -15,31 +15,15 @@ limitations under the License.
 */
 
 import React from 'react';
-import styled from 'styled-components';
 import { Cell } from 'design/DataTable';
-import Icon, * as Icons from 'design/Icon/Icon';
+import { Session } from 'teleport/services/ssh';
 
-export default function TypeCell() {
+export default function DescCell(props: any) {
+  const { rowIndex, data } = props;
+  const { hostname, addr } = data[rowIndex] as Session;
   return (
-    <Cell style={{ fontSize: '14px' }}>
-      <StyledEventType>
-        <StyledIcon p="1" mr="3" bg="bgTerminal" as={Icons.Cli} fontSize="4" />
-        Session in progress...
-      </StyledEventType>
+    <Cell>
+      {hostname} [{addr}]
     </Cell>
   );
 }
-
-const StyledIcon = styled(Icon)`
-  border-radius: 50%;
-`;
-
-const StyledEventType = styled.div`
-  display: flex;
-  align-items: center;
-  min-width: 130px;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 24px;
-  white-space: nowrap;
-`;

--- a/packages/teleport/src/cluster/components/Sessions/SessionList/SessionList.tsx
+++ b/packages/teleport/src/cluster/components/Sessions/SessionList/SessionList.tsx
@@ -17,16 +17,16 @@ limitations under the License.
 import React from 'react';
 import { TablePaged, Column, Cell, TextCell } from 'design/DataTable';
 import { Box } from 'design';
-import TypeCell from './TypeCell';
+import IconCell from './IconCell';
 import UserCell from './UserCell';
 import ActionCell from './ActionCell';
 import CreatedCell from './CreatedCell';
-import DescCell from './DescCell';
+import NodeCell from './NodeCell';
 import { Session } from 'teleport/services/ssh';
 import { Node } from 'teleport/services/nodes';
 
 export default function SessionList(props: Props) {
-  const { sessions, nodes, pageSize = 100, ...rest } = props;
+  const { sessions, pageSize = 100, ...rest } = props;
 
   const tableProps = {
     data: sessions,
@@ -37,24 +37,24 @@ export default function SessionList(props: Props) {
   return (
     <Box {...rest}>
       <TablePaged {...tableProps}>
-        <Column header={<Cell>Type</Cell>} cell={<TypeCell />} />
+        <Column header={<Cell />} cell={<IconCell />} />
         <Column
-          nodes={nodes}
           header={<Cell>Description</Cell>}
-          cell={<DescCell />}
+          cell={<Cell>Session is in progress...</Cell>}
         />
-        <Column header={<Cell>User</Cell>} cell={<UserCell />} />
+        <Column header={<Cell>Users</Cell>} cell={<UserCell />} />
+        <Column header={<Cell>Node</Cell>} cell={<NodeCell />} />
+        <Column header={<Cell>Started (UTC)</Cell>} cell={<CreatedCell />} />
         <Column
-          columnKey="hostname"
-          header={<Cell>Hostname</Cell>}
+          columnKey="durationText"
+          header={<Cell>Duration</Cell>}
           cell={<TextCell />}
         />
         <Column
-          columnKey="addr"
-          header={<Cell>Address</Cell>}
+          columnKey="sid"
+          header={<Cell>Session ID</Cell>}
           cell={<TextCell />}
         />
-        <Column header={<Cell>Created</Cell>} cell={<CreatedCell />} />
         <Column header={<Cell />} cell={<ActionCell />} />
       </TablePaged>
     </Box>

--- a/packages/teleport/src/cluster/components/Sessions/SessionList/UserCell.tsx
+++ b/packages/teleport/src/cluster/components/Sessions/SessionList/UserCell.tsx
@@ -21,6 +21,8 @@ import { Session } from 'teleport/services/ssh';
 export default function UserCell(props: any) {
   const { rowIndex, data } = props;
   const { parties } = data[rowIndex] as Session;
-  const users = parties.map(({ user }) => user).join(', ');
+  const users = parties
+    .map(({ user, remoteAddr }) => `${user} [${remoteAddr}]`)
+    .join(', ');
   return <Cell>{users}</Cell>;
 }

--- a/packages/teleport/src/cluster/components/Sessions/Sessions.tsx
+++ b/packages/teleport/src/cluster/components/Sessions/Sessions.tsx
@@ -38,7 +38,7 @@ export function Sessions(props: SessionsProps) {
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center">
-        <FeatureHeaderTitle>Sessions</FeatureHeaderTitle>
+        <FeatureHeaderTitle>Active Sessions</FeatureHeaderTitle>
       </FeatureHeader>
       {attempt.isProcessing && (
         <Box textAlign="center" m={10}>

--- a/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -65,7 +65,6 @@ exports[`loaded 1`] = `
   display: inline-block;
   -webkit-transition: color .3s;
   transition: color .3s;
-  margin-right: 16px;
   padding: 4px;
   color: #FFFFFF;
   background-color: #010B1C;
@@ -162,7 +161,6 @@ exports[`loaded 1`] = `
   display: inline-block;
   -webkit-transition: color .3s;
   transition: color .3s;
-  margin-right: 16px;
   padding: 4px;
   color: #FFFFFF;
   background-color: #010B1C;
@@ -171,19 +169,7 @@ exports[`loaded 1`] = `
 }
 
 .c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 130px;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 24px;
-  white-space: nowrap;
+  width: 0;
 }
 
 <div
@@ -207,32 +193,31 @@ exports[`loaded 1`] = `
       >
         <thead>
           <tr>
-            <th>
-              Type
-            </th>
+            <th />
             <th>
               Description
             </th>
             <th>
-              User
+              Users
             </th>
             <th>
-              Hostname
+              Node
             </th>
             <th>
-              Address
+              Started (UTC)
             </th>
             <th>
-              Created
+              Duration
+            </th>
+            <th>
+              Session ID
             </th>
             <th />
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td
-              style="font-size: 14px;"
-            >
+            <td>
               <div
                 class="c5"
               >
@@ -241,24 +226,28 @@ exports[`loaded 1`] = `
                   color="light"
                   font-size="4"
                 />
-                Session in progress...
               </div>
             </td>
             <td>
-              Session started at 
-              root@demo.gravitational.io
+              Session is in progress...
             </td>
             <td>
-              hehwawe@aw.sg, ma@pewu.tz
+              hehwawe@aw.sg [129.232.123.132], ma@pewu.tz [129.232.123.132]
             </td>
             <td>
               localhost
-            </td>
-            <td>
+               [
               1.1.1.1:1111
+              ]
             </td>
             <td>
               2019-04-22 00:00:51
+            </td>
+            <td>
+              12 min
+            </td>
+            <td>
+              sid0
             </td>
             <td
               align="right"

--- a/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -5,62 +5,6 @@ exports[`loaded 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
-  line-height: 1.5;
-  margin: 0;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  -webkit-transition: all 0.3s;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #00BFA5;
-  color: #FFFFFF;
-  font-size: 10px;
-  min-height: 24px;
-  padding: 0px 16px;
-  width: 90px;
-}
-
-.c9:active {
-  opacity: 0.56;
-}
-
-.c9:hover,
-.c9:focus {
-  background: #00EAC3;
-}
-
-.c9:active {
-  background: #26A69A;
-}
-
-.c9:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
 .c8 {
   display: inline-block;
   -webkit-transition: color .3s;
@@ -69,6 +13,62 @@ exports[`loaded 1`] = `
   color: #FFFFFF;
   background-color: #010B1C;
   font-size: 18px;
+}
+
+.c10 {
+  display: inline-block;
+  -webkit-transition: color .3s;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: none;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  outline: none;
+  border-radius: 50%;
+  overflow: visible;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  text-align: center;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  background: transparent;
+  color: inherit;
+  -webkit-transition: all .3s;
+  transition: all .3s;
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  height: 32px;
+  width: 32px;
+}
+
+.c9 .c6 {
+  color: inherit;
+}
+
+.c9:disabled {
+  color: rgba(255,255,255,0.3);
+}
+
+.c9:disabled {
+  color: rgba(255,255,255,0.3);
+}
+
+.c9:hover,
+.c9:focus {
+  background: rgba(255,255,255,0.1);
 }
 
 .c1 {
@@ -181,7 +181,7 @@ exports[`loaded 1`] = `
     <h1
       class="c2"
     >
-      Sessions
+      Active Sessions
     </h1>
   </div>
   <div
@@ -252,15 +252,15 @@ exports[`loaded 1`] = `
             <td
               align="right"
             >
-              <a
+              <button
                 class="c9"
-                href="/web/cluster/localhost/console/session/sid0"
-                kind="primary"
-                theme="[object Object]"
-                width="90px"
+                data-testid="button"
               >
-                join
-              </a>
+                <span
+                  class="icon icon-ellipsis  c6 c10"
+                  color="light"
+                />
+              </button>
             </td>
           </tr>
         </tbody>

--- a/packages/teleport/src/services/ssh/makeSession.ts
+++ b/packages/teleport/src/services/ssh/makeSession.ts
@@ -19,7 +19,6 @@ import { map } from 'lodash';
 import { Session, Participant } from './types';
 
 export default function makeSession(json): Session {
-  const clusterId = json.siteId;
   const created = new Date(json.created);
   const duration = moment(new Date()).diff(created);
   const durationText = moment.duration(duration).humanize();
@@ -29,7 +28,7 @@ export default function makeSession(json): Session {
   const serverId = json.server_id;
   const sid = json.id;
   const hostname = json.server_hostname;
-  const addr = json.server_addr;
+  const addr = json.server_addr.replace(PORT_REGEX, '');
 
   return {
     sid,
@@ -39,7 +38,6 @@ export default function makeSession(json): Session {
     durationText,
     serverId,
     hostname,
-    clusterId,
     parties,
     addr,
   };

--- a/packages/teleport/src/services/ssh/makeSession.ts
+++ b/packages/teleport/src/services/ssh/makeSession.ts
@@ -19,6 +19,7 @@ import { map } from 'lodash';
 import { Session, Participant } from './types';
 
 export default function makeSession(json): Session {
+  const clusterId = json.cluster_name;
   const created = new Date(json.created);
   const duration = moment(new Date()).diff(created);
   const durationText = moment.duration(duration).humanize();
@@ -38,6 +39,7 @@ export default function makeSession(json): Session {
     durationText,
     serverId,
     hostname,
+    clusterId,
     parties,
     addr,
   };

--- a/packages/teleport/src/services/ssh/ssh.ts
+++ b/packages/teleport/src/services/ssh/ssh.ts
@@ -44,7 +44,7 @@ const service = {
   fetchSession({ clusterId, sid }: FetchSessionParams) {
     return api
       .get(cfg.getTerminalSessionUrl({ sid, clusterId }))
-      .then(response => makeSession(response));
+      .then(makeSession);
   },
 
   fetchSessions(clusterId = cfg.clusterName) {

--- a/packages/teleport/src/services/ssh/ssh.ts
+++ b/packages/teleport/src/services/ssh/ssh.ts
@@ -42,20 +42,11 @@ const service = {
   },
 
   fetchSession({ clusterId, sid }: FetchSessionParams) {
-    // To retrieve a hostname, we are fetching all cluster nodes.
-    // TODO: optimize it by adding hostname attribute to the session (backend)
     return Promise.all([
       api.get(cfg.getTerminalSessionUrl({ sid, clusterId })),
-      api.get(cfg.getClusterNodesUrl(clusterId)),
     ]).then(response => {
-      const [sessionJson, serversJson] = response;
-      const server = serversJson.items.find(
-        s => s.id === sessionJson.server_id
-      );
-      const session = makeSession(sessionJson);
-      session.hostname = server.hostname;
-      session.clusterId = clusterId;
-      return session;
+      const [sessionJson] = response;
+      return makeSession(sessionJson);
     });
   },
 

--- a/packages/teleport/src/services/ssh/ssh.ts
+++ b/packages/teleport/src/services/ssh/ssh.ts
@@ -42,12 +42,9 @@ const service = {
   },
 
   fetchSession({ clusterId, sid }: FetchSessionParams) {
-    return Promise.all([
-      api.get(cfg.getTerminalSessionUrl({ sid, clusterId })),
-    ]).then(response => {
-      const [sessionJson] = response;
-      return makeSession(sessionJson);
-    });
+    return api
+      .get(cfg.getTerminalSessionUrl({ sid, clusterId }))
+      .then(response => makeSession(response));
   },
 
   fetchSessions(clusterId = cfg.clusterName) {

--- a/packages/teleport/src/services/ssh/types.ts
+++ b/packages/teleport/src/services/ssh/types.ts
@@ -27,7 +27,6 @@ export interface Session {
   durationText: string;
   serverId: string;
   hostname: string;
-  clusterId: string;
   parties: Participant[];
   addr: string;
 }

--- a/packages/teleport/src/services/ssh/types.ts
+++ b/packages/teleport/src/services/ssh/types.ts
@@ -27,6 +27,7 @@ export interface Session {
   durationText: string;
   serverId: string;
   hostname: string;
+  clusterId: string;
   parties: Participant[];
   addr: string;
 }


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/3544

#### Description
- Removed address, type column
- Renamed `created` to `started (utc)`
- Added duration, session ID columns
- Modified Node and Users to display name and address without port
- Modified action cell to use a dotted button dropdown menu
- Updated session.story snapshot

#### Screen
![Peek 2020-05-06 10-55](https://user-images.githubusercontent.com/43280172/81211503-5275d680-8f88-11ea-81a9-c13b1cd1cecf.gif)

