### PR TITLE
Work around for close events on ssh errors in Client

### DIFF
--- a/packages/teleport/src/console/components/DocumentSsh/useSshSession.ts
+++ b/packages/teleport/src/console/components/DocumentSsh/useSshSession.ts
@@ -38,6 +38,9 @@ export default function useSshSession(doc: DocumentSsh) {
       const tty = ctx.createTty(session);
 
       /**
+       * DELETE: Remove once remote process exit errors are handled in the backend:
+       * https://github.com/gravitational/teleport/issues/4025
+       *
        * Currently Teleport does not handle all errors that can occur during SSH session creation.
        * It can mistakenly create a session (recording) and write SSH initialization errors
        * directly into the stream as if these errors happened within an actual SSH session. It then


### PR DESCRIPTION
work around for: https://github.com/gravitational/teleport/issues/4025

#### Description
Work around for now, to handle closing tabs for exec command errors.

#### Screenshot
![Screenshot from 2020-07-20 23-39-38](https://user-images.githubusercontent.com/43280172/88021843-1102bb00-cae3-11ea-85c6-c7c1085ee351.png)
![Screenshot from 2020-07-20 23-39-47](https://user-images.githubusercontent.com/43280172/88021845-119b5180-cae3-11ea-8fee-74ad6a256746.png)
