### PR TITLE
Set user permission for viewing audit logs

### DIFF
--- a/packages/teleport/src/services/user/makeAcl.ts
+++ b/packages/teleport/src/services/user/makeAcl.ts
@@ -24,7 +24,7 @@ export default function makeAcl(json): Acl {
   const trustedClusters = makeAccess(json.trustedClusters);
   const roles = makeAccess(json.roles);
   const sessions = makeAccess(json.sessions);
-  const events = makeAccess({ list: true });
+  const events = makeAccess(json.events);
 
   return {
     logins,


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/3922

#### Description
Set user permission for viewing audit logs (events)

#### Dependent PR
https://github.com/gravitational/teleport/pull/3941

#### Screenshot
![yyyyyy](https://user-images.githubusercontent.com/43280172/86084127-eb891100-ba50-11ea-9e9b-4ae79a5cdce1.png)
![Screenshot from 2020-06-29 19-12-27](https://user-images.githubusercontent.com/43280172/86084129-ec21a780-ba50-11ea-960b-9647fa0a9e7a.png)

