### PR TITLE
Css

### DIFF
--- a/packages/design/src/DataTable/StyledTable.jsx
+++ b/packages/design/src/DataTable/StyledTable.jsx
@@ -77,7 +77,19 @@ export const StyledTable = styled.table(
 
   tbody tr:hover {
     background-color: ${darken(props.theme.colors.primary.lighter, 0.14)};
-  }`,
+
+    :last-child {
+      td:first-child {
+        border-bottom-left-radius: 8px;
+      }
+      
+      td:last-child {
+        border-bottom-right-radius: 8px;
+      }
+    }
+  }
+
+  `,
   space,
   borderRadius
 );

--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -273,6 +273,14 @@ exports[`loaded 1`] = `
   background-color: rgb(37,49,98);
 }
 
+.c12 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c12 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
 .c10 {
   box-sizing: border-box;
   display: flex;
@@ -1956,6 +1964,14 @@ exports[`overflow 1`] = `
 
 .c13 tbody tr:hover {
   background-color: rgb(37,49,98);
+}
+
+.c13 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c13 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
 }
 
 .c11 {

--- a/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -215,6 +215,14 @@ exports[`render clusters 1`] = `
   background-color: rgb(37,49,98);
 }
 
+.c10 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c10 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
 .c7 {
   box-sizing: border-box;
   display: flex;

--- a/packages/teleport/src/Console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/Console/components/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -216,6 +216,14 @@ exports[`render DocumentNodes 1`] = `
   background-color: rgb(7,40,70);
 }
 
+.c18 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c18 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
 .c15 {
   box-sizing: border-box;
   display: flex;

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -617,6 +617,14 @@ exports[`loaded 1`] = `
   background-color: rgb(37,49,98);
 }
 
+.c14 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c14 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
 .c11 {
   box-sizing: border-box;
   display: flex;

--- a/packages/teleport/src/Recordings/__snapshots__/Recordings.story.test.tsx.snap
+++ b/packages/teleport/src/Recordings/__snapshots__/Recordings.story.test.tsx.snap
@@ -260,6 +260,14 @@ exports[`rendering of Session Recordings 1`] = `
   background-color: rgb(37,49,98);
 }
 
+.c12 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c12 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
 .c10 {
   box-sizing: border-box;
   display: flex;
@@ -812,6 +820,14 @@ exports[`rendering of Session Recordings 2`] = `
 
 .c12 tbody tr:hover {
   background-color: rgb(37,49,98);
+}
+
+.c12 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c12 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
 }
 
 .c10 {

--- a/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -201,6 +201,14 @@ exports[`loaded 1`] = `
   background-color: rgb(37,49,98);
 }
 
+.c9 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c9 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
 .c6 {
   box-sizing: border-box;
   display: flex;

--- a/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
+++ b/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
@@ -152,6 +152,7 @@ const Empty = (props: EmptyProps) => {
       py={4}
       as={Flex}
       alignItems="center"
+      flex="0 0 auto"
     >
       <Box mx="4">
         <Image width="180px" src={emptyPng} />

--- a/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -262,6 +262,14 @@ exports[`success state 1`] = `
   background-color: rgb(37,49,98);
 }
 
+.c11 tbody tr:hover:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c11 tbody tr:hover:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
 .c8 {
   box-sizing: border-box;
   display: flex;


### PR DESCRIPTION
#### Description
- On hover last row of table, round out bottom corners
- In safari empty trusted cluster view, prevent shrinking of box that contains content when screen height is smaller than content