### PR TITLE
Set server/cluster ID for new session requests

### DIFF
--- a/packages/teleport/src/services/ssh/ssh.ts
+++ b/packages/teleport/src/services/ssh/ssh.ts
@@ -25,6 +25,8 @@ const service = {
     const request = {
       session: {
         login,
+        cluster_name: clusterId,
+        server_id: serverId,
       },
     };
 
@@ -32,11 +34,14 @@ const service = {
       .post(cfg.getTerminalSessionUrl({ clusterId }), request)
       .then(response => {
         const session = makeSession(response.session);
+
+        // Fallback is needed to prevent blank hostname in tab title.
+        // Proxies <4.4 will not return a hostname.
+        const hostname = session.hostname ? session.hostname : serverId;
+
         return {
           ...session,
-          hostname: serverId,
-          serverId,
-          clusterId,
+          hostname,
         };
       });
   },


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/4143

#### Description
Display hostname instead of nodes UUID (which is less readable and relatable)
- Include serverID and clusterID when making request for a new session
- serverID is required to look up nodes to get its hostname
- include serverId as fallback for hostname to prevent hostname part of tab title to be blank b/c proxy <4.4 returns empty hostname 

#### Related PR
https://github.com/gravitational/teleport/pull/4239

#### Manual testing
First time connecting through UUID and hostname:
![Screenshot from 2020-08-20 13-55-04](https://user-images.githubusercontent.com/43280172/90824800-cf854b80-e2ec-11ea-8d61-246ecc907df8.png)

First time connecting through ip address:
![Screenshot from 2020-08-20 13-58-34](https://user-images.githubusercontent.com/43280172/90825097-4c182a00-e2ed-11ea-8873-f2f73a263c8e.png)

