### PR TITLE
Remove uppercasing of login names

### DIFF
--- a/packages/design/src/TopNav/TopNavItem.jsx
+++ b/packages/design/src/TopNav/TopNavItem.jsx
@@ -36,7 +36,6 @@ const TopNavItem = styled.button`
   padding: 0 16px;
   position: relative;
   text-decoration: none;
-  text-transform: uppercase;
 
   &:hover, &:focus {
     background:  ${props =>

--- a/packages/design/src/TopNav/TopNavUserMenu/TopNavUserMenu.jsx
+++ b/packages/design/src/TopNav/TopNavUserMenu/TopNavUserMenu.jsx
@@ -53,7 +53,13 @@ class TopNavUserMenu extends React.Component {
       children,
       menuListCss,
     } = this.props;
-    const initial = user && user.length ? user.trim().charAt(0) : '';
+    const initial =
+      user && user.length
+        ? user
+            .trim()
+            .charAt(0)
+            .toUpperCase()
+        : '';
     const anchorEl = open ? this.btnRef : null;
     return (
       <>
@@ -63,7 +69,7 @@ class TopNavUserMenu extends React.Component {
           ref={this.setRef}
           onClick={onShow}
         >
-          <Text typography="subtitle2" bold>
+          <Text fontSize="12px" bold>
             {user}
           </Text>
           <StyledAvatar>{initial}</StyledAvatar>
@@ -93,7 +99,9 @@ const StyledAvatar = styled.div`
   justify-content: center;
   height: 32px;
   margin-left: 16px;
-  width: 32px;
+  width: 100%;
+  max-width: 32px;
+  min-width: 32px;
 `;
 
 export default TopNavUserMenu;

--- a/packages/design/src/TopNav/__snapshots__/Topnav.story.test.js.snap
+++ b/packages/design/src/TopNav/__snapshots__/Topnav.story.test.js.snap
@@ -91,8 +91,7 @@ exports[`rendering of TopNav and TopNavItem 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
-  font-size: 10px;
-  line-height: 16px;
+  font-size: 12px;
   margin: 0px;
 }
 
@@ -106,7 +105,9 @@ exports[`rendering of TopNav and TopNavItem 1`] = `
   justify-content: center;
   height: 32px;
   margin-left: 16px;
-  width: 32px;
+  width: 100%;
+  max-width: 32px;
+  min-width: 32px;
 }
 
 <nav
@@ -128,13 +129,14 @@ exports[`rendering of TopNav and TopNavItem 1`] = `
   >
     <div
       class="c3"
+      font-size="12px"
     >
       example@example.com
     </div>
     <div
       class="c4"
     >
-      e
+      E
     </div>
   </button>
 </nav>

--- a/packages/design/src/TopNav/__snapshots__/Topnav.story.test.js.snap
+++ b/packages/design/src/TopNav/__snapshots__/Topnav.story.test.js.snap
@@ -26,7 +26,6 @@ exports[`rendering of TopNav and TopNavItem 1`] = `
   padding: 0 16px;
   position: relative;
   text-decoration: none;
-  text-transform: uppercase;
 }
 
 .c1:hover,
@@ -64,7 +63,6 @@ exports[`rendering of TopNav and TopNavItem 1`] = `
   padding: 0 16px;
   position: relative;
   text-decoration: none;
-  text-transform: uppercase;
   margin-left: auto;
   max-width: 250px;
 }

--- a/packages/teleport/src/cluster/components/TopBar/__snapshots__/TopBar.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/TopBar/__snapshots__/TopBar.story.test.tsx.snap
@@ -94,8 +94,7 @@ exports[`rendering of ClusterTopBar 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
-  font-size: 10px;
-  line-height: 16px;
+  font-size: 12px;
   margin: 0px;
 }
 
@@ -209,7 +208,9 @@ exports[`rendering of ClusterTopBar 1`] = `
   justify-content: center;
   height: 32px;
   margin-left: 16px;
-  width: 32px;
+  width: 100%;
+  max-width: 32px;
+  min-width: 32px;
 }
 
 .c4 {
@@ -292,6 +293,7 @@ exports[`rendering of ClusterTopBar 1`] = `
     >
       <div
         class="c10"
+        font-size="12px"
       >
         Timothy Kim
       </div>

--- a/packages/teleport/src/cluster/components/TopBar/__snapshots__/TopBar.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/TopBar/__snapshots__/TopBar.story.test.tsx.snap
@@ -137,7 +137,6 @@ exports[`rendering of ClusterTopBar 1`] = `
   padding: 0 16px;
   position: relative;
   text-decoration: none;
-  text-transform: uppercase;
   width: 208px;
 }
 
@@ -176,7 +175,6 @@ exports[`rendering of ClusterTopBar 1`] = `
   padding: 0 16px;
   position: relative;
   text-decoration: none;
-  text-transform: uppercase;
   margin-left: auto;
   max-width: 250px;
 }


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/3832#issuecomment-651436183 (login names)

#### Description
- Removes upper casings for usernames/emails in topbars

**Note:** Teleport seems to allow case sensitive usernames, so I did not enforce lowercasing

#### Screenshot
![Screenshot from 2020-06-29 18-13-22](https://user-images.githubusercontent.com/43280172/86071503-42342200-ba34-11ea-888c-6ac2f21e2092.png)
