### PR TITLE
Check for expired session before resources unload (redirect)

### DIFF
--- a/packages/teleport/src/console/useOnExitConfirmation.test.ts
+++ b/packages/teleport/src/console/useOnExitConfirmation.test.ts
@@ -17,6 +17,7 @@
 import renderHook from 'design/utils/renderHook';
 import ConsoleContext from './consoleContext';
 import useOnExitConfirmation from './useOnExitConfirmation';
+import session from 'teleport/services/session';
 
 test('confirmation dialog before terminating an active ssh session', () => {
   const ctx = new ConsoleContext();
@@ -74,12 +75,18 @@ test('confirmation dialog before terminating an active ssh session', () => {
   // change date to an old date
   docTerminal.created = new Date('2019-04-01');
 
+  // test that expired session does not prompt
+  jest.spyOn(session, '_timeLeft').mockReturnValue(0);
+  window.dispatchEvent(event);
+  expect(event.preventDefault).not.toHaveBeenCalled();
+
   // test aged terminal doc calls prompt
   retVal = current.verifyAndConfirm(docTerminal);
   expect(retVal).toBe(false);
   expect(window.confirm).toHaveReturnedWith(false);
 
   // test aged terminal doc triggers prompt
+  jest.spyOn(session, '_timeLeft').mockReturnValue(5);
   window.dispatchEvent(event);
   expect(event.preventDefault).toHaveBeenCalledTimes(1);
 });

--- a/packages/teleport/src/console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/console/useOnExitConfirmation.ts
@@ -17,6 +17,7 @@
 import React from 'react';
 import ConsoleContext from './consoleContext';
 import * as stores from './stores/types';
+import session from 'teleport/services/session';
 
 // TAB_MIN_AGE defines "active terminal" session in ms
 const TAB_MIN_AGE = 30000;
@@ -37,6 +38,13 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
      * of document opened and how long it has been active for.
      */
     const handleBeforeunload = event => {
+      // Do not ask for confirmation when session is expired, which may trigger prompt
+      // when browser triggers page reload before it receives session.end event,
+      // which is not guaranteed to happen in that order.
+      if (!session.isValid()) {
+        return;
+      }
+
       const shouldNotify = ctx.getDocuments().some(hasLastingSshConnection);
 
       if (shouldNotify) {


### PR DESCRIPTION
fixes https://github.com/gravitational/webapps/issues/97

#### Description
- Check for expired session before prompting confirmation
- Test expired session don't prompt 