### PR TITLE
Remove gh from web-apps Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM node:12-slim
-RUN apt-get update && apt-get install curl git -y
-RUN curl -Lso /tmp/gh.deb https://github.com/cli/cli/releases/download/v0.12.0/gh_0.12.0_linux_amd64.deb && \
-    dpkg -i /tmp/gh.deb && \
-    rm -f /tmp/gh.deb
+RUN apt-get update && apt-get install git -y
 
 RUN mkdir -p web-apps
 COPY yarn.lock web-apps/


### PR DESCRIPTION
We're running gh directly on the host now that https://github.com/gravitational/ops/pull/171 has been merged, so there's no need to install it inside the Docker image.