### PR TITLE
Fix assortment of user issues

### DIFF
--- a/packages/design/src/DataTable/Paged/Pager/Pager.jsx
+++ b/packages/design/src/DataTable/Paged/Pager/Pager.jsx
@@ -24,12 +24,13 @@ export default function Pager(props) {
   const { startFrom = 0, endAt = 0, totalRows = 0, onPrev, onNext } = props;
   const isPrevDisabled = totalRows === 0 || startFrom === 0;
   const isNextDisabled = totalRows === 0 || endAt === totalRows;
+  const initialStartFrom = totalRows > 0 ? startFrom + 1 : 0;
 
   return (
     <>
       <Text typography="body2" color="primary.contrastText">
-        SHOWING <strong>{startFrom + 1}</strong> to <strong>{endAt}</strong> of{' '}
-        <strong>{totalRows}</strong>
+        SHOWING <strong>{initialStartFrom}</strong> - <strong>{endAt}</strong>{' '}
+        of <strong>{totalRows}</strong>
       </Text>
       <StyledButtons>
         <button

--- a/packages/design/src/DataTable/Paged/Pager/Pager.test.js
+++ b/packages/design/src/DataTable/Paged/Pager/Pager.test.js
@@ -24,7 +24,7 @@ describe('design/DataTable Pager', () => {
     ${2}      | ${5}  | ${10}     | ${[false, false]} | ${[3, 5, 10]}
     ${0}      | ${5}  | ${10}     | ${[true, false]}  | ${[1, 5, 10]}
     ${1}      | ${5}  | ${5}      | ${[false, true]}  | ${[2, 5, 5]}
-    ${1}      | ${2}  | ${0}      | ${[true, true]}   | ${[2, 2, 0]}
+    ${0}      | ${0}  | ${0}      | ${[true, true]}   | ${[0, 0, 0]}
   `(
     'respects props: startFrom=$startFrom, endAt=$endAt, totalRows=$totalRows, disablePrevNext=$expPrevNextBtns',
     ({ startFrom, endAt, totalRows, expPrevNextBtns, expNumRanges }) => {
@@ -40,7 +40,7 @@ describe('design/DataTable Pager', () => {
       );
 
       expect(container.firstChild.textContent).toEqual(
-        `SHOWING ${expNumRanges[0]} to ${expNumRanges[1]} of ${expNumRanges[2]}`
+        `SHOWING ${expNumRanges[0]} - ${expNumRanges[1]} of ${expNumRanges[2]}`
       );
 
       const buttons = container.querySelectorAll('button');

--- a/packages/design/src/DataTable/Table.jsx
+++ b/packages/design/src/DataTable/Table.jsx
@@ -169,7 +169,7 @@ class SortHeaderCell extends React.Component {
     const { sortDir, columnKey } = this.props;
 
     // default
-    let newDir = SortTypes.ASC;
+    let newDir = SortTypes.DESC;
     if (sortDir) {
       newDir = sortDir === SortTypes.DESC ? SortTypes.ASC : SortTypes.DESC;
     }

--- a/packages/design/src/DataTable/Table.jsx
+++ b/packages/design/src/DataTable/Table.jsx
@@ -169,7 +169,7 @@ class SortHeaderCell extends React.Component {
     const { sortDir, columnKey } = this.props;
 
     // default
-    let newDir = SortTypes.DESC;
+    let newDir = SortTypes.ASC;
     if (sortDir) {
       newDir = sortDir === SortTypes.DESC ? SortTypes.ASC : SortTypes.DESC;
     }

--- a/packages/design/src/DataTable/Table.test.js
+++ b/packages/design/src/DataTable/Table.test.js
@@ -157,15 +157,15 @@ describe('design/Table SortIndicator', () => {
 
     // b/c TableSample is initially sorted by "Hostname"
     // "Address" header starts with sort vertical (neither ASC or DESC)
-    // on sort vertical, ASC is default
+    // on sort vertical, DESC is default
     fireEvent.click(screen.getByText(tableSampleHeaders[1]));
     expect(
-      header2.querySelector('span').classList.contains('icon-chevron-up')
+      header2.querySelector('span').classList.contains('icon-chevron-down')
     ).toBe(true);
 
     fireEvent.click(screen.getByText(tableSampleHeaders[1]));
     expect(
-      header2.querySelector('span').classList.contains('icon-chevron-down')
+      header2.querySelector('span').classList.contains('icon-chevron-up')
     ).toBe(true);
   });
 });
@@ -176,7 +176,7 @@ describe('design/Table SortHeaderCell', () => {
 
     const tableTitle = 'some title';
     const colKey = 'col key';
-    const retVal = [colKey, SortTypes.ASC];
+    const retVal = [colKey, SortTypes.DESC];
 
     render(
       <Table data={[]}>

--- a/packages/design/src/DataTable/Table.test.js
+++ b/packages/design/src/DataTable/Table.test.js
@@ -149,7 +149,7 @@ describe('design/Table SortIndicator', () => {
     const header1 = anchorTags[0];
     const header2 = anchorTags[1];
 
-    // TableSample initially sorts with "Hostname" DESC
+    // TableSample initially sorts with "Hostname" ASC
     fireEvent.click(screen.getByText(tableSampleHeaders[0]));
     expect(
       header1.querySelector('span').classList.contains('icon-chevron-up')
@@ -157,15 +157,15 @@ describe('design/Table SortIndicator', () => {
 
     // b/c TableSample is initially sorted by "Hostname"
     // "Address" header starts with sort vertical (neither ASC or DESC)
-    // on sort vertical, DESC is default
+    // on sort vertical, ASC is default
     fireEvent.click(screen.getByText(tableSampleHeaders[1]));
     expect(
-      header2.querySelector('span').classList.contains('icon-chevron-down')
+      header2.querySelector('span').classList.contains('icon-chevron-up')
     ).toBe(true);
 
     fireEvent.click(screen.getByText(tableSampleHeaders[1]));
     expect(
-      header2.querySelector('span').classList.contains('icon-chevron-up')
+      header2.querySelector('span').classList.contains('icon-chevron-down')
     ).toBe(true);
   });
 });
@@ -176,7 +176,7 @@ describe('design/Table SortHeaderCell', () => {
 
     const tableTitle = 'some title';
     const colKey = 'col key';
-    const retVal = [colKey, SortTypes.DESC];
+    const retVal = [colKey, SortTypes.ASC];
 
     render(
       <Table data={[]}>

--- a/packages/teleport/src/cluster/components/Audit/AuditEvents/__snapshots__/AuditEvents.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/AuditEvents/__snapshots__/AuditEvents.story.test.tsx.snap
@@ -255,12 +255,12 @@ exports[`rendering of Events 1`] = `
         <strong>
           1
         </strong>
-         to 
+         - 
         <strong>
           37
         </strong>
-         of
          
+        of 
         <strong>
           37
         </strong>

--- a/packages/teleport/src/cluster/components/Audit/AuditSessions/__snapshots__/AuditSessions.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/AuditSessions/__snapshots__/AuditSessions.story.test.tsx.snap
@@ -246,12 +246,12 @@ exports[`rendering of Audit Sessions 1`] = `
         <strong>
           1
         </strong>
-         to 
+         - 
         <strong>
           3
         </strong>
-         of
          
+        of 
         <strong>
           3
         </strong>

--- a/packages/teleport/src/cluster/components/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -415,14 +415,14 @@ exports[`overflow 1`] = `
       >
         SHOWING 
         <strong>
-          1
+          0
         </strong>
-         to 
+         - 
         <strong>
           0
         </strong>
-         of
          
+        of 
         <strong>
           0
         </strong>

--- a/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -447,12 +447,12 @@ exports[`loaded 1`] = `
           <strong>
             1
           </strong>
-           to 
+           - 
           <strong>
             7
           </strong>
-           of
            
+          of 
           <strong>
             7
           </strong>
@@ -514,93 +514,7 @@ exports[`loaded 1`] = `
         <tbody>
           <tr>
             <td>
-              zebpecda
-            </td>
-            <td>
-              <span
-                style="cursor: default;"
-                title="This node is connected to cluster through reverse tunnel"
-              >
-                ⟵ tunnel
-              </span>
-            </td>
-            <td>
-              <div
-                class="c14"
-                kind="secondary"
-              >
-                cluster: one
-              </div>
-              <div
-                class="c14"
-                kind="secondary"
-              >
-                kernel: 4.15.0-51-generic
-              </div>
-            </td>
-            <td
-              align="right"
-            >
-              <button
-                class="c15"
-                height="24px"
-                kind="border"
-              >
-                CONNECT
-                <span
-                  class="c9 c16 icon icon-caret-down "
-                  color="text.secondary"
-                  font-size="2"
-                />
-              </button>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              zebpecda
-            </td>
-            <td>
-              <span
-                style="cursor: default;"
-                title="This node is connected to cluster through reverse tunnel"
-              >
-                ⟵ tunnel
-              </span>
-            </td>
-            <td>
-              <div
-                class="c14"
-                kind="secondary"
-              >
-                cluster: one
-              </div>
-              <div
-                class="c14"
-                kind="secondary"
-              >
-                kernel: 4.15.0-51-generic
-              </div>
-            </td>
-            <td
-              align="right"
-            >
-              <button
-                class="c15"
-                height="24px"
-                kind="border"
-              >
-                CONNECT
-                <span
-                  class="c9 c16 icon icon-caret-down "
-                  color="text.secondary"
-                  font-size="2"
-                />
-              </button>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              zebpecda
+              duzsevkig
             </td>
             <td>
               172.10.1.1:3022
@@ -638,7 +552,7 @@ exports[`loaded 1`] = `
           </tr>
           <tr>
             <td>
-              kuhinur
+              facuzguv
             </td>
             <td>
               172.10.1.1:3022
@@ -714,7 +628,7 @@ exports[`loaded 1`] = `
           </tr>
           <tr>
             <td>
-              facuzguv
+              kuhinur
             </td>
             <td>
               172.10.1.1:3022
@@ -752,10 +666,96 @@ exports[`loaded 1`] = `
           </tr>
           <tr>
             <td>
-              duzsevkig
+              zebpecda
             </td>
             <td>
               172.10.1.1:3022
+            </td>
+            <td>
+              <div
+                class="c14"
+                kind="secondary"
+              >
+                cluster: one
+              </div>
+              <div
+                class="c14"
+                kind="secondary"
+              >
+                kernel: 4.15.0-51-generic
+              </div>
+            </td>
+            <td
+              align="right"
+            >
+              <button
+                class="c15"
+                height="24px"
+                kind="border"
+              >
+                CONNECT
+                <span
+                  class="c9 c16 icon icon-caret-down "
+                  color="text.secondary"
+                  font-size="2"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              zebpecda
+            </td>
+            <td>
+              <span
+                style="cursor: default;"
+                title="This node is connected to cluster through reverse tunnel"
+              >
+                ⟵ tunnel
+              </span>
+            </td>
+            <td>
+              <div
+                class="c14"
+                kind="secondary"
+              >
+                cluster: one
+              </div>
+              <div
+                class="c14"
+                kind="secondary"
+              >
+                kernel: 4.15.0-51-generic
+              </div>
+            </td>
+            <td
+              align="right"
+            >
+              <button
+                class="c15"
+                height="24px"
+                kind="border"
+              >
+                CONNECT
+                <span
+                  class="c9 c16 icon icon-caret-down "
+                  color="text.secondary"
+                  font-size="2"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              zebpecda
+            </td>
+            <td>
+              <span
+                style="cursor: default;"
+                title="This node is connected to cluster through reverse tunnel"
+              >
+                ⟵ tunnel
+              </span>
             </td>
             <td>
               <div

--- a/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -491,7 +491,7 @@ exports[`loaded 1`] = `
               <a>
                 Hostname
                 <span
-                  class="c9 c13 icon icon-chevron-up "
+                  class="c9 c13 icon icon-chevron-down "
                   color="light"
                 />
               </a>

--- a/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -262,12 +262,12 @@ exports[`loaded 1`] = `
           <strong>
             1
           </strong>
-           to 
+           - 
           <strong>
             1
           </strong>
-           of
            
+          of 
           <strong>
             1
           </strong>

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -35,7 +35,7 @@ function NodeList(props: NodeListProps) {
   const { nodes = [], onLoginMenuOpen, onLoginSelect, pageSize = 100 } = props;
   const [searchValue, setSearchValue] = React.useState('');
   const [sortDir, setSortDir] = React.useState<Record<string, string>>({
-    hostname: SortTypes.ASC,
+    hostname: SortTypes.DESC,
   });
 
   function sortAndFilter(search) {
@@ -48,7 +48,7 @@ function NodeList(props: NodeListProps) {
 
     const columnKey = Object.getOwnPropertyNames(sortDir)[0];
     const sorted = sortBy(filtered, columnKey);
-    if (sortDir[columnKey] !== SortTypes.ASC) {
+    if (sortDir[columnKey] === SortTypes.ASC) {
       return sorted.reverse();
     }
 

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -48,7 +48,7 @@ function NodeList(props: NodeListProps) {
 
     const columnKey = Object.getOwnPropertyNames(sortDir)[0];
     const sorted = sortBy(filtered, columnKey);
-    if (sortDir[columnKey] === SortTypes.ASC) {
+    if (sortDir[columnKey] !== SortTypes.ASC) {
       return sorted.reverse();
     }
 

--- a/packages/teleport/src/console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -671,7 +671,7 @@ exports[`render DocumentNodes 1`] = `
                   <a>
                     Hostname
                     <span
-                      class="c15 c19 icon icon-chevron-up "
+                      class="c15 c19 icon icon-chevron-down "
                       color="light"
                     />
                   </a>

--- a/packages/teleport/src/console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -627,12 +627,12 @@ exports[`render DocumentNodes 1`] = `
               <strong>
                 1
               </strong>
-               to 
+               - 
               <strong>
                 5
               </strong>
-               of
                
+              of 
               <strong>
                 5
               </strong>
@@ -694,69 +694,7 @@ exports[`render DocumentNodes 1`] = `
             <tbody>
               <tr>
                 <td>
-                  zebpecda
-                </td>
-                <td>
-                  172.10.1.24:3022
-                </td>
-                <td>
-                  <div
-                    class="c20"
-                    kind="secondary"
-                  >
-                    cluster: one
-                  </div>
-                  <div
-                    class="c20"
-                    kind="secondary"
-                  >
-                    kernel: 4.15.0-51-generic
-                  </div>
-                  <div
-                    class="c20"
-                    kind="secondary"
-                  >
-                    lortavma: one
-                  </div>
-                  <div
-                    class="c20"
-                    kind="secondary"
-                  >
-                    lenisret: 4.15.0-51-generic
-                  </div>
-                  <div
-                    class="c20"
-                    kind="secondary"
-                  >
-                    lofdevod: one
-                  </div>
-                  <div
-                    class="c20"
-                    kind="secondary"
-                  >
-                    llhurlaz: 4.15.0-51-generic
-                  </div>
-                </td>
-                <td
-                  align="right"
-                >
-                  <button
-                    class="c21"
-                    height="24px"
-                    kind="border"
-                  >
-                    CONNECT
-                    <span
-                      class="c15 c22 icon icon-caret-down "
-                      color="text.secondary"
-                      font-size="2"
-                    />
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  kuhinur
+                  duzsevkig
                 </td>
                 <td>
                   <span
@@ -765,44 +703,6 @@ exports[`render DocumentNodes 1`] = `
                   >
                     ⟵ tunnel
                   </span>
-                </td>
-                <td>
-                  <div
-                    class="c20"
-                    kind="secondary"
-                  >
-                    cluster: one
-                  </div>
-                  <div
-                    class="c20"
-                    kind="secondary"
-                  >
-                    kernel: 4.15.0-51-generic
-                  </div>
-                </td>
-                <td
-                  align="right"
-                >
-                  <button
-                    class="c21"
-                    height="24px"
-                    kind="border"
-                  >
-                    CONNECT
-                    <span
-                      class="c15 c22 icon icon-caret-down "
-                      color="text.secondary"
-                      font-size="2"
-                    />
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  fujedu
-                </td>
-                <td>
-                  172.10.1.20:3022
                 </td>
                 <td>
                   <div
@@ -875,7 +775,45 @@ exports[`render DocumentNodes 1`] = `
               </tr>
               <tr>
                 <td>
-                  duzsevkig
+                  fujedu
+                </td>
+                <td>
+                  172.10.1.20:3022
+                </td>
+                <td>
+                  <div
+                    class="c20"
+                    kind="secondary"
+                  >
+                    cluster: one
+                  </div>
+                  <div
+                    class="c20"
+                    kind="secondary"
+                  >
+                    kernel: 4.15.0-51-generic
+                  </div>
+                </td>
+                <td
+                  align="right"
+                >
+                  <button
+                    class="c21"
+                    height="24px"
+                    kind="border"
+                  >
+                    CONNECT
+                    <span
+                      class="c15 c22 icon icon-caret-down "
+                      color="text.secondary"
+                      font-size="2"
+                    />
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  kuhinur
                 </td>
                 <td>
                   <span
@@ -897,6 +835,68 @@ exports[`render DocumentNodes 1`] = `
                     kind="secondary"
                   >
                     kernel: 4.15.0-51-generic
+                  </div>
+                </td>
+                <td
+                  align="right"
+                >
+                  <button
+                    class="c21"
+                    height="24px"
+                    kind="border"
+                  >
+                    CONNECT
+                    <span
+                      class="c15 c22 icon icon-caret-down "
+                      color="text.secondary"
+                      font-size="2"
+                    />
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  zebpecda
+                </td>
+                <td>
+                  172.10.1.24:3022
+                </td>
+                <td>
+                  <div
+                    class="c20"
+                    kind="secondary"
+                  >
+                    cluster: one
+                  </div>
+                  <div
+                    class="c20"
+                    kind="secondary"
+                  >
+                    kernel: 4.15.0-51-generic
+                  </div>
+                  <div
+                    class="c20"
+                    kind="secondary"
+                  >
+                    lortavma: one
+                  </div>
+                  <div
+                    class="c20"
+                    kind="secondary"
+                  >
+                    lenisret: 4.15.0-51-generic
+                  </div>
+                  <div
+                    class="c20"
+                    kind="secondary"
+                  >
+                    lofdevod: one
+                  </div>
+                  <div
+                    class="c20"
+                    kind="secondary"
+                  >
+                    llhurlaz: 4.15.0-51-generic
                   </div>
                 </td>
                 <td

--- a/packages/teleport/src/console/useOnExitConfirmation.test.ts
+++ b/packages/teleport/src/console/useOnExitConfirmation.test.ts
@@ -59,6 +59,7 @@ test('confirmation dialog before terminating an active ssh session', () => {
     serverId: 'serverId',
     login: 'login',
     created: new Date(),
+    sid: 'random-123-sid',
   });
   docs = ctx.getDocuments();
 
@@ -81,6 +82,7 @@ test('confirmation dialog before terminating an active ssh session', () => {
   expect(event.preventDefault).not.toHaveBeenCalled();
 
   // test aged terminal doc calls prompt
+  ctx.storeParties.setParties({ 'random-123-sid': [] });
   retVal = current.verifyAndConfirm(docTerminal);
   expect(retVal).toBe(false);
   expect(window.confirm).toHaveReturnedWith(false);

--- a/packages/teleport/src/console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/console/useOnExitConfirmation.ts
@@ -67,7 +67,7 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
    * confirmCloseSession prompts user to confirm to close.
    */
   function confirmCloseSession(doc) {
-    if (!doc || !doc.sid) return;
+    if (!doc || !doc.sid) return false;
 
     const numUsers = ctx.storeParties.state[doc.sid];
     if (numUsers.length > 1) {

--- a/packages/teleport/src/console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/console/useOnExitConfirmation.ts
@@ -66,7 +66,14 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
   /**
    * confirmCloseSession prompts user to confirm to close.
    */
-  function confirmCloseSession() {
+  function confirmCloseSession(doc) {
+    if (!doc || !doc.sid) return;
+
+    const numUsers = ctx.storeParties.state[doc.sid];
+    if (numUsers.length > 1) {
+      return window.confirm('Are you sure you want to leave this session?');
+    }
+
     return window.confirm('Are you sure you want to terminate this session?');
   }
 
@@ -95,7 +102,7 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
    */
   function verifyAndConfirm(doc: stores.Document) {
     if (hasLastingSshConnection(doc)) {
-      return confirmCloseSession();
+      return confirmCloseSession(doc);
     }
 
     return true;

--- a/packages/teleport/src/dashboard/components/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/packages/teleport/src/dashboard/components/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -318,12 +318,12 @@ exports[`render cluster nodes 1`] = `
       <strong>
         1
       </strong>
-       to 
+       - 
       <strong>
         37
       </strong>
-       of
        
+      of 
       <strong>
         37
       </strong>

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -500,6 +500,10 @@ export const formatters: Formatters = {
     desc: 'User Role Deleted',
     format: ({ user, name }) => `User "${user}" deleted role "${name}"`,
   },
+  [CodeEnum.TRUSTED_CLUSTER_TOKEN_CREATED]: {
+    desc: 'Trusted Cluster Token Created',
+    format: ({ user }) => `User "${user}" has created a trusted cluster token`,
+  },
 };
 
 const unknownFormatter = {

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -57,6 +57,8 @@ export const CodeEnum = {
   SAML_CONNECTOR_DELETED: 'T8201I',
   ACCESS_REQUEST_CREATED: 'T5000I',
   ACCESS_REQUEST_UPDATED: 'T5001I',
+  TRUSTED_CLUSTER_TOKEN_CREATED: 'T7002I',
+
   // Gravity
   G_ALERT_CREATED: 'G1007I',
   G_ALERT_DELETED: 'G2007I',
@@ -507,6 +509,9 @@ export type RawEvents = {
   [CodeEnum.ROLE_DELETED]: RawEvent<typeof CodeEnum.ROLE_DELETED, HasName>;
   [CodeEnum.G_ROLE_CREATED]: RawEvent<typeof CodeEnum.G_ROLE_CREATED, HasName>;
   [CodeEnum.G_ROLE_DELETED]: RawEvent<typeof CodeEnum.G_ROLE_DELETED, HasName>;
+  [CodeEnum.TRUSTED_CLUSTER_TOKEN_CREATED]: RawEvent<
+    typeof CodeEnum.TRUSTED_CLUSTER_TOKEN_CREATED
+  >;
 };
 
 /**


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/3827
fixes https://github.com/gravitational/teleport/issues/3836
fixes https://github.com/gravitational/teleport/issues/3835
fixes https://github.com/gravitational/teleport/issues/3837

#### Description
- Set sorting to ASC as default, fix Nodelist sort to be ASC on initial render
- On exit confirmation for console, `leave session` for parties > 1, else `terminate session`
- Prevent incrementing page numbers when there are no data
- Provide description for `trusted_cluster_token.created` event

#### Screenshots
Sort ASC default:
![Screenshot from 2020-06-15 14-26-56](https://user-images.githubusercontent.com/43280172/84714493-aa5a1280-af22-11ea-8bdd-f7cd18b04145.png)

Leave (user > 1) and Terminate (user == 1):
![screenshot_2](https://user-images.githubusercontent.com/43280172/84718935-d2e80980-af2e-11ea-9aeb-3c7ec890244d.png)
![screenshot_3](https://user-images.githubusercontent.com/43280172/84718936-d380a000-af2e-11ea-909e-2c8c68d069b5.png)

Prevent incrementing page numbers when there are no data:
![Screenshot from 2020-06-15 18-18-11](https://user-images.githubusercontent.com/43280172/84721064-9ddeb580-af34-11ea-9514-cec2b9e7748c.png)

Provide description for trusted_cluster_token.created:
![Screenshot from 2020-06-15 20-13-58](https://user-images.githubusercontent.com/43280172/84727844-d5edf480-af44-11ea-936e-1888d6d48cc6.png)
