### PR TITLE
Pass hostname when creating new session

### DIFF
--- a/packages/teleport/src/cluster/components/Nodes/Nodes.tsx
+++ b/packages/teleport/src/cluster/components/Nodes/Nodes.tsx
@@ -26,6 +26,7 @@ import QuickLaunch from 'teleport/components/QuickLaunch';
 import { useTeleport } from 'teleport/teleportContextProvider';
 import NodeList from 'teleport/components/NodeList';
 import useClusterNodes from './useClusterNodes';
+import { SshNode } from 'teleport/services/nodes';
 
 export default function ClusterNodes() {
   const teleCtx = useTeleport();
@@ -43,13 +44,13 @@ export function Nodes({
     return <Cards.Failed alignSelf="baseline" message={attempt.message} />;
   }
 
-  function onLoginSelect(e: React.MouseEvent, login: string, serverId: string) {
+  function onLoginSelect(e: React.MouseEvent, node: SshNode) {
     e.preventDefault();
-    startSshSession(login, serverId);
+    startSshSession(node);
   }
 
-  function onQuickLaunchEnter(login: string, serverId: string) {
-    startSshSession(login, serverId);
+  function onQuickLaunchEnter(node: SshNode) {
+    startSshSession(node);
   }
 
   return (

--- a/packages/teleport/src/cluster/components/Nodes/useClusterNodes.ts
+++ b/packages/teleport/src/cluster/components/Nodes/useClusterNodes.ts
@@ -19,7 +19,7 @@ import { useAttempt } from 'shared/hooks';
 import { useStore } from 'shared/libs/stores';
 import TeleportContext from 'teleport/teleportContext';
 import cfg from 'teleport/config';
-import { Node } from 'teleport/services/nodes';
+import { Node, SshNode } from 'teleport/services/nodes';
 
 export default function useClusterNodes(teleCtx: TeleportContext) {
   const storeUser = useStore(teleCtx.storeUser);
@@ -47,11 +47,8 @@ export default function useClusterNodes(teleCtx: TeleportContext) {
     document.body.removeChild(element);
   };
 
-  const startSshSession = (login: string, serverId: string) => {
-    const url = cfg.getSshConnectRoute({
-      serverId,
-      login,
-    });
+  const startSshSession = (node: SshNode) => {
+    const url = cfg.getSshConnectRoute(node);
 
     openNewTab(url);
   };

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -28,7 +28,7 @@ import {
 } from 'design/DataTable';
 import Table from 'design/DataTable/Paged';
 import MenuSshLogin, { LoginItem } from 'shared/components/MenuSshLogin';
-import { Node } from 'teleport/services/nodes';
+import { Node, SshNode } from 'teleport/services/nodes';
 import InputSearch from 'teleport/components/InputSearch';
 
 function NodeList(props: Props) {
@@ -123,13 +123,9 @@ function searchAndFilterCb(
   }
 }
 
-const LoginCell: React.FC<Required<{
-  onSelect?: (e: React.SyntheticEvent, login: string, serverId: string) => void;
-  onOpen: (serverId: string) => LoginItem[];
-  [key: string]: any;
-}>> = props => {
+const LoginCell = (props: LoginCellProps) => {
   const { rowIndex, data, onOpen, onSelect } = props;
-  const { id } = data[rowIndex] as Node;
+  const { id, hostname } = data[rowIndex] as Node;
   const serverId = id;
   function handleOnOpen() {
     return onOpen(serverId);
@@ -140,7 +136,7 @@ const LoginCell: React.FC<Required<{
       return [];
     }
 
-    return onSelect(e, login, serverId);
+    return onSelect(e, { login, serverId, hostname });
   }
 
   return (
@@ -197,12 +193,14 @@ const StyledTable = styled(Table)`
 type Props = {
   nodes: Node[];
   onLoginMenuOpen: (serverId: string) => { login: string; url: string }[];
-  onLoginSelect: (
-    e: React.SyntheticEvent,
-    login: string,
-    serverId: string
-  ) => void;
+  onLoginSelect: (e: React.SyntheticEvent, node: SshNode) => void;
   pageSize?: number;
+};
+
+type LoginCellProps = {
+  onSelect?: (e: React.SyntheticEvent, node: SshNode) => void;
+  onOpen: (serverId: string) => LoginItem[];
+  [key: string]: any;
 };
 
 export default NodeList;

--- a/packages/teleport/src/components/QuickLaunch/QuickLaunch.jsx
+++ b/packages/teleport/src/components/QuickLaunch/QuickLaunch.jsx
@@ -34,8 +34,8 @@ export default function FieldInputSsh({
       const match = check(value);
       setHasError(!match);
       if (match) {
-        const { username, host } = match.groups;
-        onPress(username, host);
+        const { login, serverId } = match.groups;
+        onPress({ login, serverId });
       }
     } else {
       setHasError(false);
@@ -65,7 +65,7 @@ export default function FieldInputSsh({
 
 // Checks for spaces between chars, and
 // captures two named groups: username and host.
-const SSH_STR_REGEX = /^(?:(?<username>[^\s]+)@)(?<host>[^\s]+)$/;
+const SSH_STR_REGEX = /^(?:(?<login>[^\s]+)@)(?<serverId>[^\s]+)$/;
 const check = value => {
   return SSH_STR_REGEX.exec(value.trim());
 };

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -50,7 +50,8 @@ const cfg = {
     clusterSessions: '/web/cluster/:clusterId/sessions',
     console: '/web/cluster/:clusterId/console',
     consoleNodes: '/web/cluster/:clusterId/console/nodes',
-    consoleConnect: '/web/cluster/:clusterId/console/node/:serverId/:login',
+    consoleConnect:
+      '/web/cluster/:clusterId/console/node/:serverId/:login/:hostname?',
     consoleSession: '/web/cluster/:clusterId/console/session/:sid',
     player: '/web/cluster/:clusterId/session/:sid',
     sessionAuditPlayer: '/web/cluster/:clusterId/session/:sid/player',
@@ -84,9 +85,7 @@ const cfg = {
     u2fChangePassChallengePath: '/v1/webapi/u2f/password/changerequest',
     u2fSessionPath: '/v1/webapi/u2f/sessions',
     nodesPath: '/v1/webapi/sites/:clusterId/nodes',
-    siteSessionPath: '/v1/webapi/sites/:siteId/sessions',
     sessionEventsPath: '/v1/webapi/sites/:siteId/sessions/:sid/events',
-    siteEventSessionFilterPath: `/v1/webapi/sites/:siteId/sessions`,
     siteEventsFilterPath: `/v1/webapi/sites/:siteId/events?event=session.start&event=session.end&from=:start&to=:end`,
     ttyWsAddr:
       'wss://:fqdm/v1/webapi/sites/:clusterId/connect?access_token=:token&params=:params',
@@ -153,16 +152,17 @@ const cfg = {
     });
   },
 
-  getSshConnectRoute({ clusterId, login, serverId }: UrlParams) {
+  getSshConnectRoute({ clusterId, login, serverId, hostname }: UrlSshParams) {
     clusterId = clusterId || cfg.clusterName;
     return generatePath(cfg.routes.consoleConnect, {
       clusterId,
       serverId,
       login,
+      hostname,
     });
   },
 
-  getSshSessionRoute({ clusterId, sid }: UrlParams) {
+  getSshSessionRoute({ clusterId, sid }: UrlSshParams) {
     clusterId = clusterId || cfg.clusterName;
     return generatePath(cfg.routes.consoleSession, { clusterId, sid });
   },
@@ -181,17 +181,17 @@ const cfg = {
     return generatePath(cfg.routes.console, { clusterId });
   },
 
-  getPlayerRoute({ clusterId, sid }: UrlParams) {
+  getPlayerRoute({ clusterId, sid }: UrlSshParams) {
     clusterId = clusterId || cfg.clusterName;
     return generatePath(cfg.routes.player, { clusterId, sid });
   },
 
-  getSessionAuditPlayerRoute({ clusterId, sid }: UrlParams) {
+  getSessionAuditPlayerRoute({ clusterId, sid }: UrlSshParams) {
     clusterId = clusterId || cfg.clusterName;
     return generatePath(cfg.routes.sessionAuditPlayer, { clusterId, sid });
   },
 
-  getSessionAuditCmdsRoute({ clusterId, sid }: UrlParams) {
+  getSessionAuditCmdsRoute({ clusterId, sid }: UrlSshParams) {
     clusterId = clusterId || cfg.clusterName;
     return generatePath(cfg.routes.sessionAuditCmds, { clusterId, sid });
   },
@@ -201,7 +201,7 @@ const cfg = {
     return generatePath(cfg.api.userContextPath, { clusterId });
   },
 
-  getTerminalSessionUrl({ clusterId, sid }: UrlParams) {
+  getTerminalSessionUrl({ clusterId, sid }: UrlSshParams) {
     clusterId = clusterId || cfg.clusterName;
     return generatePath(cfg.api.terminalSessionPath, { clusterId, sid });
   },
@@ -230,13 +230,6 @@ const cfg = {
   },
 };
 
-export interface UrlParams {
-  sid?: string;
-  clusterId?: string;
-  login?: string;
-  serverId?: string;
-}
-
 export interface UrlScpParams {
   clusterId: string;
   serverId: string;
@@ -250,6 +243,7 @@ export interface UrlSshParams {
   serverId?: string;
   sid?: string;
   clusterId?: string;
+  hostname?: string;
 }
 
 export interface UrlClusterEventsParams {

--- a/packages/teleport/src/console/components/DocumentNodes/DocumentNodes.tsx
+++ b/packages/teleport/src/console/components/DocumentNodes/DocumentNodes.tsx
@@ -25,6 +25,7 @@ import ClusterSelector from './ClusterSelector';
 import useNodes from './useNodes';
 import ThemeProvider from './ThemeProvider';
 import * as stores from 'teleport/console/stores/types';
+import { SshNode } from 'teleport/services/nodes';
 
 type Props = {
   visible: boolean;
@@ -42,21 +43,17 @@ export default function DocumentNodes(props: Props) {
   } = useNodes(doc);
   const { isProcessing, isSuccess, isFailed, message } = attempt;
 
-  function onLoginMenuSelect(
-    e: React.MouseEvent,
-    login: string,
-    serverId: string
-  ) {
+  function onLoginMenuSelect(e: React.MouseEvent, node: SshNode) {
     // allow to open a new browser tab (not the console one) when requested
     const newBrowserTabRequested = e.ctrlKey || e.metaKey;
     if (!newBrowserTabRequested) {
       e.preventDefault();
-      createSshSession(login, serverId);
+      createSshSession(node);
     }
   }
 
-  function onQuickLaunchEnter(login: string, serverId: string) {
-    createSshSession(login, serverId);
+  function onQuickLaunchEnter(node: SshNode) {
+    createSshSession(node);
   }
 
   function onLoginMenuOpen(serverId: string) {

--- a/packages/teleport/src/console/components/DocumentNodes/useNodes.ts
+++ b/packages/teleport/src/console/components/DocumentNodes/useNodes.ts
@@ -18,7 +18,7 @@ import { useEffect, useState } from 'react';
 import { useAttempt } from 'shared/hooks';
 import * as stores from './../../stores';
 import { useConsoleContext } from 'teleport/console/consoleContextProvider';
-import { Node } from 'teleport/services/nodes';
+import { Node, SshNode } from 'teleport/services/nodes';
 
 export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
   const consoleCtx = useConsoleContext();
@@ -39,11 +39,12 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
     });
   }, [clusterId]);
 
-  function createSshSession(login: string, serverId: string) {
+  function createSshSession({ login, serverId, hostname }: SshNode) {
     const url = consoleCtx.getSshDocumentUrl({
       serverId,
       login,
       clusterId,
+      hostname,
     });
     consoleCtx.gotoTab({ url });
     consoleCtx.removeDocument(id);

--- a/packages/teleport/src/console/components/DocumentSsh/useSshSession.ts
+++ b/packages/teleport/src/console/components/DocumentSsh/useSshSession.ts
@@ -25,7 +25,7 @@ import { useConsoleContext } from 'teleport/console/consoleContextProvider';
 import { DocumentSsh } from 'teleport/console/stores';
 
 export default function useSshSession(doc: DocumentSsh) {
-  const { clusterId, sid, serverId, login } = doc;
+  const { clusterId, sid, serverId, login, hostname } = doc;
   const ctx = useConsoleContext();
   const ttyRef = React.useRef<Tty>(null);
   const [session, setSession] = React.useState<Session>(null);
@@ -94,7 +94,7 @@ export default function useSshSession(doc: DocumentSsh) {
     } else {
       // create new ssh session
       ctx
-        .createSshSession(clusterId, serverId, login)
+        .createSshSession({ clusterId, serverId, login, hostname })
         .then(initTty)
         .catch(err => {
           setStatus('error');

--- a/packages/teleport/src/console/consoleContext.tsx
+++ b/packages/teleport/src/console/consoleContext.tsx
@@ -23,7 +23,7 @@ import { getAccessToken } from 'teleport/services/api';
 import Tty from 'teleport/lib/term/tty';
 import TtyAddressResolver from 'teleport/lib/term/ttyAddressResolver';
 import serviceSsh, { Session, ParticipantList } from 'teleport/services/ssh';
-import serviceNodes from 'teleport/services/nodes';
+import serviceNodes, { SshNode } from 'teleport/services/nodes';
 import serviceClusters from 'teleport/services/clusters';
 import serviceUser from 'teleport/services/user';
 
@@ -76,13 +76,14 @@ export default class ConsoleContext {
     });
   }
 
-  addSshDocument({ login, serverId, sid, clusterId }: UrlSshParams) {
+  addSshDocument({ login, serverId, sid, clusterId, hostname }: UrlSshParams) {
     const title = login && serverId ? `${login}@${serverId}` : sid;
     const url = this.getSshDocumentUrl({
       clusterId,
       login,
       serverId,
       sid,
+      hostname,
     });
 
     return this.storeDocs.add({
@@ -95,6 +96,7 @@ export default class ConsoleContext {
       sid,
       url,
       created: new Date(),
+      hostname,
     });
   }
 
@@ -165,12 +167,8 @@ export default class ConsoleContext {
     return serviceSsh.fetchSession({ clusterId, sid });
   }
 
-  createSshSession(clusterId: string, serverId: string, login: string) {
-    return serviceSsh.create({
-      serverId,
-      clusterId,
-      login,
-    });
+  createSshSession(node: SshNode) {
+    return serviceSsh.create(node);
   }
 
   logout() {

--- a/packages/teleport/src/console/stores/types.ts
+++ b/packages/teleport/src/console/stores/types.ts
@@ -32,9 +32,10 @@ export interface DocumentBlank extends DocumentBase {
 export interface DocumentSsh extends DocumentBase {
   status: 'connected' | 'disconnected';
   kind: 'terminal';
-  sid?: string;
   serverId: string;
   login: string;
+  sid?: string;
+  hostname?: string;
 }
 
 export interface DocumentNodes extends DocumentBase {

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -27,3 +27,13 @@ export interface Node {
   addr: string;
   tunnel: boolean;
 }
+
+/**
+ * SshNode contains fields that are used to connect to a node.
+ */
+export interface SshNode {
+  login: string;
+  serverId: string;
+  hostname?: string;
+  clusterId?: string;
+}

--- a/packages/teleport/src/services/ssh/ssh.ts
+++ b/packages/teleport/src/services/ssh/ssh.ts
@@ -19,12 +19,16 @@ import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import makeSession, { makeParticipant } from './makeSession';
 import { ParticipantList } from './types';
+import { SshNode } from 'teleport/services/nodes';
 
 const service = {
-  create({ serverId, clusterId, login }: CreateParams) {
+  create({ serverId, clusterId, login, hostname }: SshNode) {
     const request = {
       session: {
         login,
+        server_hostname: hostname,
+        server_id: serverId,
+        cluster_name: clusterId,
       },
     };
 
@@ -34,9 +38,7 @@ const service = {
         const session = makeSession(response.session);
         return {
           ...session,
-          hostname: serverId,
-          serverId,
-          clusterId,
+          hostname: hostname ? hostname : serverId,
         };
       });
   },
@@ -75,14 +77,7 @@ const service = {
     });
   },
 };
-
 export default service;
-
-type CreateParams = {
-  serverId: string;
-  clusterId: string;
-  login: string;
-};
 
 type FetchSessionParams = {
   sid: string;


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/4143

#### Description
When creating new session, set the hostname, so that the dummy session returned contains the hostname
- refactored how we pass around data related to c/n to a node
- removed unused api routes
- manually tested