### PR TITLE
Allow dashes for login name in QuickLauncher

### DIFF
--- a/packages/teleport/src/components/QuickLaunch/QuickLaunch.jsx
+++ b/packages/teleport/src/components/QuickLaunch/QuickLaunch.jsx
@@ -54,7 +54,7 @@ export default function FieldInputSsh({ onPress, ...boxProps }) {
   );
 }
 
-const SSH_STR_REGEX = /(^\w+@(\S+)$)/;
+const SSH_STR_REGEX = /(^(\w+-?\w+)+@(\S+)$)/;
 const check = value => {
   const match = SSH_STR_REGEX.exec(value);
   return match !== null;


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/3790

#### Description
QuickLaunch regex now accepts dashes between words.