### PR TITLE
Replace '+' symbols with empty spaces

### DIFF
--- a/packages/teleport/src/components/Login/LoginFailed.jsx
+++ b/packages/teleport/src/components/Login/LoginFailed.jsx
@@ -22,7 +22,7 @@ import cfg from 'teleport/config';
 import LogoHero from './../LogoHero';
 
 export default function LoginFailed() {
-  const message = getUrlParameter('details');
+  const message = getUrlParameter('details', window.location.search);
   return (
     <>
       <LogoHero />

--- a/packages/teleport/src/services/history.js
+++ b/packages/teleport/src/services/history.js
@@ -118,15 +118,7 @@ const match = url => route => {
 export default history;
 
 export function getUrlParameter(name, path) {
-  path = path || window.location.search;
-  const query = path.substring(1);
-  const vars = query.split('&');
-  for (var i = 0; i < vars.length; i++) {
-    var pair = vars[i].split('=');
-    if (decodeURIComponent(pair[0]) == name) {
-      return decodeURIComponent(pair[1]).replace(/\+/g, ' ');
-    }
-  }
-
-  return '';
+  const params = new URLSearchParams(path || window.location.search);
+  const value = params.get(name);
+  return value || '';
 }

--- a/packages/teleport/src/services/history.js
+++ b/packages/teleport/src/services/history.js
@@ -118,7 +118,7 @@ const match = url => route => {
 export default history;
 
 export function getUrlParameter(name, path) {
-  const params = new URLSearchParams(path || window.location.search);
+  const params = new URLSearchParams(path);
   const value = params.get(name);
   return value || '';
 }

--- a/packages/teleport/src/services/history.js
+++ b/packages/teleport/src/services/history.js
@@ -124,7 +124,7 @@ export function getUrlParameter(name, path) {
   for (var i = 0; i < vars.length; i++) {
     var pair = vars[i].split('=');
     if (decodeURIComponent(pair[0]) == name) {
-      return decodeURIComponent(pair[1]);
+      return decodeURIComponent(pair[1]).replace(/\+/g, ' ');
     }
   }
 

--- a/packages/teleport/src/services/history.test.js
+++ b/packages/teleport/src/services/history.test.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { createMemoryHistory } from 'history';
-import history from 'teleport/services/history';
+import history, { getUrlParameter } from 'teleport/services/history';
 
 history.init(new createMemoryHistory());
 
@@ -90,4 +90,15 @@ describe('services/history', () => {
       expect(history._pageRefresh).toBeCalledWith(expected);
     });
   });
+});
+
+test('getUrlParameter replaces all + symbols with empty space', () => {
+  // test from URL
+  window.history.replaceState({}, '', '/login_failed?details=hello+big+world');
+  let retVal = getUrlParameter('details');
+  expect(retVal).toBe('hello big world');
+
+  // test with given path
+  retVal = getUrlParameter('details', '?details=hello+big+world');
+  expect(retVal).toBe('hello big world');
 });

--- a/packages/teleport/src/services/history.test.js
+++ b/packages/teleport/src/services/history.test.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { createMemoryHistory } from 'history';
-import history, { getUrlParameter } from 'teleport/services/history';
+import history from 'teleport/services/history';
 
 history.init(new createMemoryHistory());
 
@@ -91,49 +91,4 @@ describe('services/history', () => {
       expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
   });
-});
-
-test('getUrlParameter escapes character as expected', () => {
-  // test empty URL
-  let retVal = getUrlParameter('none');
-  expect(retVal).toBe('');
-
-  // actual response from github auth
-  let testStr =
-    'callback' +
-    '?error=redirect_uri_mismatch' +
-    '&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.' +
-    '&error_uri=https%3A%2F%2Fdeveloper.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch' +
-    '&state=01c002c10fc3d0b1becb8225f26cb07b';
-
-  // test from URL
-  window.history.replaceState({}, '', testStr);
-
-  // test no escape symbols
-  retVal = getUrlParameter('error');
-  expect(retVal).toBe('redirect_uri_mismatch');
-  retVal = getUrlParameter('state');
-  expect(retVal).toBe('01c002c10fc3d0b1becb8225f26cb07b');
-
-  // test "+" symbol gets read as white space
-  retVal = getUrlParameter('error_description');
-  expect(retVal).toBe(
-    'The redirect_uri MUST match the registered callback URL for this application.'
-  );
-
-  // test varity of escape symbols
-  retVal = getUrlParameter('error_uri');
-  expect(retVal).toBe(
-    'https://developer.github.com/apps/managing-oauth-apps/troubleshooting-authorization-request-errors/#redirect-uri-mismatch'
-  );
-
-  // test non-existing param
-  retVal = getUrlParameter('none');
-  expect(retVal).toBe('');
-  retVal = getUrlParameter('');
-  expect(retVal).toBe('');
-
-  // test with given path
-  retVal = getUrlParameter('details', '?details=hello+big+world');
-  expect(retVal).toBe('hello big world');
 });

--- a/packages/teleport/src/services/history.test.js
+++ b/packages/teleport/src/services/history.test.js
@@ -41,6 +41,7 @@ describe('services/history', () => {
       },
     });
 
+    // eslint-disable-next-line jest/expect-expect
     it('should push if allowed else fallback to default route', () => {
       history.getRoutes.mockReturnValue([
         '/valid',
@@ -75,7 +76,7 @@ describe('services/history', () => {
       let route = '/';
       history.getRoutes.mockReturnValue([route]);
       history.push(route, true);
-      expect(history._pageRefresh).toBeCalledWith(route);
+      expect(history._pageRefresh).toHaveBeenCalledWith(route);
     });
   });
 
@@ -87,16 +88,50 @@ describe('services/history', () => {
 
       const expected =
         '/web/login?redirect_uri=http://localhost/current-location';
-      expect(history._pageRefresh).toBeCalledWith(expected);
+      expect(history._pageRefresh).toHaveBeenCalledWith(expected);
     });
   });
 });
 
-test('getUrlParameter replaces all + symbols with empty space', () => {
+test('getUrlParameter escapes character as expected', () => {
+  // test empty URL
+  let retVal = getUrlParameter('none');
+  expect(retVal).toBe('');
+
+  // actual response from github auth
+  let testStr =
+    'callback' +
+    '?error=redirect_uri_mismatch' +
+    '&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.' +
+    '&error_uri=https%3A%2F%2Fdeveloper.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch' +
+    '&state=01c002c10fc3d0b1becb8225f26cb07b';
+
   // test from URL
-  window.history.replaceState({}, '', '/login_failed?details=hello+big+world');
-  let retVal = getUrlParameter('details');
-  expect(retVal).toBe('hello big world');
+  window.history.replaceState({}, '', testStr);
+
+  // test no escape symbols
+  retVal = getUrlParameter('error');
+  expect(retVal).toBe('redirect_uri_mismatch');
+  retVal = getUrlParameter('state');
+  expect(retVal).toBe('01c002c10fc3d0b1becb8225f26cb07b');
+
+  // test "+" symbol gets read as white space
+  retVal = getUrlParameter('error_description');
+  expect(retVal).toBe(
+    'The redirect_uri MUST match the registered callback URL for this application.'
+  );
+
+  // test varity of escape symbols
+  retVal = getUrlParameter('error_uri');
+  expect(retVal).toBe(
+    'https://developer.github.com/apps/managing-oauth-apps/troubleshooting-authorization-request-errors/#redirect-uri-mismatch'
+  );
+
+  // test non-existing param
+  retVal = getUrlParameter('none');
+  expect(retVal).toBe('');
+  retVal = getUrlParameter('');
+  expect(retVal).toBe('');
 
   // test with given path
   retVal = getUrlParameter('details', '?details=hello+big+world');


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/3774

#### Description
- Use native URLSearchParams to handle escape symbols
- Add unit test

#### Screenshot
![Screenshot from 2020-06-17 21-47-43](https://user-images.githubusercontent.com/43280172/84980037-d83b8480-b0e5-11ea-91a6-73a4a8a321ba.png)
