### PR TITLE
use publicAddr and clusterName URL parameters to launch apps.

### DIFF
--- a/packages/teleport/src/AppLauncher/useAppLauncher.ts
+++ b/packages/teleport/src/AppLauncher/useAppLauncher.ts
@@ -18,18 +18,21 @@ import React from 'react';
 import { useParams } from 'react-router';
 import service from 'teleport/services/apps';
 import useAttempt from 'shared/hooks/useAttemptNext';
+import { UrlLauncherParams } from 'teleport/config';
 
 export default function useAppLauncher() {
-  const params = useParams<{ fqdn: string }>();
+  const params = useParams<UrlLauncherParams>();
   const { attempt, setAttempt } = useAttempt('processing');
 
   React.useEffect(() => {
     service
-      .createAppSession(params.fqdn)
-      .then(cookieValue => {
-        // make a page redirect to the requested app domain
+      .createAppSession(params)
+      .then(result => {
+        // make a redirect to the requested app auth endpoint
+        const location = window.location;
+        const port = location.port ? ':' + location.port : '';
         window.location.replace(
-          `https://${params.fqdn}/x-teleport-auth#value=${cookieValue}`
+          `https://${result.fqdn}${port}/x-teleport-auth#value=${result.value}`
         );
       })
       .catch((err: Error) => {

--- a/packages/teleport/src/Apps/Apps.story.tsx
+++ b/packages/teleport/src/Apps/Apps.story.tsx
@@ -19,6 +19,8 @@ import DefaultApps from './Apps';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router';
 import makeAcl from 'teleport/services/user/makeAcl';
+import makeApp from 'teleport/services/apps/makeApps';
+
 import TeleportContext, {
   ReactContextProvider,
 } from 'teleport/teleportContext';
@@ -32,7 +34,7 @@ export const Loaded = () => {
   const acl = makeAcl(sample.acl);
 
   ctx.storeUser.setState({ acl });
-  ctx.appService.fetchApps = () => Promise.resolve(sample.apps);
+  ctx.appService.fetchApps = () => Promise.resolve(sample.apps.map(makeApp));
   return render(ctx);
 };
 
@@ -91,24 +93,20 @@ const sample = {
   },
   apps: [
     {
-      id: '61',
       name: 'jenkins',
-      uri: '/internal/',
-      publicAddr: 'jenkins.one',
+      uri: '',
+      publicAddr: 'jenkins',
+      labels: [],
       clusterId: 'one',
       fqdn: 'jenkins.one',
-      launchUrl: '/web/launch/one',
-      labels: [],
     },
     {
-      id: '191',
       name: 'jenkins',
-      uri: '/internal/',
-      publicAddr: 'jenkins.two',
+      uri: '',
+      publicAddr: 'jenkins',
+      labels: [],
       clusterId: 'two',
       fqdn: 'jenkins.two',
-      launchUrl: '/web/launch/two',
-      labels: [],
     },
   ],
 };

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -517,7 +517,7 @@ exports[`loaded state 1`] = `
         <a
           class="c10"
           color="text.primary"
-          href="/web/launch/one"
+          href="/web/launch/jenkins.one/one/jenkins"
           style="text-decoration: none;"
           tabindex="-1"
           target="_blank"
@@ -565,7 +565,7 @@ exports[`loaded state 1`] = `
         <a
           class="c10"
           color="text.primary"
-          href="/web/launch/two"
+          href="/web/launch/jenkins.two/two/jenkins"
           style="text-decoration: none;"
           tabindex="-1"
           target="_blank"

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -39,7 +39,7 @@ const cfg = {
   routes: {
     root: '/web',
     apps: '/web/cluster/:clusterId/apps',
-    appLauncher: '/web/launch/:fqdn',
+    appLauncher: '/web/launch/:fqdn/:clusterId?/:publicAddr?',
     support: '/web/support',
     settings: '/web/settings',
     account: '/web/account',
@@ -185,8 +185,8 @@ const cfg = {
     return generatePath(cfg.routes.console, { clusterId });
   },
 
-  getAppLauncherRoute(fqdn: string) {
-    return generatePath(cfg.routes.appLauncher, { fqdn });
+  getAppLauncherRoute(params: UrlLauncherParams) {
+    return generatePath(cfg.routes.appLauncher, { ...params });
   },
 
   getPlayerRoute({ clusterId, sid }: UrlParams) {
@@ -282,6 +282,12 @@ export interface UrlClusterEventsParams {
   start: string;
   end: string;
   limit?: number;
+}
+
+export interface UrlLauncherParams {
+  fqdn: string;
+  clusterId?: string;
+  publicAddr?: string;
 }
 
 export default cfg;

--- a/packages/teleport/src/features.ts
+++ b/packages/teleport/src/features.ts
@@ -330,10 +330,6 @@ export class FeatureApps {
   };
 
   register(ctx: Ctx) {
-    if (!ctx.isApplicationsEnabled()) {
-      return;
-    }
-
     ctx.storeNav.addSideItem({
       title: 'Applications',
       Icon: Icons.NewTab,

--- a/packages/teleport/src/services/apps/apps.ts
+++ b/packages/teleport/src/services/apps/apps.ts
@@ -17,22 +17,34 @@
 import { map } from 'lodash';
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
-import makeApps from './makeApps';
+import makeApp from './makeApps';
 
 const service = {
   fetchApps(clusterId: string) {
     return api
       .get(cfg.getApplicationsUrl(clusterId))
-      .then(json => map(json.items, makeApps));
+      .then(json => map(json.items, makeApp));
   },
 
-  createAppSession(fqdn: string) {
+  createAppSession(params: CreateAppSessionParams) {
+    const { fqdn, clusterId = '', publicAddr = '' } = params;
     return api
       .post(cfg.api.aapSession, {
         fqdn,
+        cluster_name: clusterId,
+        public_addr: publicAddr,
       })
-      .then(json => json.value as string);
+      .then(json => ({
+        fqdn: json.fqdn as string,
+        value: json.value as string,
+      }));
   },
 };
 
 export default service;
+
+type CreateAppSessionParams = {
+  fqdn: string;
+  clusterId?: string;
+  publicAddr?: string;
+};

--- a/packages/teleport/src/services/apps/makeApps.ts
+++ b/packages/teleport/src/services/apps/makeApps.ts
@@ -18,7 +18,7 @@ import { at } from 'lodash';
 import { App } from './types';
 import cfg from 'teleport/config';
 
-export default function makeApps(json): App {
+export default function makeApp(json): App {
   const [name, uri, publicAddr, labels, clusterId, fqdn] = at(json, [
     'name',
     'uri',
@@ -29,6 +29,7 @@ export default function makeApps(json): App {
   ]);
 
   const id = `${clusterId}-${name}-${publicAddr}`;
+  const launchUrl = cfg.getAppLauncherRoute({ fqdn, clusterId, publicAddr });
 
   return {
     id,
@@ -38,6 +39,6 @@ export default function makeApps(json): App {
     labels,
     clusterId,
     fqdn,
-    launchUrl: cfg.getAppLauncherRoute(fqdn),
+    launchUrl,
   };
 }

--- a/packages/teleport/src/services/user/makeAcl.ts
+++ b/packages/teleport/src/services/user/makeAcl.ts
@@ -26,7 +26,7 @@ export default function makeAcl(json): Acl {
   const sessions = makeAccess(json.sessions);
   const events = makeAccess(json.events);
   const users = makeAccess(json.users);
-  const apps = makeAccess(json.access);
+  const apps = makeAccess(json.appServers);
 
   return {
     logins,


### PR DESCRIPTION
This PR implements additional requirements for AAP 

1. When redirecting to AppLauncher, provide PublicAddr and ClusterName parameters (if available) 
