### PR TITLE
Tweak styling for topbar auto scrollX and text alignment

### DIFF
--- a/packages/design/src/DataTable/Paged/Pager/Pager.jsx
+++ b/packages/design/src/DataTable/Paged/Pager/Pager.jsx
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 import styled from 'styled-components';
 import Icon, { CircleArrowLeft, CircleArrowRight } from 'design/Icon';
-import { Text } from 'design';
+import { Text, Flex } from 'design';
 import PropTypes from 'prop-types';
 
 export default function Pager(props) {
@@ -55,7 +55,7 @@ Pager.propTypes = {
   onNext: PropTypes.func.isRequired,
 };
 
-export const StyledButtons = styled.div`
+export const StyledButtons = styled(Flex)`
   button {
     background: none;
     border: none;

--- a/packages/design/src/Dialog/Dialog.jsx
+++ b/packages/design/src/Dialog/Dialog.jsx
@@ -69,5 +69,5 @@ const DialogBox = styled.div`
   position: relative;
   overflow-y: auto;
   max-height: calc(100% - 96px);
-  ${props => props.dialogCss && props.dialogCss(props)}
+  ${props => props.dialogCss && props.dialogCss(props)};
 `;

--- a/packages/teleport/src/cluster/components/Audit/AuditEvents/EventList/EventList.tsx
+++ b/packages/teleport/src/cluster/components/Audit/AuditEvents/EventList/EventList.tsx
@@ -102,7 +102,7 @@ export default function EventList(props: EventListProps) {
         <Table.Column
           columnKey="message"
           header={<Table.Cell>Description</Table.Cell>}
-          cell={<DescCell style={{ wordBreak: 'break-all' }} />}
+          cell={<DescCell />}
         />
         <Table.Column
           columnKey="time"

--- a/packages/teleport/src/cluster/components/Audit/AuditEvents/EventList/EventListCells.tsx
+++ b/packages/teleport/src/cluster/components/Audit/AuditEvents/EventList/EventListCells.tsx
@@ -44,5 +44,5 @@ export const TimeCell = props => {
 export function DescCell(props) {
   const { rowIndex, data } = props;
   const { message } = data[rowIndex];
-  return <Cell>{message}</Cell>;
+  return <Cell style={{ wordBreak: 'break-word' }}>{message}</Cell>;
 }

--- a/packages/teleport/src/cluster/components/Audit/AuditEvents/__snapshots__/AuditEvents.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/AuditEvents/__snapshots__/AuditEvents.story.test.tsx.snap
@@ -338,7 +338,9 @@ exports[`rendering of Events 1`] = `
               OIDC Auth Connector Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "unimplemented" created OIDC connector "new_oidc_connector"
           </td>
           <td
@@ -370,7 +372,9 @@ exports[`rendering of Events 1`] = `
               GITHUB Auth Connector Deleted
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "unimplemented" deleted Github connector "new_github_connector"
           </td>
           <td
@@ -402,7 +406,9 @@ exports[`rendering of Events 1`] = `
               GITHUB Auth Connector Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "unimplemented" created Github connector "new_github_connector" has been created
           </td>
           <td
@@ -434,7 +440,9 @@ exports[`rendering of Events 1`] = `
               User Password Updated
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "Ivan_Jordan" has changed a password
           </td>
           <td
@@ -466,7 +474,9 @@ exports[`rendering of Events 1`] = `
               Access Request Updated
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Access request "66b827b2-1b0b-512b-965d-6c789388d3c9" has been updated to APPROVED
           </td>
           <td
@@ -498,7 +508,9 @@ exports[`rendering of Events 1`] = `
               Access Request Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Access request "66b827b2-1b0b-512b-965d-6c789388d3c9" has been created and is PENDING
           </td>
           <td
@@ -530,7 +542,9 @@ exports[`rendering of Events 1`] = `
               Reset Password Token Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "b331fb6c-85f9-4cb0-b308-3452420bf81e.one" created a password reset token for user "hello" which expires in 8h0m0s
           </td>
           <td
@@ -562,7 +576,9 @@ exports[`rendering of Events 1`] = `
               User Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User hello has been created
           </td>
           <td
@@ -594,7 +610,9 @@ exports[`rendering of Events 1`] = `
               User Updated
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User bob has been updated
           </td>
           <td
@@ -626,7 +644,9 @@ exports[`rendering of Events 1`] = `
               User Deleted
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User bob has been deleted
           </td>
           <td
@@ -658,7 +678,9 @@ exports[`rendering of Events 1`] = `
               Session Report
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Report has been created for session "5fc8bf85-a73e-11ea-afd1-0242ac0a0101"
           </td>
           <td
@@ -690,7 +712,9 @@ exports[`rendering of Events 1`] = `
               Session Report
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Report has been created for session "5fc8bf85-a73e-11ea-afd1-0242ac0a0101"
           </td>
           <td
@@ -722,7 +746,9 @@ exports[`rendering of Events 1`] = `
               Session Command
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             ping has been executed
           </td>
           <td
@@ -754,7 +780,9 @@ exports[`rendering of Events 1`] = `
               Log Forwarder Deleted
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" deleted log forwarder "forwarder1"
           </td>
           <td
@@ -786,7 +814,9 @@ exports[`rendering of Events 1`] = `
               Log Forwarder Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" created log forwarder "forwarder1"
           </td>
           <td
@@ -818,7 +848,9 @@ exports[`rendering of Events 1`] = `
               Invite Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" invited user "fdsfsdf" with roles @teleadmin
           </td>
           <td
@@ -850,7 +882,9 @@ exports[`rendering of Events 1`] = `
               Role Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" created role "admin323232323"
           </td>
           <td
@@ -882,7 +916,9 @@ exports[`rendering of Events 1`] = `
               Role Deleted
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" deleted role "admin323232323f"
           </td>
           <td
@@ -914,7 +950,9 @@ exports[`rendering of Events 1`] = `
               Role Created
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" created role "admin323232323f"
           </td>
           <td
@@ -946,7 +984,9 @@ exports[`rendering of Events 1`] = `
               SCP Download
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" downloaded a file ~/fsdfsdfsdfsdfs from node 172.31.28.130:3022
           </td>
           <td
@@ -978,7 +1018,9 @@ exports[`rendering of Events 1`] = `
               SCP Download
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" downloaded a file ~/fsdfsdfsdfsdfs from node 172.31.28.130:3022
           </td>
           <td
@@ -1010,7 +1052,9 @@ exports[`rendering of Events 1`] = `
               User Joined
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" has joined the session "56408539-6536-11e9-80a1-427cfde50f5a"
           </td>
           <td
@@ -1042,7 +1086,9 @@ exports[`rendering of Events 1`] = `
               User Joined
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" has joined the session "56408539-6536-11e9-80a1-427cfde50f5a"
           </td>
           <td
@@ -1074,7 +1120,9 @@ exports[`rendering of Events 1`] = `
               Terminal Resize
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" resized the terminal
           </td>
           <td
@@ -1106,7 +1154,9 @@ exports[`rendering of Events 1`] = `
               Terminal Resize
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" resized the terminal
           </td>
           <td
@@ -1138,7 +1188,9 @@ exports[`rendering of Events 1`] = `
               Session Started
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" has started a session "56408539-6536-11e9-80a1-427cfde50f5a"
           </td>
           <td
@@ -1170,7 +1222,9 @@ exports[`rendering of Events 1`] = `
               Session Started
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" has started a session "56408539-6536-11e9-80a1-427cfde50f5a"
           </td>
           <td
@@ -1202,7 +1256,9 @@ exports[`rendering of Events 1`] = `
               Session File Access
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             /etc/profile.d/
           </td>
           <td
@@ -1234,7 +1290,9 @@ exports[`rendering of Events 1`] = `
               Session Network Connection
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Session "44c6cea8-362f-11ea-83aa-125400432324" opened a connection bash: 10.217.136.161 &lt;-&gt; 190.58.129.4:3000
           </td>
           <td
@@ -1266,7 +1324,9 @@ exports[`rendering of Events 1`] = `
               Local Login Failed
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Local user "fsdfsdf" login failed: user(name="fsdfsdf") not found
           </td>
           <td
@@ -1298,7 +1358,9 @@ exports[`rendering of Events 1`] = `
               Local Login Failed
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Local user "fsdfsdf" login failed: user(name="fsdfsdf") not found
           </td>
           <td
@@ -1330,7 +1392,9 @@ exports[`rendering of Events 1`] = `
               Auth Attempt Failed
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" failed auth attempt: ssh: principal "fsdfdsf" not in the set of valid principals for given certificate: ["root"]
           </td>
           <td
@@ -1362,7 +1426,9 @@ exports[`rendering of Events 1`] = `
               Auth Attempt Failed
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" failed auth attempt: ssh: principal "fsdfdsf" not in the set of valid principals for given certificate: ["root"]
           </td>
           <td
@@ -1394,7 +1460,9 @@ exports[`rendering of Events 1`] = `
               Local Login
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Local user "admin@example.com" successfully logged in
           </td>
           <td
@@ -1426,7 +1494,9 @@ exports[`rendering of Events 1`] = `
               Local Login
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             Local user "admin@example.com" successfully logged in
           </td>
           <td
@@ -1458,7 +1528,9 @@ exports[`rendering of Events 1`] = `
               Session Ended
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" has ended the session "9febab45-6491-11e9-80a1-427cfde50f5a"
           </td>
           <td
@@ -1490,7 +1562,9 @@ exports[`rendering of Events 1`] = `
               Session Ended
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             User "admin@example.com" has ended the session "9febab45-6491-11e9-80a1-427cfde50f5a"
           </td>
           <td

--- a/packages/teleport/src/cluster/components/Audit/AuditEvents/__snapshots__/AuditEvents.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/AuditEvents/__snapshots__/AuditEvents.story.test.tsx.snap
@@ -150,6 +150,11 @@ exports[`rendering of Events 1`] = `
   justify-content: flex-start;
 }
 
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+}
+
 .c4 button {
   background: none;
   border: none;
@@ -266,7 +271,7 @@ exports[`rendering of Events 1`] = `
         </strong>
       </div>
       <div
-        class="c4"
+        class="sc-AxgMl c4"
       >
         <button
           disabled=""

--- a/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.tsx
+++ b/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.tsx
@@ -106,7 +106,7 @@ export default function SessionList(props: SessionListProps) {
         <Table.Column
           columnKey="users"
           header={<Table.Cell>User(s)</Table.Cell>}
-          cell={<Table.TextCell />}
+          cell={<Table.TextCell style={{ wordBreak: 'break-word' }} />}
         />
         <Table.Column
           columnKey="hostname"

--- a/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.tsx
+++ b/packages/teleport/src/cluster/components/Audit/AuditSessions/AuditSessions.tsx
@@ -17,7 +17,6 @@ limitations under the License.
 import React from 'react';
 import { sortBy } from 'lodash';
 import isMatch from 'design/utils/match';
-import { NavLink } from 'react-router-dom';
 import { ButtonBorder, Flex } from 'design';
 import { displayDateTime } from 'shared/services/loc';
 import * as Icons from 'design/Icon';

--- a/packages/teleport/src/cluster/components/Audit/AuditSessions/__snapshots__/AuditSessions.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/AuditSessions/__snapshots__/AuditSessions.story.test.tsx.snap
@@ -151,6 +151,11 @@ exports[`rendering of Audit Sessions 1`] = `
   line-height: 16px;
 }
 
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+}
+
 .c4 button {
   background: none;
   border: none;
@@ -257,7 +262,7 @@ exports[`rendering of Audit Sessions 1`] = `
         </strong>
       </div>
       <div
-        class="c4"
+        class="sc-AxirZ c4"
       >
         <button
           disabled=""

--- a/packages/teleport/src/cluster/components/Audit/AuditSessions/__snapshots__/AuditSessions.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/AuditSessions/__snapshots__/AuditSessions.story.test.tsx.snap
@@ -330,7 +330,9 @@ exports[`rendering of Audit Sessions 1`] = `
               240355-6491-11e9-80a1-427cfde50f5a
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             one, two
           </td>
           <td>
@@ -369,7 +371,9 @@ exports[`rendering of Audit Sessions 1`] = `
               377875-6491-11e9-80a1-427cfde50f5a
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             one, two
           </td>
           <td>
@@ -408,7 +412,9 @@ exports[`rendering of Audit Sessions 1`] = `
               426485-6491-11e9-80a1-427cfde50f5a
             </div>
           </td>
-          <td>
+          <td
+            style="word-break: break-word;"
+          >
             one, two
           </td>
           <td>

--- a/packages/teleport/src/cluster/components/Audit/EventDialog/EventDialog.tsx
+++ b/packages/teleport/src/cluster/components/Audit/EventDialog/EventDialog.tsx
@@ -64,7 +64,8 @@ EventDialog.propTypes = {
 
 const dialogCss = () => `
   min-height: 400px;
-  min-width: 600px;
+  max-width: 600px;
+  width: calc(100% - 20%);
 `;
 
 export default EventDialog;

--- a/packages/teleport/src/cluster/components/Audit/EventDialog/EventDialog.tsx
+++ b/packages/teleport/src/cluster/components/Audit/EventDialog/EventDialog.tsx
@@ -65,7 +65,7 @@ EventDialog.propTypes = {
 const dialogCss = () => `
   min-height: 400px;
   max-width: 600px;
-  width: calc(100% - 20%);
+  width: 100%;
 `;
 
 export default EventDialog;

--- a/packages/teleport/src/cluster/components/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -161,6 +161,7 @@ exports[`overflow 1`] = `
 
 .c0 {
   box-sizing: border-box;
+  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;
@@ -270,6 +271,11 @@ exports[`overflow 1`] = `
 .c15 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
+}
+
+.c13 {
+  box-sizing: border-box;
+  display: flex;
 }
 
 .c13 button {

--- a/packages/teleport/src/cluster/components/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -161,7 +161,6 @@ exports[`overflow 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;

--- a/packages/teleport/src/cluster/components/Cluster.tsx
+++ b/packages/teleport/src/cluster/components/Cluster.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Redirect, Switch, Route } from 'teleport/components/Router';
 import { useAttempt } from 'shared/hooks';
-import { Indicator } from 'design';
+import { Indicator, Flex } from 'design';
 import { Failed } from 'design/CardError';
 import { useTeleport } from 'teleport/teleportContextProvider';
 import cfg from 'teleport/config';
@@ -71,14 +71,16 @@ export default function Cluster() {
       <TopBar onClickClusterInfo={handleViewClusterInfo} />
       <VerticalSplit>
         <SideNav />
-        <Switch>
-          <Redirect
-            exact
-            from={cfg.routes.cluster}
-            to={cfg.routes.clusterNodes}
-          />
-          {$features}
-        </Switch>
+        <Flex width="100%" style={{ overflowX: 'auto' }}>
+          <Switch>
+            <Redirect
+              exact
+              from={cfg.routes.cluster}
+              to={cfg.routes.clusterNodes}
+            />
+            {$features}
+          </Switch>
+        </Flex>
       </VerticalSplit>
       {viewClusterInfo && (
         <ClusterInfoDialog

--- a/packages/teleport/src/cluster/components/Cluster.tsx
+++ b/packages/teleport/src/cluster/components/Cluster.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Redirect, Switch, Route } from 'teleport/components/Router';
 import { useAttempt } from 'shared/hooks';
-import { Indicator, Flex } from 'design';
+import { Indicator } from 'design';
 import { Failed } from 'design/CardError';
 import { useTeleport } from 'teleport/teleportContextProvider';
 import cfg from 'teleport/config';
@@ -71,16 +71,14 @@ export default function Cluster() {
       <TopBar onClickClusterInfo={handleViewClusterInfo} />
       <VerticalSplit>
         <SideNav />
-        <Flex width="100%" style={{ overflowX: 'auto' }}>
-          <Switch>
-            <Redirect
-              exact
-              from={cfg.routes.cluster}
-              to={cfg.routes.clusterNodes}
-            />
-            {$features}
-          </Switch>
-        </Flex>
+        <Switch>
+          <Redirect
+            exact
+            from={cfg.routes.cluster}
+            to={cfg.routes.clusterNodes}
+          />
+          {$features}
+        </Switch>
       </VerticalSplit>
       {viewClusterInfo && (
         <ClusterInfoDialog

--- a/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -249,7 +249,6 @@ exports[`loaded 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;

--- a/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -249,6 +249,7 @@ exports[`loaded 1`] = `
 
 .c0 {
   box-sizing: border-box;
+  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;
@@ -323,6 +324,11 @@ exports[`loaded 1`] = `
 .c11 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  display: flex;
 }
 
 .c8 button {
@@ -458,7 +464,7 @@ exports[`loaded 1`] = `
           </strong>
         </div>
         <div
-          class="c8"
+          class="sc-AxirZ c8"
         >
           <button
             disabled=""

--- a/packages/teleport/src/cluster/components/Nodes/useClusterNodes.ts
+++ b/packages/teleport/src/cluster/components/Nodes/useClusterNodes.ts
@@ -19,7 +19,6 @@ import { useAttempt } from 'shared/hooks';
 import { useStore } from 'shared/libs/stores';
 import TeleportContext from 'teleport/teleportContext';
 import cfg from 'teleport/config';
-import history from 'teleport/services/history';
 import { Node } from 'teleport/services/nodes';
 
 export default function useClusterNodes(teleCtx: TeleportContext) {

--- a/packages/teleport/src/cluster/components/Sessions/SessionList/ActionCell.tsx
+++ b/packages/teleport/src/cluster/components/Sessions/SessionList/ActionCell.tsx
@@ -16,7 +16,6 @@ limitations under the License.
 
 import React from 'react';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
-import { NavLink } from 'react-router-dom';
 import { Cell } from 'design/DataTable';
 import { Session } from 'teleport/services/ssh';
 import cfg from 'teleport/config';

--- a/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -115,7 +115,6 @@ exports[`loaded 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;

--- a/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`loaded 1`] = `
 
 .c0 {
   box-sizing: border-box;
+  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;
@@ -189,6 +190,11 @@ exports[`loaded 1`] = `
 .c9 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  display: flex;
 }
 
 .c6 button {
@@ -273,7 +279,7 @@ exports[`loaded 1`] = `
           </strong>
         </div>
         <div
-          class="c6"
+          class="sc-fzqBZW c6"
         >
           <button
             disabled=""

--- a/packages/teleport/src/cluster/components/Support/Support.tsx
+++ b/packages/teleport/src/cluster/components/Support/Support.tsx
@@ -179,7 +179,7 @@ const StyledSupportLink = styled.a`
 
 const ClusterData = ({ title = '', data = null }) => (
   <Flex mb={3}>
-    <Text typography="body2" bold mr={3}>
+    <Text typography="body2" bold style={{ width: '130px' }}>
       {title}:
     </Text>
     <Text typography="body2">{data}</Text>

--- a/packages/teleport/src/cluster/components/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Support/__snapshots__/Support.story.test.tsx.snap
@@ -128,7 +128,6 @@ exports[`support Enterprise 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;
@@ -562,7 +561,6 @@ exports[`support OSS 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;

--- a/packages/teleport/src/cluster/components/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Support/__snapshots__/Support.story.test.tsx.snap
@@ -66,7 +66,6 @@ exports[`support Enterprise 1`] = `
   font-size: 12px;
   line-height: 16px;
   margin: 0px;
-  margin-right: 16px;
 }
 
 .c15 {
@@ -129,6 +128,7 @@ exports[`support Enterprise 1`] = `
 
 .c0 {
   box-sizing: border-box;
+  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;
@@ -371,6 +371,7 @@ exports[`support Enterprise 1`] = `
     >
       <div
         class="c14"
+        style="width: 130px;"
       >
         Cluster Name
         :
@@ -386,6 +387,7 @@ exports[`support Enterprise 1`] = `
     >
       <div
         class="c14"
+        style="width: 130px;"
       >
         Teleport Version
         :
@@ -401,6 +403,7 @@ exports[`support Enterprise 1`] = `
     >
       <div
         class="c14"
+        style="width: 130px;"
       >
         Public Address
         :
@@ -416,6 +419,7 @@ exports[`support Enterprise 1`] = `
     >
       <div
         class="c14"
+        style="width: 130px;"
       >
         Connected Nodes
         :
@@ -496,7 +500,6 @@ exports[`support OSS 1`] = `
   font-size: 12px;
   line-height: 16px;
   margin: 0px;
-  margin-right: 16px;
 }
 
 .c15 {
@@ -559,6 +562,7 @@ exports[`support OSS 1`] = `
 
 .c0 {
   box-sizing: border-box;
+  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;
@@ -795,6 +799,7 @@ exports[`support OSS 1`] = `
     >
       <div
         class="c14"
+        style="width: 130px;"
       >
         Cluster Name
         :
@@ -810,6 +815,7 @@ exports[`support OSS 1`] = `
     >
       <div
         class="c14"
+        style="width: 130px;"
       >
         Teleport Version
         :
@@ -825,6 +831,7 @@ exports[`support OSS 1`] = `
     >
       <div
         class="c14"
+        style="width: 130px;"
       >
         Public Address
         :
@@ -840,6 +847,7 @@ exports[`support OSS 1`] = `
     >
       <div
         class="c14"
+        style="width: 130px;"
       >
         Connected Nodes
         :

--- a/packages/teleport/src/cluster/components/TopBar/ClusterInfoDialog/ClusterInfoDialog.tsx
+++ b/packages/teleport/src/cluster/components/TopBar/ClusterInfoDialog/ClusterInfoDialog.tsx
@@ -38,8 +38,13 @@ const ClusterInfoDialog: React.FC<ClusterInfoDialogProps> = ({
   proxyVersion,
 }) => {
   return (
-    <Dialog disableEscapeKeyDown={false} onClose={onClose} open={true}>
-      <Box width="600px">
+    <Dialog
+      disableEscapeKeyDown={false}
+      onClose={onClose}
+      open={true}
+      dialogCss={dialogCss}
+    >
+      <Box minWidth="400px">
         <DialogHeader>
           <DialogTitle>Cluster Information</DialogTitle>
         </DialogHeader>
@@ -58,9 +63,14 @@ const ClusterInfoDialog: React.FC<ClusterInfoDialogProps> = ({
   );
 };
 
+const dialogCss = () => `
+  max-width: 600px;
+  width: calc(100% - 20%);
+`;
+
 const Attribute = ({ title = '', value = null }) => (
   <Flex mb={3}>
-    <Text typography="body2" bold mr={3}>
+    <Text typography="body2" bold style={{ width: '150px' }}>
       {title}:
     </Text>
     <Text typography="body2">{value}</Text>

--- a/packages/teleport/src/cluster/components/TopBar/ClusterInfoDialog/ClusterInfoDialog.tsx
+++ b/packages/teleport/src/cluster/components/TopBar/ClusterInfoDialog/ClusterInfoDialog.tsx
@@ -44,28 +44,27 @@ const ClusterInfoDialog: React.FC<ClusterInfoDialogProps> = ({
       open={true}
       dialogCss={dialogCss}
     >
-      <Box minWidth="400px">
-        <DialogHeader>
-          <DialogTitle>Cluster Information</DialogTitle>
-        </DialogHeader>
-        <DialogContent>
-          <LabelInput>Public URL</LabelInput>
-          <PublicURL url={publicURL} />
-          <Attribute title="Cluster Name" value={clusterId} />
-          <Attribute title="Auth Service Version" value={authVersion} />
-          <Attribute title="Proxy Service Version" value={proxyVersion} />
-        </DialogContent>
-        <DialogFooter>
-          <ButtonPrimary onClick={onClose}>Done</ButtonPrimary>
-        </DialogFooter>
-      </Box>
+      <DialogHeader>
+        <DialogTitle>Cluster Information</DialogTitle>
+      </DialogHeader>
+      <DialogContent>
+        <LabelInput>Public URL</LabelInput>
+        <PublicURL url={publicURL} />
+        <Attribute title="Cluster Name" value={clusterId} />
+        <Attribute title="Auth Service Version" value={authVersion} />
+        <Attribute title="Proxy Service Version" value={proxyVersion} />
+      </DialogContent>
+      <DialogFooter>
+        <ButtonPrimary onClick={onClose}>Done</ButtonPrimary>
+      </DialogFooter>
     </Dialog>
   );
 };
 
 const dialogCss = () => `
   max-width: 600px;
-  width: calc(100% - 20%);
+  minWidth: 400px;
+  width: 100%;
 `;
 
 const Attribute = ({ title = '', value = null }) => (

--- a/packages/teleport/src/cluster/components/TopBar/ClusterInfoDialog/__snapshots__/ClusterInfoDialog.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/TopBar/ClusterInfoDialog/__snapshots__/ClusterInfoDialog.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rendering of static texts 1`] = `
 .c4 {
   box-sizing: border-box;
-  width: 600px;
+  min-width: 400px;
 }
 
 .c11 {
@@ -129,7 +129,6 @@ exports[`rendering of static texts 1`] = `
   font-size: 12px;
   line-height: 16px;
   margin: 0px;
-  margin-right: 16px;
 }
 
 .c14 {
@@ -202,6 +201,8 @@ exports[`rendering of static texts 1`] = `
   position: relative;
   overflow-y: auto;
   max-height: calc(100% - 96px);
+  max-width: 600px;
+  width: calc(100% - 20%);
 }
 
 .c5 {
@@ -242,7 +243,6 @@ exports[`rendering of static texts 1`] = `
     >
       <div
         class="c4"
-        width="600px"
       >
         <div
           class="c5"
@@ -284,6 +284,7 @@ exports[`rendering of static texts 1`] = `
           >
             <div
               class="c13"
+              style="width: 150px;"
             >
               Cluster Name
               :
@@ -299,6 +300,7 @@ exports[`rendering of static texts 1`] = `
           >
             <div
               class="c13"
+              style="width: 150px;"
             >
               Auth Service Version
               :
@@ -314,6 +316,7 @@ exports[`rendering of static texts 1`] = `
           >
             <div
               class="c13"
+              style="width: 150px;"
             >
               Proxy Service Version
               :

--- a/packages/teleport/src/cluster/components/TopBar/ClusterInfoDialog/__snapshots__/ClusterInfoDialog.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/TopBar/ClusterInfoDialog/__snapshots__/ClusterInfoDialog.test.tsx.snap
@@ -1,12 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rendering of static texts 1`] = `
-.c4 {
-  box-sizing: border-box;
-  min-width: 400px;
-}
-
-.c11 {
+.c10 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -32,25 +27,25 @@ exports[`rendering of static texts 1`] = `
   padding: 0px 16px;
 }
 
-.c11:active {
+.c10:active {
   opacity: 0.56;
 }
 
-.c11:hover,
-.c11:focus {
+.c10:hover,
+.c10:focus {
   background: #651FFF;
 }
 
-.c11:active {
+.c10:active {
   background: #354AA4;
 }
 
-.c11:disabled {
+.c10:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c16 {
+.c15 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -76,25 +71,25 @@ exports[`rendering of static texts 1`] = `
   padding: 0px 24px;
 }
 
-.c16:active {
+.c15:active {
   opacity: 0.56;
 }
 
-.c16:hover,
-.c16:focus {
+.c15:hover,
+.c15:focus {
   background: #651FFF;
 }
 
-.c16:active {
+.c15:active {
   background: #354AA4;
 }
 
-.c16:disabled {
+.c15:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c8 {
+.c7 {
   color: #FFFFFF;
   display: block;
   font-size: 11px;
@@ -104,7 +99,7 @@ exports[`rendering of static texts 1`] = `
   margin-bottom: 4px;
 }
 
-.c6 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -115,14 +110,14 @@ exports[`rendering of static texts 1`] = `
   color: rgba(255,255,255,0.87);
 }
 
-.c10 {
+.c9 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
   margin-right: 16px;
 }
 
-.c13 {
+.c12 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
@@ -131,7 +126,7 @@ exports[`rendering of static texts 1`] = `
   margin: 0px;
 }
 
-.c14 {
+.c13 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -140,7 +135,7 @@ exports[`rendering of static texts 1`] = `
   margin: 0px;
 }
 
-.c9 {
+.c8 {
   box-sizing: border-box;
   margin-bottom: 32px;
   padding: 8px;
@@ -150,7 +145,7 @@ exports[`rendering of static texts 1`] = `
   justify-content: space-between;
 }
 
-.c12 {
+.c11 {
   box-sizing: border-box;
   margin-bottom: 16px;
   display: flex;
@@ -202,10 +197,11 @@ exports[`rendering of static texts 1`] = `
   overflow-y: auto;
   max-height: calc(100% - 96px);
   max-width: 600px;
-  width: calc(100% - 20%);
+  minWidth: 400px;
+  width: 100%;
 }
 
-.c5 {
+.c4 {
   box-sizing: border-box;
   margin-bottom: 16px;
   min-height: 32px;
@@ -213,7 +209,7 @@ exports[`rendering of static texts 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   margin-bottom: 32px;
   flex: 1;
@@ -221,7 +217,7 @@ exports[`rendering of static texts 1`] = `
   flex-direction: column;
 }
 
-.c15 {
+.c14 {
   box-sizing: border-box;
 }
 
@@ -242,102 +238,98 @@ exports[`rendering of static texts 1`] = `
       data-testid="dialogbox"
     >
       <div
-        class="c4"
+        class="sc-AxirZ c4"
       >
         <div
           class="c5"
+          color="text.primary"
         >
-          <div
-            class="c6"
-            color="text.primary"
-          >
-            Cluster Information
-          </div>
+          Cluster Information
         </div>
-        <div
+      </div>
+      <div
+        class="sc-AxirZ c6"
+      >
+        <label
           class="c7"
+          font-size="0"
         >
-          <label
-            class="c8"
-            font-size="0"
-          >
-            Public URL
-          </label>
+          Public URL
+        </label>
+        <div
+          class="sc-AxirZ c8"
+        >
           <div
             class="c9"
+            style="word-break: break-all;"
           >
-            <div
-              class="c10"
-              style="word-break: break-all;"
-            >
-              some.kind.of.host:8080
-            </div>
-            <button
-              class="c11"
-              kind="primary"
-            >
-              Copy
-            </button>
+            some.kind.of.host:8080
           </div>
+          <button
+            class="c10"
+            kind="primary"
+          >
+            Copy
+          </button>
+        </div>
+        <div
+          class="sc-AxirZ c11"
+        >
           <div
             class="c12"
+            style="width: 150px;"
           >
-            <div
-              class="c13"
-              style="width: 150px;"
-            >
-              Cluster Name
-              :
-            </div>
-            <div
-              class="c14"
-            >
-              applePie
-            </div>
+            Cluster Name
+            :
           </div>
           <div
-            class="c12"
+            class="c13"
           >
-            <div
-              class="c13"
-              style="width: 150px;"
-            >
-              Auth Service Version
-              :
-            </div>
-            <div
-              class="c14"
-            >
-              5.0.0
-            </div>
-          </div>
-          <div
-            class="c12"
-          >
-            <div
-              class="c13"
-              style="width: 150px;"
-            >
-              Proxy Service Version
-              :
-            </div>
-            <div
-              class="c14"
-            >
-              4.2.2
-            </div>
+            applePie
           </div>
         </div>
         <div
-          class="c15"
+          class="sc-AxirZ c11"
         >
-          <button
-            class="c16"
-            kind="primary"
+          <div
+            class="c12"
+            style="width: 150px;"
           >
-            Done
-          </button>
+            Auth Service Version
+            :
+          </div>
+          <div
+            class="c13"
+          >
+            5.0.0
+          </div>
         </div>
+        <div
+          class="sc-AxirZ c11"
+        >
+          <div
+            class="c12"
+            style="width: 150px;"
+          >
+            Proxy Service Version
+            :
+          </div>
+          <div
+            class="c13"
+          >
+            4.2.2
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-AxirZ c14"
+      >
+        <button
+          class="c15"
+          kind="primary"
+        >
+          Done
+        </button>
       </div>
     </div>
   </div>

--- a/packages/teleport/src/cluster/components/TopBar/TopBar.jsx
+++ b/packages/teleport/src/cluster/components/TopBar/TopBar.jsx
@@ -42,11 +42,16 @@ export default function ClusterTopBar({ onClickClusterInfo }) {
           mr="3"
           typography="h5"
           color="text.primary"
-          style={{ maxWidth: '200px' }}
+          style={{ maxWidth: '200px', whiteSpace: 'nowrap' }}
+          title={clusterId}
         >
           {clusterId}
         </Text>
-        <ButtonOutlined size="small" onClick={onClickClusterInfo}>
+        <ButtonOutlined
+          size="small"
+          style={{ whiteSpace: 'nowrap' }}
+          onClick={onClickClusterInfo}
+        >
           Cluster Info
         </ButtonOutlined>
       </Flex>
@@ -56,8 +61,9 @@ export default function ClusterTopBar({ onClickClusterInfo }) {
 
 const BreadCrumbLink = styled(Text)`
   text-decoration: none;
-  font-size: 14px; 
+  font-size: 14px;
   font-weight: 300;
+  white-space: nowrap;
 
   &:hover {
     color: ${props => props.theme.colors.text.primary};

--- a/packages/teleport/src/cluster/components/TopBar/__snapshots__/TopBar.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/TopBar/__snapshots__/TopBar.story.test.tsx.snap
@@ -226,6 +226,7 @@ exports[`rendering of ClusterTopBar 1`] = `
   text-decoration: none;
   font-size: 14px;
   font-weight: 300;
+  white-space: nowrap;
 }
 
 .c4:hover {
@@ -235,7 +236,7 @@ exports[`rendering of ClusterTopBar 1`] = `
 <nav
   class="sc-AxiKw c0"
   height="56px"
-  style="z-index: 1; box-shadow: 0 8px 24px rgba(0,0,0,.24);"
+  style="z-index: 1; box-shadow: 0 8px 24px rgba(0,0,0,.24); overflow-x: auto;"
 >
   <a
     class="c1"
@@ -270,12 +271,14 @@ exports[`rendering of ClusterTopBar 1`] = `
     <div
       class="c6"
       color="text.primary"
-      style="max-width: 200px;"
+      style="max-width: 200px; white-space: nowrap;"
+      title="localhost"
     >
       localhost
     </div>
     <button
       class="c7"
+      style="white-space: nowrap;"
     >
       <span>
         Cluster Info

--- a/packages/teleport/src/components/Layout/Layout.jsx
+++ b/packages/teleport/src/components/Layout/Layout.jsx
@@ -72,7 +72,6 @@ const FeatureBox = styled(Flex)`
 FeatureBox.defaultProps = {
   theme: defaultTheme,
   px: 6,
-  minWidth: '800px',
 };
 
 /**

--- a/packages/teleport/src/components/Layout/Layout.jsx
+++ b/packages/teleport/src/components/Layout/Layout.jsx
@@ -72,6 +72,7 @@ const FeatureBox = styled(Flex)`
 FeatureBox.defaultProps = {
   theme: defaultTheme,
   px: 6,
+  minWidth: '800px',
 };
 
 /**

--- a/packages/teleport/src/components/TopBar/TopBar.jsx
+++ b/packages/teleport/src/components/TopBar/TopBar.jsx
@@ -68,7 +68,11 @@ export class DashboardTopNav extends React.Component {
       <TopNav
         height="56px"
         pl={pl}
-        style={{ zIndex: '1', boxShadow: '0 8px 24px rgba(0,0,0,.24)' }}
+        style={{
+          zIndex: '1',
+          boxShadow: '0 8px 24px rgba(0,0,0,.24)',
+          overflowX: 'auto',
+        }}
       >
         <TopNavItem width="208px" as={Link} to={cfg.routes.app}>
           <Image

--- a/packages/teleport/src/console/components/DocumentNodes/DocumentNodes.tsx
+++ b/packages/teleport/src/console/components/DocumentNodes/DocumentNodes.tsx
@@ -82,6 +82,7 @@ export default function DocumentNodes(props: Props) {
               value={doc.clusterId}
               width="400px"
               maxMenuHeight={200}
+              mr="20px"
               onChange={onChangeCluster}
             />
             <QuickLaunch onPress={onQuickLaunchEnter} mr="3" />

--- a/packages/teleport/src/console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`render DocumentNodes 1`] = `
 .c4 {
   box-sizing: border-box;
+  margin-right: 20px;
   width: 400px;
 }
 
@@ -221,6 +222,11 @@ exports[`render DocumentNodes 1`] = `
 .c17 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
+}
+
+.c14 {
+  box-sizing: border-box;
+  display: flex;
 }
 
 .c14 button {

--- a/packages/teleport/src/console/components/Tabs/JoinedUsers/JoinedUsers.jsx
+++ b/packages/teleport/src/console/components/Tabs/JoinedUsers/JoinedUsers.jsx
@@ -105,6 +105,7 @@ const StyledUsers = styled.div`
   flex-shrink: 0;
   border-radius: 50%;
   justify-content: center;
+  margin-right: 3px;
   background-color: ${props =>
     props.active ? theme.colors.accent : theme.colors.grey[900]};
 `;

--- a/packages/teleport/src/dashboard/components/Clusters/ClusterList/ClusterList.tsx
+++ b/packages/teleport/src/dashboard/components/Clusters/ClusterList/ClusterList.tsx
@@ -237,7 +237,6 @@ type ClusterListProps = {
 
 const ClusterTable = styled(Table)`
   td {
-    padding 4px 24px !important;
     height: 22px;
   }
 

--- a/packages/teleport/src/dashboard/components/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/packages/teleport/src/dashboard/components/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -156,7 +156,6 @@ exports[`render cluster nodes 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;

--- a/packages/teleport/src/dashboard/components/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/packages/teleport/src/dashboard/components/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -156,11 +156,11 @@ exports[`render cluster nodes 1`] = `
 
 .c0 {
   box-sizing: border-box;
+  min-width: 800px;
   padding-left: 40px;
   padding-right: 40px;
   display: flex;
   flex-direction: column;
-  overflow: auto;
   width: 100%;
   height: 100%;
 }
@@ -232,6 +232,11 @@ exports[`render cluster nodes 1`] = `
   line-height: 16px;
 }
 
+.c7 {
+  box-sizing: border-box;
+  display: flex;
+}
+
 .c7 button {
   background: none;
   border: none;
@@ -271,7 +276,6 @@ exports[`render cluster nodes 1`] = `
 }
 
 .c11 td {
-  padding: 4px 24px !important;
   height: 22px;
 }
 
@@ -329,7 +333,7 @@ exports[`render cluster nodes 1`] = `
       </strong>
     </div>
     <div
-      class="c7"
+      class="sc-AxirZ c7"
     >
       <button
         disabled=""

--- a/packages/teleport/src/dashboard/components/Dashboard.tsx
+++ b/packages/teleport/src/dashboard/components/Dashboard.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import styled from 'styled-components';
-import { Indicator, Flex } from 'design';
+import { Indicator } from 'design';
 import { Failed } from 'design/CardError';
 import { useAttempt } from 'shared/hooks';
 import { Switch, Route } from 'teleport/components/Router';
@@ -65,9 +65,7 @@ export default function Dashboard() {
   return (
     <StyledLayout>
       <TopBar />
-      <Flex width="100%" flex="1 0 auto" style={{ overflowX: 'auto' }}>
-        <Switch>{$features}</Switch>
-      </Flex>
+      <Switch>{$features}</Switch>
     </StyledLayout>
   );
 }

--- a/packages/teleport/src/dashboard/components/Dashboard.tsx
+++ b/packages/teleport/src/dashboard/components/Dashboard.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import styled from 'styled-components';
-import { Indicator } from 'design';
+import { Indicator, Flex } from 'design';
 import { Failed } from 'design/CardError';
 import { useAttempt } from 'shared/hooks';
 import { Switch, Route } from 'teleport/components/Router';
@@ -65,7 +65,9 @@ export default function Dashboard() {
   return (
     <StyledLayout>
       <TopBar />
-      <Switch>{$features}</Switch>
+      <Flex width="100%" flex="1 0 auto" style={{ overflowX: 'auto' }}>
+        <Switch>{$features}</Switch>
+      </Flex>
     </StyledLayout>
   );
 }

--- a/packages/teleport/src/dashboard/components/Layout/Layout.jsx
+++ b/packages/teleport/src/dashboard/components/Layout/Layout.jsx
@@ -40,7 +40,6 @@ const FeatureBox = styled(Flex)`
 FeatureBox.defaultProps = {
   px: 6,
   flexDirection: 'column',
-  minWidth: '800px',
 };
 
 const AppVerticalSplit = styled.div`

--- a/packages/teleport/src/dashboard/components/Layout/Layout.jsx
+++ b/packages/teleport/src/dashboard/components/Layout/Layout.jsx
@@ -29,7 +29,6 @@ FeatureHeader.defaultProps = {
 const FeatureHeaderTitle = props => <Text typography="h2" as="h2" {...props} />;
 
 const FeatureBox = styled(Flex)`
-  overflow: auto;
   width: 100%;
   height: 100%;
   ::after {
@@ -41,6 +40,7 @@ const FeatureBox = styled(Flex)`
 FeatureBox.defaultProps = {
   px: 6,
   flexDirection: 'column',
+  minWidth: '800px',
 };
 
 const AppVerticalSplit = styled.div`


### PR DESCRIPTION
#### Description
- Cluster info and support cluster info has their text aligned
- Put more spacing between number of users joined in session
- Put space between cluster and quick launch component in console
- Set Topbar to `overflowX` to scroll 
- Updated snapshots

#### Related PR
https://github.com/gravitational/webapps.e/pull/11