### PR TITLE
Drop UTM link prefixes

### DIFF
--- a/packages/teleport/src/cluster/components/Support/Support.tsx
+++ b/packages/teleport/src/cluster/components/Support/Support.tsx
@@ -145,7 +145,7 @@ const getDocURLs = (version = '') => {
    * @param anchorHash the hash in URL that predefines scroll location in the page.
    */
   const withUTM = (url = '', anchorHash = '') =>
-    `${url}?utm_source=teleport&utm_medium=${verPrefix}_${version}${anchorHash}`;
+    `${url}?product=teleport&version=${verPrefix}_${version}${anchorHash}`;
 
   return {
     quickstart: withUTM('https://gravitational.com/teleport/docs/quickstart'),

--- a/packages/teleport/src/cluster/components/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/packages/teleport/src/cluster/components/Support/__snapshots__/Support.story.test.tsx.snap
@@ -249,19 +249,19 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/quickstart?utm_source=teleport&utm_medium=e_5.0.0"
+          href="https://gravitational.com/teleport/docs/quickstart?product=teleport&version=e_5.0.0"
         >
           Quickstart Guide
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/user-manual?utm_source=teleport&utm_medium=e_5.0.0"
+          href="https://gravitational.com/teleport/docs/user-manual?product=teleport&version=e_5.0.0"
         >
           tsh User Guide
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=e_5.0.0"
+          href="https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=e_5.0.0"
         >
           Admin Guide
         </a>
@@ -273,7 +273,7 @@ exports[`support Enterprise 1`] = `
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/faq?utm_source=teleport&utm_medium=e_5.0.0"
+          href="https://gravitational.com/teleport/docs/faq?product=teleport&version=e_5.0.0"
         >
           FAQ
         </a>
@@ -302,19 +302,19 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=e_5.0.0#troubleshooting"
+          href="https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=e_5.0.0#troubleshooting"
         >
           Monitoring Teleport
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=e_5.0.0#troubleshooting"
+          href="https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=e_5.0.0#troubleshooting"
         >
           Collecting Debug Data
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=e_5.0.0#troubleshooting"
+          href="https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=e_5.0.0#troubleshooting"
         >
           Troubleshooting FAQ
         </a>
@@ -676,19 +676,19 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/quickstart?utm_source=teleport&utm_medium=oss_5.0.0"
+          href="https://gravitational.com/teleport/docs/quickstart?product=teleport&version=oss_5.0.0"
         >
           Quickstart Guide
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/user-manual?utm_source=teleport&utm_medium=oss_5.0.0"
+          href="https://gravitational.com/teleport/docs/user-manual?product=teleport&version=oss_5.0.0"
         >
           tsh User Guide
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=oss_5.0.0"
+          href="https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=oss_5.0.0"
         >
           Admin Guide
         </a>
@@ -700,7 +700,7 @@ exports[`support OSS 1`] = `
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/faq?utm_source=teleport&utm_medium=oss_5.0.0"
+          href="https://gravitational.com/teleport/docs/faq?product=teleport&version=oss_5.0.0"
         >
           FAQ
         </a>
@@ -729,19 +729,19 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=oss_5.0.0#troubleshooting"
+          href="https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=oss_5.0.0#troubleshooting"
         >
           Monitoring Teleport
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=oss_5.0.0#troubleshooting"
+          href="https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=oss_5.0.0#troubleshooting"
         >
           Collecting Debug Data
         </a>
         <a
           class="c10"
-          href="https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=oss_5.0.0#troubleshooting"
+          href="https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=oss_5.0.0#troubleshooting"
         >
           Troubleshooting FAQ
         </a>


### PR DESCRIPTION
resolves https://github.com/gravitational/webapps/issues/125

#### Description
Replace `utm_source` and `utm_medium` with `product` and `version`.

#### Comparison
Enterprise: 
  - before: "https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=e_5.0.0#troubleshooting"
  - after: "https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=e_5.0.0#troubleshooting"

OSS: 
  - before: "https://gravitational.com/teleport/docs/admin-guide?utm_source=teleport&utm_medium=oss_5.0.0#troubleshooting"
  - after: "https://gravitational.com/teleport/docs/admin-guide?product=teleport&version=oss_5.0.0#troubleshooting"