### PR TITLE
Remove checking for keywords for close event

### DIFF
--- a/packages/teleport/src/console/components/DocumentSsh/useSshSession.ts
+++ b/packages/teleport/src/console/components/DocumentSsh/useSshSession.ts
@@ -37,34 +37,8 @@ export default function useSshSession(doc: DocumentSsh) {
     function initTty(session: Session) {
       const tty = ctx.createTty(session);
 
-      /**
-       * DELETE: Remove once remote process exit errors are handled in the backend:
-       * https://github.com/gravitational/teleport/issues/4025
-       *
-       * Currently Teleport does not handle all errors that can occur during SSH session creation.
-       * It can mistakenly create a session (recording) and write SSH initialization errors
-       * directly into the stream as if these errors happened within an actual SSH session. It then
-       * proceeds with emitting the rest of audit events as if SSH session successfully started and
-       * ended even though it never did.
-       *
-       * Since we are closing the tab automatically on "end" event, there is no way a user can see
-       * an actual error why SSH session failed to start.
-       *
-       * In here we are trying to detect this scenario by looking at the last received payload before
-       * closing the terminal tab. If it's empty or it has special "keywords" in it then do not close the
-       * tab automatically on "close" event and let a user see the error.
-       */
-      let latest = '';
-      tty.on(TermEventEnum.DATA, data => {
-        latest = data;
-      });
-
       // subscribe to tty events to handle connect/disconnects events
-      tty.on(TermEventEnum.CLOSE, () => {
-        if (latest && latest.indexOf('Failed to launch') === -1) {
-          ctx.closeTab(doc);
-        }
-      });
+      tty.on(TermEventEnum.CLOSE, () => ctx.closeTab(doc));
 
       tty.on(TermEventEnum.CONN_CLOSE, () =>
         ctx.updateSshDocument(doc.id, { status: 'disconnected' })


### PR DESCRIPTION
resolves https://github.com/gravitational/webapps/issues/133

#### Description
Removed checking for error keywords for close events.

#### Manual test
Tested the error path that handles this error after removal:
![Screenshot from 2020-09-02 11-05-14](https://user-images.githubusercontent.com/43280172/92019908-343c9f00-ed0c-11ea-87b2-bcfc71ed1957.png)
