### PR TITLE
Update xterm to 2.8.1

### DIFF
--- a/packages/gravity/package.json
+++ b/packages/gravity/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "Apache-2.0",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/gravitational/webapps/webapps.git",
+    "type": "git",
+    "url": "https://github.com/gravitational/webapps/webapps.git",
     "directory": "packages/gravity"
   },
   "dependencies": {
@@ -24,7 +24,7 @@
     "jquery": "3.5.0",
     "nuclear-js": "1.4.0",
     "u2f-api-polyfill": "^0.4.3",
-    "xterm": "https://github.com/gravitational/xterm.js#v2.4.0",
+    "xterm": "https://github.com/gravitational/xterm.js#v2.8.1",
     "cross-env": "5.0.5",
     "@gravitational/shared": "1.0.0",
     "@gravitational/design": "1.0.0"

--- a/packages/teleport/package.json
+++ b/packages/teleport/package.json
@@ -12,14 +12,14 @@
   "author": "",
   "license": "Apache-2.0",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/gravitational/webapps/webapps.git",
+    "type": "git",
+    "url": "https://github.com/gravitational/webapps/webapps.git",
     "directory": "packages/teleport"
   },
   "dependencies": {
     "@gravitational/shared": "1.0.0",
     "@gravitational/design": "1.0.0",
-    "xterm": "https://github.com/gravitational/xterm.js#v2.4.0"
+    "xterm": "https://github.com/gravitational/xterm.js#v2.8.1"
   },
   "devDependencies": {
     "@gravitational/build": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7618,10 +7618,10 @@ jest@^25.1.0:
     import-local "^3.0.2"
     jest-cli "^25.2.4"
 
-jquery@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+jquery@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -12391,9 +12391,9 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-"xterm@https://github.com/gravitational/xterm.js#v2.4.0":
-  version "2.4.0"
-  resolved "https://github.com/gravitational/xterm.js#ebffd9370bc3882856d92a8887d7698f7dac1eb6"
+"xterm@https://github.com/gravitational/xterm.js#v2.8.1":
+  version "2.8.1"
+  resolved "https://github.com/gravitational/xterm.js#6aa864910a8360abca99dbfa4c5f45b9bf5bf4ef"
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
fixes https://github.com/gravitational/webapps/issues/92

#### Description
Update xterm to the minimum version (`2.8.1`), that fixes the wrap problem when copying and pasting

- Did some light manual testing on the terminal for possible udpate bug: `ls`, `exit`, session replay, alt switch tabs

#### Manual Test
![no-wrap-copy](https://user-images.githubusercontent.com/43280172/83584367-c8c01700-a4fb-11ea-8601-22c171027f40.gif)
