### PR TITLE
Remove unnecessary css

### DIFF
--- a/packages/teleport/src/console/components/DocumentSsh/ActionBar/ActionBar.jsx
+++ b/packages/teleport/src/console/components/DocumentSsh/ActionBar/ActionBar.jsx
@@ -27,7 +27,7 @@ export default function ActionBar({
 }) {
   const isScpDisabled = isDownloadOpen || isUploadOpen || !isConnected;
   return (
-    <Flex alignItems="center">
+    <Flex flex="none" alignItems="center" height="24px">
       <ButtonIcon
         disabled={isScpDisabled}
         size={0}

--- a/packages/teleport/src/console/components/DocumentSsh/ActionBar/ActionBar.jsx
+++ b/packages/teleport/src/console/components/DocumentSsh/ActionBar/ActionBar.jsx
@@ -27,7 +27,7 @@ export default function ActionBar({
 }) {
   const isScpDisabled = isDownloadOpen || isUploadOpen || !isConnected;
   return (
-    <Flex flex="0 0" alignItems="center" height="32px">
+    <Flex alignItems="center">
       <ButtonIcon
         disabled={isScpDisabled}
         size={0}


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/4235

#### Description
- `flex: 0 0` was canceling `height: 32px`, so the height never mattered here (regardless of browser), so removed both
- `flex: 0 0` the third value is flex-basis which is set to 0. In safari this makes the ActionBar fall/collapse behind the xterm container.

I think this is what we wanted to achieve: https://css-tricks.com/almanac/properties/f/flex/#flex-none
But it isn't necessary b/c the icons sizes are fixed.

#### Testing
manually tested the icons showed in safari/firefox/chrome in mac/linux