### PR TITLE
Bring back QuickLaunch

### DIFF
--- a/packages/teleport/src/cluster/components/Nodes/Nodes.tsx
+++ b/packages/teleport/src/cluster/components/Nodes/Nodes.tsx
@@ -16,12 +16,13 @@ limitations under the License.
 
 import React from 'react';
 import * as Cards from 'design/CardError';
-import { Indicator, Box } from 'design';
+import { Indicator, Box, Flex } from 'design';
 import {
   FeatureBox,
   FeatureHeader,
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
+import QuickLaunch from 'teleport/components/QuickLaunch';
 import { useTeleport } from 'teleport/teleportContextProvider';
 import NodeList from 'teleport/components/NodeList';
 import useClusterNodes from './useClusterNodes';
@@ -47,10 +48,25 @@ export function Nodes({
     startSshSession(login, serverId);
   }
 
+  function onQuickLaunchEnter(login: string, serverId: string) {
+    startSshSession(login, serverId);
+  }
+
   return (
     <FeatureBox>
-      <FeatureHeader alignItems="center">
+      <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle mr="5">Nodes</FeatureHeaderTitle>
+        <QuickLaunch
+          as={Flex}
+          autoFocus={false}
+          alignItems="center"
+          labelProps={{
+            mr: 3,
+            mb: 0,
+            style: { whiteSpace: 'nowrap', width: 'auto' },
+          }}
+          onPress={onQuickLaunchEnter}
+        />
       </FeatureHeader>
       {attempt.isProcessing && (
         <Box textAlign="center" m={10}>

--- a/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -71,7 +71,11 @@ exports[`failed 1`] = `
 `;
 
 exports[`loaded 1`] = `
-.c14 {
+.c4 {
+  box-sizing: border-box;
+}
+
+.c18 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -100,40 +104,40 @@ exports[`loaded 1`] = `
   height: 24px;
 }
 
-.c14:active {
+.c18:active {
   opacity: 0.56;
 }
 
-.c14:hover,
-.c14:focus {
+.c18:hover,
+.c18:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c14:active {
+.c18:active {
   opacity: 0.24;
 }
 
-.c14:disabled {
+.c18:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c9 {
+.c13 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
   font-size: 16px;
 }
 
-.c12 {
+.c16 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c15 {
+.c19 {
   display: inline-block;
   transition: color .3s;
   margin-left: 8px;
@@ -142,7 +146,7 @@ exports[`loaded 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c17 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -159,7 +163,18 @@ exports[`loaded 1`] = `
   margin-right: 4px;
 }
 
-.c6 {
+.c5 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 0px;
+  margin-right: 16px;
+}
+
+.c10 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -170,6 +185,12 @@ exports[`loaded 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+}
+
+.c7 {
   box-sizing: border-box;
   margin-bottom: 24px;
   display: flex;
@@ -182,6 +203,7 @@ exports[`loaded 1`] = `
   margin-bottom: 24px;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   flex-shrink: 0;
   border-bottom: 1px solid #1C254D;
   height: 56px;
@@ -218,7 +240,52 @@ exports[`loaded 1`] = `
   padding-bottom: 24px;
 }
 
-.c10 {
+.c6 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  color: rgba(255,255,255,0.87);
+  background-color: #222C59;
+  width: 200px;
+  height: 34px;
+  background: #222C59;
+  border: 1px solid #111B48;
+  border-radius: 4px;
+  border-color: rgba(255,255,255,0.24);
+  font-size: 14px;
+  font-family: Ubuntu2,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+}
+
+.c6::-ms-clear {
+  display: none;
+}
+
+.c6::placeholder {
+  opacity: 0.4;
+}
+
+.c6:hover,
+.c6:focus,
+.c6:active {
+  color: rgba(255,255,255,0.87);
+  background: #2C3A73;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+}
+
+.c6::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 14px;
+}
+
+.c14 {
   background: #222C59;
   box-shadow: 0 4px 16px rgba(0,0,0,0.24);
   border-collapse: collapse;
@@ -228,35 +295,35 @@ exports[`loaded 1`] = `
   width: 100%;
 }
 
-.c10 > thead > tr > th,
-.c10 > tbody > tr > th,
-.c10 > tfoot > tr > th,
-.c10 > thead > tr > td,
-.c10 > tbody > tr > td,
-.c10 > tfoot > tr > td {
+.c14 > thead > tr > th,
+.c14 > tbody > tr > th,
+.c14 > tfoot > tr > th,
+.c14 > thead > tr > td,
+.c14 > tbody > tr > td,
+.c14 > tfoot > tr > td {
   padding: 8px 8px;
   vertical-align: middle;
 }
 
-.c10 > thead > tr > th:first-child,
-.c10 > tbody > tr > th:first-child,
-.c10 > tfoot > tr > th:first-child,
-.c10 > thead > tr > td:first-child,
-.c10 > tbody > tr > td:first-child,
-.c10 > tfoot > tr > td:first-child {
+.c14 > thead > tr > th:first-child,
+.c14 > tbody > tr > th:first-child,
+.c14 > tfoot > tr > th:first-child,
+.c14 > thead > tr > td:first-child,
+.c14 > tbody > tr > td:first-child,
+.c14 > tfoot > tr > td:first-child {
   padding-left: 24px;
 }
 
-.c10 > thead > tr > th:last-child,
-.c10 > tbody > tr > th:last-child,
-.c10 > tfoot > tr > th:last-child,
-.c10 > thead > tr > td:last-child,
-.c10 > tbody > tr > td:last-child,
-.c10 > tfoot > tr > td:last-child {
+.c14 > thead > tr > th:last-child,
+.c14 > tbody > tr > th:last-child,
+.c14 > tfoot > tr > th:last-child,
+.c14 > thead > tr > td:last-child,
+.c14 > tbody > tr > td:last-child,
+.c14 > tfoot > tr > td:last-child {
   padding-right: 24px;
 }
 
-.c10 > thead > tr > th {
+.c14 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
   cursor: pointer;
@@ -270,23 +337,23 @@ exports[`loaded 1`] = `
   white-space: nowrap;
 }
 
-.c10 > thead > tr > th .c8 {
+.c14 > thead > tr > th .c12 {
   font-weight: bold;
   font-size: 8px;
   margin-left: 8px;
 }
 
-.c10 > tbody > tr > td {
+.c14 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
 }
 
-.c7 {
+.c11 {
   box-sizing: border-box;
   display: flex;
 }
 
-.c7 button {
+.c11 button {
   background: none;
   border: none;
   border-radius: 200px;
@@ -298,23 +365,23 @@ exports[`loaded 1`] = `
   text-align: center;
 }
 
-.c7 button:hover,
-.c7 button:focus {
+.c11 button:hover,
+.c11 button:focus {
   background: #1C254D;
 }
 
-.c7 button:hover .c8,
-.c7 button:focus .c8 {
+.c11 button:hover .c12,
+.c11 button:focus .c12 {
   opacity: 1;
 }
 
-.c7 button .c8 {
+.c11 button .c12 {
   opacity: 0.4;
   font-size: 20px;
   transition: all 0.3s;
 }
 
-.c5 {
+.c9 {
   padding: 8px 24px;
   display: flex;
   height: 24px;
@@ -326,7 +393,7 @@ exports[`loaded 1`] = `
   border-top-right-radius: 8px;
 }
 
-.c4 {
+.c8 {
   box-sizing: border-box;
   font-size: 12px;
   min-width: 200px;
@@ -343,46 +410,64 @@ exports[`loaded 1`] = `
   height: 30px;
 }
 
-.c4:hover {
+.c8:hover {
   background: #2C3A73;
 }
 
-.c4:focus,
-.c4:active {
+.c8:focus,
+.c8:active {
   background: #2C3A73;
   box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
   color: rgba(255,255,255,0.87);
 }
 
-.c4::placeholder {
+.c8::placeholder {
   color: rgba(255,255,255,0.24);
   font-size: 12px;
 }
 
-.c11 > tbody > tr > td {
+.c15 > tbody > tr > td {
   vertical-align: baseline;
 }
 
 <div
-  class="sc-AxirZ c0"
+  class="c0"
 >
   <div
-    class="sc-AxirZ c1"
+    class="c1"
   >
     <div
       class="c2"
     >
       Nodes
     </div>
+    <div
+      class="c3 sc-AxirZ c4"
+    >
+      <label
+        class="c5"
+        font-size="0"
+        style="white-space: nowrap; width: auto;"
+      >
+        Quick Launch
+      </label>
+      <input
+        class="sc-fzozJi c6"
+        color="text.primary"
+        height="34px"
+        placeholder="login@host"
+        width="200px"
+      />
+    </div>
   </div>
   <div
     style="width: 100%;"
   >
     <div
-      class="sc-AxirZ c3"
+      class="c7"
     >
       <input
-        class="c4"
+        class="c8"
         color="text.primary"
         height="30px"
         placeholder="SEARCH..."
@@ -391,10 +476,10 @@ exports[`loaded 1`] = `
     </div>
     <div>
       <nav
-        class="c5"
+        class="c9"
       >
         <div
-          class="c6"
+          class="c10"
           color="primary.contrastText"
         >
           SHOWING 
@@ -412,14 +497,14 @@ exports[`loaded 1`] = `
           </strong>
         </div>
         <div
-          class="sc-AxirZ c7"
+          class="c11"
         >
           <button
             disabled=""
             title="Previous Page"
           >
             <span
-              class="c8 c9 icon icon-arrow-left-circle "
+              class="c12 c13 icon icon-arrow-left-circle "
               color="light"
               font-size="3"
             />
@@ -429,7 +514,7 @@ exports[`loaded 1`] = `
             title="Next Page"
           >
             <span
-              class="c8 c9 icon icon-arrow-right-circle "
+              class="c12 c13 icon icon-arrow-right-circle "
               color="light"
               font-size="3"
             />
@@ -437,7 +522,7 @@ exports[`loaded 1`] = `
         </div>
       </nav>
       <table
-        class="c10 c11"
+        class="c14 c15"
       >
         <thead>
           <tr>
@@ -445,7 +530,7 @@ exports[`loaded 1`] = `
               <a>
                 Hostname
                 <span
-                  class="c8 c12 icon icon-chevron-down "
+                  class="c12 c16 icon icon-chevron-down "
                   color="light"
                 />
               </a>
@@ -454,7 +539,7 @@ exports[`loaded 1`] = `
               <a>
                 Address
                 <span
-                  class="c8 c12 icon icon-chevrons-expand-vertical "
+                  class="c12 c16 icon icon-chevrons-expand-vertical "
                   color="light"
                 />
               </a>
@@ -475,13 +560,13 @@ exports[`loaded 1`] = `
             </td>
             <td>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -491,13 +576,13 @@ exports[`loaded 1`] = `
               align="right"
             >
               <button
-                class="c14"
+                class="c18"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c8 c15 icon icon-caret-down "
+                  class="c12 c19 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -513,13 +598,13 @@ exports[`loaded 1`] = `
             </td>
             <td>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -529,13 +614,13 @@ exports[`loaded 1`] = `
               align="right"
             >
               <button
-                class="c14"
+                class="c18"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c8 c15 icon icon-caret-down "
+                  class="c12 c19 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -551,13 +636,13 @@ exports[`loaded 1`] = `
             </td>
             <td>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -567,13 +652,13 @@ exports[`loaded 1`] = `
               align="right"
             >
               <button
-                class="c14"
+                class="c18"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c8 c15 icon icon-caret-down "
+                  class="c12 c19 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -589,13 +674,13 @@ exports[`loaded 1`] = `
             </td>
             <td>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -605,13 +690,13 @@ exports[`loaded 1`] = `
               align="right"
             >
               <button
-                class="c14"
+                class="c18"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c8 c15 icon icon-caret-down "
+                  class="c12 c19 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -627,13 +712,13 @@ exports[`loaded 1`] = `
             </td>
             <td>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -643,13 +728,13 @@ exports[`loaded 1`] = `
               align="right"
             >
               <button
-                class="c14"
+                class="c18"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c8 c15 icon icon-caret-down "
+                  class="c12 c19 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -670,13 +755,13 @@ exports[`loaded 1`] = `
             </td>
             <td>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -686,13 +771,13 @@ exports[`loaded 1`] = `
               align="right"
             >
               <button
-                class="c14"
+                class="c18"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c8 c15 icon icon-caret-down "
+                  class="c12 c19 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -713,13 +798,13 @@ exports[`loaded 1`] = `
             </td>
             <td>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c13"
+                class="c17"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -729,13 +814,13 @@ exports[`loaded 1`] = `
               align="right"
             >
               <button
-                class="c14"
+                class="c18"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c8 c15 icon icon-caret-down "
+                  class="c12 c19 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />

--- a/packages/teleport/src/components/QuickLaunch/QuickLaunch.jsx
+++ b/packages/teleport/src/components/QuickLaunch/QuickLaunch.jsx
@@ -18,7 +18,13 @@ import React from 'react';
 import styled from 'styled-components';
 import { Box, Input, LabelInput } from 'design';
 
-export default function FieldInputSsh({ onPress, ...boxProps }) {
+export default function FieldInputSsh({
+  onPress,
+  autoFocus = true,
+  width = '200px',
+  labelProps = {},
+  ...boxProps
+}) {
   const [hasError, setHasError] = React.useState(false);
 
   function onKeyPress(e) {
@@ -39,14 +45,16 @@ export default function FieldInputSsh({ onPress, ...boxProps }) {
 
   return (
     <Box {...boxProps}>
-      <LabelInput hasError={hasError}>{labelText}</LabelInput>
+      <LabelInput {...labelProps} hasError={hasError}>
+        {labelText}
+      </LabelInput>
       <StyledInput
-        autoFocus
         height="34px"
-        width="240px"
         bg="primary.light"
         color="text.primary"
         placeholder="login@host"
+        autoFocus={autoFocus}
+        width={width}
         onKeyPress={onKeyPress}
       />
     </Box>

--- a/packages/teleport/src/console/components/DocumentNodes/DocumentNodes.tsx
+++ b/packages/teleport/src/console/components/DocumentNodes/DocumentNodes.tsx
@@ -85,7 +85,7 @@ export default function DocumentNodes(props: Props) {
               mr="20px"
               onChange={onChangeCluster}
             />
-            <QuickLaunch onPress={onQuickLaunchEnter} mr="3" />
+            <QuickLaunch width="240px" onPress={onQuickLaunchEnter} />
           </Flex>
           {isProcessing && (
             <Box textAlign="center" m={10}>

--- a/packages/teleport/src/console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`render DocumentNodes 1`] = `
 
 .c8 {
   box-sizing: border-box;
-  margin-right: 16px;
 }
 
 .c21 {

--- a/packages/teleport/src/dashboard/components/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/packages/teleport/src/dashboard/components/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`render cluster nodes 1`] = `
-.c14 {
+.c15 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -30,22 +30,22 @@ exports[`render cluster nodes 1`] = `
   height: 24px;
 }
 
-.c14:active {
+.c15:active {
   opacity: 0.56;
 }
 
-.c14:hover,
-.c14:focus {
+.c15:hover,
+.c15:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c14:active {
+.c15:active {
   opacity: 0.24;
 }
 
-.c14:disabled {
+.c15:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -63,7 +63,7 @@ exports[`render cluster nodes 1`] = `
   color: #FFFFFF;
 }
 
-.c15 {
+.c16 {
   display: inline-block;
   transition: color .3s;
   margin-left: 8px;
@@ -287,9 +287,25 @@ exports[`render cluster nodes 1`] = `
 }
 
 .c11 tbody tr:hover {
-  cursor: pointer;
-  background-color: #2C3A73;
-  border-bottom: 1px solid #2C3A73;
+  background-color: #2c3a7357;
+}
+
+.c14 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  color: rgba(255,255,255,0.87);
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.c14:focus {
+  background: #2c3a73;
+  padding: 2px 4px;
+  margin: 0 -4px;
 }
 
 <div
@@ -418,15 +434,29 @@ exports[`render cluster nodes 1`] = `
           </div>
         </td>
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lawnabza"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             localhost
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          30
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/localhost/console/nodes"
+            target="_blank"
+          >
+            30
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -435,13 +465,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -451,15 +481,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/nidvojik"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             nidvojik
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          21
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/nidvojik/console/nodes"
+            target="_blank"
+          >
+            21
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -468,13 +512,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -484,15 +528,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             lidtabih
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          35
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/lidtabih/console/nodes"
+            target="_blank"
+          >
+            35
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -501,13 +559,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -517,15 +575,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             farovluv
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          12
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/farovluv/console/nodes"
+            target="_blank"
+          >
+            12
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -534,13 +606,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -550,15 +622,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             rozpaari
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          32
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/rozpaari/console/nodes"
+            target="_blank"
+          >
+            32
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -567,13 +653,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -583,15 +669,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             wetjolune
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          8
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/wetjolune/console/nodes"
+            target="_blank"
+          >
+            8
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -600,13 +700,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -616,15 +716,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             dashawic
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          11
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/dashawic/console/nodes"
+            target="_blank"
+          >
+            11
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -633,13 +747,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -649,15 +763,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             jesushenry58
-          </strong>
+          </a>
         </td>
         <td>
           1.2.239
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/jesushenry58/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -666,13 +794,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -682,15 +810,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             jordansimpson35
-          </strong>
+          </a>
         </td>
         <td>
           1.2.20
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/jordansimpson35/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -699,13 +841,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -715,15 +857,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             leonamann249
-          </strong>
+          </a>
         </td>
         <td>
           1.2.245
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/leonamann249/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -732,13 +888,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -748,15 +904,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             bessiecohen207
-          </strong>
+          </a>
         </td>
         <td>
           1.2.239
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/bessiecohen207/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -765,13 +935,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -781,15 +951,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             philipjohnson10
-          </strong>
+          </a>
         </td>
         <td>
           1.2.20
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/philipjohnson10/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -798,13 +982,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -814,15 +998,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             teresastone14
-          </strong>
+          </a>
         </td>
         <td>
           1.2.236
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/teresastone14/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -831,13 +1029,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -847,15 +1045,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             connorsharp137
-          </strong>
+          </a>
         </td>
         <td>
           1.2.224
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/connorsharp137/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -864,13 +1076,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -880,15 +1092,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             ricardosingleton242
-          </strong>
+          </a>
         </td>
         <td>
           1.2.105
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/ricardosingleton242/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -897,13 +1123,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -913,15 +1139,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             rozpaari
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          32
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/rozpaari/console/nodes"
+            target="_blank"
+          >
+            32
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -930,13 +1170,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -946,15 +1186,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             wetjolune
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          8
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/wetjolune/console/nodes"
+            target="_blank"
+          >
+            8
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -963,13 +1217,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -979,15 +1233,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             dashawic
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          11
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/dashawic/console/nodes"
+            target="_blank"
+          >
+            11
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -996,13 +1264,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1012,15 +1280,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             williepayne223
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/williepayne223/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1029,13 +1311,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1045,15 +1327,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             samlewis176
-          </strong>
+          </a>
         </td>
         <td>
           1.2.84
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/samlewis176/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1062,13 +1358,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1078,15 +1374,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             nellwheeler72
-          </strong>
+          </a>
         </td>
         <td>
           1.2.55
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/nellwheeler72/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1095,13 +1405,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1111,15 +1421,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             albertowens200
-          </strong>
+          </a>
         </td>
         <td>
           1.2.144
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/albertowens200/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1128,13 +1452,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1144,15 +1468,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             beatricecarson171
-          </strong>
+          </a>
         </td>
         <td>
           1.2.251
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/beatricecarson171/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1161,13 +1499,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1177,15 +1515,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             besscarroll152
-          </strong>
+          </a>
         </td>
         <td>
           1.2.104
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/besscarroll152/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1194,13 +1546,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1210,15 +1562,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             hannahsutton232
-          </strong>
+          </a>
         </td>
         <td>
           1.2.110
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/hannahsutton232/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1227,13 +1593,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1243,15 +1609,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             barrynelson110
-          </strong>
+          </a>
         </td>
         <td>
           1.2.199
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/barrynelson110/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1260,13 +1640,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1276,15 +1656,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             rozpaari
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          32
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/rozpaari/console/nodes"
+            target="_blank"
+          >
+            32
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1293,13 +1687,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1309,15 +1703,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             wetjolune
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          8
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/wetjolune/console/nodes"
+            target="_blank"
+          >
+            8
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1326,13 +1734,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1342,15 +1750,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             dashawic
-          </strong>
+          </a>
         </td>
         <td>
           1.2.3
         </td>
         <td>
-          11
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/dashawic/console/nodes"
+            target="_blank"
+          >
+            11
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1359,13 +1781,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1375,15 +1797,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             henriettarios78
-          </strong>
+          </a>
         </td>
         <td>
           1.2.153
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/henriettarios78/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1392,13 +1828,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1408,15 +1844,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             josephinewolfe55
-          </strong>
+          </a>
         </td>
         <td>
           1.2.154
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/josephinewolfe55/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1425,13 +1875,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1441,15 +1891,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             jaysandoval137
-          </strong>
+          </a>
         </td>
         <td>
           1.2.66
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/jaysandoval137/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1458,13 +1922,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1474,15 +1938,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             isabellekim81
-          </strong>
+          </a>
         </td>
         <td>
           1.2.150
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/isabellekim81/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1491,13 +1969,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1507,15 +1985,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             francismoran134
-          </strong>
+          </a>
         </td>
         <td>
           1.2.82
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/francismoran134/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1524,13 +2016,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1540,15 +2032,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             theodorefrazier78
-          </strong>
+          </a>
         </td>
         <td>
           1.2.61
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/theodorefrazier78/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1557,13 +2063,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1573,15 +2079,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             hattiestanley34
-          </strong>
+          </a>
         </td>
         <td>
           1.2.93
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/hattiestanley34/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1590,13 +2110,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1606,15 +2126,29 @@ exports[`render cluster nodes 1`] = `
       <tr>
         <td />
         <td>
-          <strong>
+          <a
+            class="c14"
+            color="text.primary"
+            href="/localhost/1/lidtabih"
+            m="0"
+            theme="[object Object]"
+            typography="body2"
+          >
             tommybrooks146
-          </strong>
+          </a>
         </td>
         <td>
           1.2.112
         </td>
         <td>
-          23
+          <a
+            class="c14"
+            color="text.primary"
+            href="/web/cluster/tommybrooks146/console/nodes"
+            target="_blank"
+          >
+            23
+          </a>
         </td>
         <td>
           https://abc.example.com:333/web
@@ -1623,13 +2157,13 @@ exports[`render cluster nodes 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c8 c15 icon icon-caret-down "
+              class="c8 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />


### PR DESCRIPTION
This change brings back the QuickLaunch input to the Cluster Nodes screen.
It also removes the Cluster list "on row click" event. Now, to get to the cluster management screen you have to click on the cluster name.
![image](https://user-images.githubusercontent.com/7816406/86834131-72994300-c068-11ea-9411-5da3f36dd319.png)
