### PR TITLE
Filter non interactive sessions out

### DIFF
--- a/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.story.test.tsx
+++ b/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.story.test.tsx
@@ -3,6 +3,7 @@ import { Sessions } from './AuditSessions.story';
 import { render } from 'design/utils/testing';
 
 test('rendering of Audit Sessions', () => {
-  const { container } = render(<Sessions />);
+  const { container, queryByText } = render(<Sessions />);
+  expect(queryByText('no-display')).toBeNull();
   expect(container).toMatchSnapshot();
 });

--- a/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.story.tsx
+++ b/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.story.tsx
@@ -43,6 +43,7 @@ const events = [
     participants: ['one', 'two'],
     server_id: 'serverId',
     server_hostname: 'apple-node',
+    interactive: true,
   },
   {
     code: 'T2004I',
@@ -56,6 +57,7 @@ const events = [
     participants: ['one', 'two'],
     server_id: 'serverId',
     server_hostname: 'peach-node',
+    interactive: true,
   },
   {
     code: 'T2004I',
@@ -69,6 +71,21 @@ const events = [
     participants: ['one', 'two'],
     server_id: 'serverId',
     server_hostname: 'pear-node',
+    interactive: true,
+  },
+  {
+    code: 'T2004I',
+    ei: 0,
+    event: 'session.end',
+    namespace: 'default',
+    sid: 'no-display',
+    time: 'no-display',
+    uid: 'no-display',
+    user: 'no-display',
+    participants: 'no-display',
+    server_id: 'no-display',
+    server_hostname: 'no-display',
+    interactive: false,
   },
 ];
 

--- a/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.tsx
+++ b/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.tsx
@@ -60,7 +60,9 @@ export default function SessionList(props: SessionListProps) {
   // sort and filter
   const data = React.useMemo(() => {
     const { colSortDirs, search } = state;
-    const rows = events.filter(e => e.code === 'T2004I').map(makeRows);
+    const rows = events
+      .filter(e => e.code === 'T2004I' && e.raw.interactive)
+      .map(makeRows);
 
     const filtered = rows.filter(obj =>
       isMatch(obj, search, {

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -344,6 +344,7 @@ export type RawEvents = {
       server_id: string;
       participants?: string[];
       server_hostname: string;
+      interactive: boolean;
     }
   >;
   [CodeEnum.SESSION_LEAVE]: RawEvent<


### PR DESCRIPTION
closes https://github.com/gravitational/teleport/issues/3545

#### Description
- Filters out non-interactive sessions (execs)
- Add `interactive` field to `SESSION_END` RawEvent type
- Update unit test