### PR TITLE
Disable AddServer and AddApp buttons on leaf clusters

### DIFF
--- a/packages/teleport/src/Apps/Apps.tsx
+++ b/packages/teleport/src/Apps/Apps.tsx
@@ -36,6 +36,7 @@ export default function Container() {
 export function Apps(props: State) {
   const {
     clusterId,
+    isLeafCluster,
     isEnterprise,
     isAddAppVisible,
     showAddApp,
@@ -53,6 +54,7 @@ export function Apps(props: State) {
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Applications</FeatureHeaderTitle>
         <ButtonAdd
+          isLeafCluster={isLeafCluster}
           isEnterprise={isEnterprise}
           canCreate={canCreate}
           onClick={showAddApp}
@@ -67,8 +69,9 @@ export function Apps(props: State) {
       {hasApps && <AppList apps={apps} />}
       {isEmpty && (
         <Empty
-          clusterId={clusterId}
+          isLeafCluster={isLeafCluster}
           isEnterprise={isEnterprise}
+          clusterId={clusterId}
           canCreate={canCreate}
           onCreate={showAddApp}
         />

--- a/packages/teleport/src/Apps/ButtonAdd.tsx
+++ b/packages/teleport/src/Apps/ButtonAdd.tsx
@@ -20,10 +20,12 @@ import { ButtonPrimary } from 'design';
 const docUrl = 'https://gravitational.com/teleport/docs/';
 
 export default function ButtonAdd(props: Props) {
-  if (!props.isEnterprise) {
+  const { isEnterprise, isLeafCluster, ...rest } = props;
+
+  if (!isEnterprise) {
     return (
       <ButtonPrimary
-        {...props}
+        {...rest}
         width="240px"
         onClick={() => null}
         as="a"
@@ -36,8 +38,17 @@ export default function ButtonAdd(props: Props) {
   }
 
   if (props.canCreate) {
+    const title = isLeafCluster
+      ? 'Adding an application to the leaf cluster is not supported'
+      : 'Add an application to the root cluster';
+
     return (
-      <ButtonPrimary width="240px" {...props}>
+      <ButtonPrimary
+        title={title}
+        disabled={isLeafCluster}
+        width="240px"
+        {...rest}
+      >
         Add Application
       </ButtonPrimary>
     );
@@ -47,6 +58,7 @@ export default function ButtonAdd(props: Props) {
 }
 
 type Props = {
+  isLeafCluster: boolean;
   isEnterprise: boolean;
   canCreate: boolean;
   onClick?: () => void;

--- a/packages/teleport/src/Apps/ButtonAdd.tsx
+++ b/packages/teleport/src/Apps/ButtonAdd.tsx
@@ -39,7 +39,7 @@ export default function ButtonAdd(props: Props) {
 
   if (props.canCreate) {
     const title = isLeafCluster
-      ? 'Adding an application to the leaf cluster is not supported'
+      ? 'Adding an application to a leaf cluster is not supported'
       : 'Add an application to the root cluster';
 
     return (

--- a/packages/teleport/src/Apps/Empty/Empty.tsx
+++ b/packages/teleport/src/Apps/Empty/Empty.tsx
@@ -22,8 +22,10 @@ import ButtonAdd from './../ButtonAdd';
 import { emptyPng } from './assets';
 
 export default function Empty(props: Props) {
+  const { isLeafCluster, isEnterprise, canCreate, onCreate, ...rest } = props;
+
   // always show the welcome for enterprise users who have access to create an app
-  if (!props.canCreate) {
+  if (isLeafCluster || !canCreate) {
     return (
       <Box
         p="8"
@@ -34,7 +36,7 @@ export default function Empty(props: Props) {
         color="text.primary"
         bg="primary.light"
         borderRadius="12px"
-        {...props}
+        {...rest}
       >
         <Text typography="h2" mb="3">
           No Applications Found
@@ -67,9 +69,10 @@ export default function Empty(props: Props) {
           </Text>
         </Box>
         <ButtonAdd
-          isEnterprise={props.isEnterprise}
-          canCreate={props.canCreate}
-          onClick={props.onCreate}
+          isLeafCluster={isLeafCluster}
+          isEnterprise={isEnterprise}
+          canCreate={canCreate}
+          onClick={onCreate}
           mb="2"
           mx="auto"
           width="240px"
@@ -81,6 +84,7 @@ export default function Empty(props: Props) {
 }
 
 export type Props = {
+  isLeafCluster: boolean;
   isEnterprise: boolean;
   canCreate: boolean;
   onCreate(): void;

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -213,6 +213,7 @@ exports[`empty state 1`] = `
       <button
         class="c3"
         kind="primary"
+        title="Add an application to the root cluster"
         width="240px"
       >
         Add Application
@@ -250,6 +251,7 @@ exports[`empty state 1`] = `
         <button
           class="c12"
           kind="primary"
+          title="Add an application to the root cluster"
           width="240px"
         >
           Add Application
@@ -471,6 +473,7 @@ exports[`loaded state 1`] = `
       <button
         class="c3"
         kind="primary"
+        title="Add an application to the root cluster"
         width="240px"
       >
         Add Application

--- a/packages/teleport/src/Apps/useApps.ts
+++ b/packages/teleport/src/Apps/useApps.ts
@@ -24,7 +24,7 @@ export default function useApps() {
   const ctx = useTeleport();
   const canCreate = ctx.storeUser.getTokenAccess().create;
   const [isAddAppVisible, setAppAddVisible] = useState(false);
-  const { clusterId } = useStickyClusterId();
+  const { clusterId, isLeafCluster } = useStickyClusterId();
   const { attempt, setAttempt, run } = useAttempt('processing');
   const [apps, setApps] = useState([] as App[]);
   const isEnterprise = ctx.isEnterprise;
@@ -53,6 +53,7 @@ export default function useApps() {
 
   return {
     clusterId,
+    isLeafCluster,
     isEnterprise,
     isAddAppVisible,
     hideAddApp,

--- a/packages/teleport/src/Nodes/ButtonAdd.tsx
+++ b/packages/teleport/src/Nodes/ButtonAdd.tsx
@@ -21,10 +21,12 @@ const docUrl =
   'https://gravitational.com/teleport/docs/admin-guide/#adding-nodes-to-the-cluster';
 
 export default function ButtonAdd(props: Props) {
-  if (!props.isEnterprise) {
+  const { isEnterprise, canCreate, isLeafCluster, ...rest } = props;
+
+  if (!isEnterprise) {
     return (
       <ButtonPrimary
-        {...props}
+        {...rest}
         width="240px"
         onClick={() => null}
         as="a"
@@ -36,9 +38,18 @@ export default function ButtonAdd(props: Props) {
     );
   }
 
-  if (props.canCreate) {
+  if (canCreate) {
+    const title = isLeafCluster
+      ? 'Adding a server to the leaf cluster is not supported'
+      : 'Add a server to the root cluster';
+
     return (
-      <ButtonPrimary width="240px" {...props}>
+      <ButtonPrimary
+        title={title}
+        disabled={isLeafCluster}
+        width="240px"
+        {...props}
+      >
         Add Server
       </ButtonPrimary>
     );
@@ -48,6 +59,7 @@ export default function ButtonAdd(props: Props) {
 }
 
 type Props = {
+  isLeafCluster: boolean;
   isEnterprise: boolean;
   canCreate: boolean;
   onClick?: () => void;

--- a/packages/teleport/src/Nodes/ButtonAdd.tsx
+++ b/packages/teleport/src/Nodes/ButtonAdd.tsx
@@ -40,7 +40,7 @@ export default function ButtonAdd(props: Props) {
 
   if (canCreate) {
     const title = isLeafCluster
-      ? 'Adding a server to the leaf cluster is not supported'
+      ? 'Adding a server to a leaf cluster is not supported'
       : 'Add a server to the root cluster';
 
     return (

--- a/packages/teleport/src/Nodes/Nodes.story.tsx
+++ b/packages/teleport/src/Nodes/Nodes.story.tsx
@@ -45,6 +45,7 @@ function render(
   nodeList = nodes
 ) {
   const props = {
+    isLeafCluster: false,
     isEnterprise: true,
     canCreate: true,
     searchValue: '',

--- a/packages/teleport/src/Nodes/Nodes.tsx
+++ b/packages/teleport/src/Nodes/Nodes.tsx
@@ -33,8 +33,8 @@ import ButtonAdd from './ButtonAdd';
 
 export default function Container() {
   const teleCtx = useTeleport();
-  const { clusterId } = useStickyClusterId();
-  const state = useNodes(teleCtx, clusterId);
+  const stickyCluster = useStickyClusterId();
+  const state = useNodes(teleCtx, stickyCluster);
   return <Nodes {...state} />;
 }
 
@@ -49,6 +49,7 @@ export function Nodes(props: State) {
     showAddNode,
     canCreate,
     hideAddNode,
+    isLeafCluster,
     isAddNodeVisible,
     isEnterprise,
   } = props;
@@ -67,6 +68,7 @@ export function Nodes(props: State) {
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Servers</FeatureHeaderTitle>
         <ButtonAdd
+          isLeafCluster={isLeafCluster}
           isEnterprise={isEnterprise}
           canCreate={canCreate}
           onClick={showAddNode}

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -220,6 +220,7 @@ exports[`failed 1`] = `
     <button
       class="c3"
       kind="primary"
+      title="Add a server to the root cluster"
       width="240px"
     >
       Add Server
@@ -685,6 +686,7 @@ exports[`loaded 1`] = `
     <button
       class="c3"
       kind="primary"
+      title="Add a server to the root cluster"
       width="240px"
     >
       Add Server

--- a/packages/teleport/src/Nodes/useNodes.ts
+++ b/packages/teleport/src/Nodes/useNodes.ts
@@ -16,16 +16,18 @@ limitations under the License.
 
 import { useState, useEffect, useCallback } from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
-import TeleportContext from 'teleport/teleportContext';
+import Ctx from 'teleport/teleportContext';
+import { StickyCluster } from 'teleport/types';
 import cfg from 'teleport/config';
 import { Node } from 'teleport/services/nodes';
 
-export default function useNodes(ctx: TeleportContext, clusterId: string) {
-  const canCreate = ctx.storeUser.getTokenAccess().create;
+export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
+  const { isLeafCluster, clusterId } = stickyCluster;
   const [nodes, setNodes] = useState<Node[]>([]);
   const [searchValue, setSearchValue] = useState('');
   const { attempt, run, setAttempt } = useAttempt('processing');
   const [isAddNodeVisible, setIsAddNodeVisible] = useState(false);
+  const canCreate = ctx.storeUser.getTokenAccess().create;
   const logins = ctx.storeUser.getLogins();
   const isEnterprise = ctx.isEnterprise;
 
@@ -87,6 +89,7 @@ export default function useNodes(ctx: TeleportContext, clusterId: string) {
     startSshSession,
     isAddNodeVisible,
     isEnterprise,
+    isLeafCluster,
     hideAddNode,
     showAddNode,
   };

--- a/packages/teleport/src/TopBar/useTopBar.ts
+++ b/packages/teleport/src/TopBar/useTopBar.ts
@@ -18,7 +18,7 @@ import { matchPath, useHistory } from 'react-router';
 import session from 'teleport/services/session';
 import Ctx from 'teleport/teleportContext';
 import cfg from 'teleport/config';
-import { StickyCluster } from 'teleport/useStickyClusterId';
+import { StickyCluster } from 'teleport/types';
 
 export default function useTopBar(ctx: Ctx, stickyCluster: StickyCluster) {
   const history = useHistory();

--- a/packages/teleport/src/types.ts
+++ b/packages/teleport/src/types.ts
@@ -32,6 +32,12 @@ export interface Feature {
   register(ctx: Context): void;
 }
 
+export type StickyCluster = {
+  clusterId: string;
+  hasClusterUrl: boolean;
+  isLeafCluster: boolean;
+};
+
 type FeatureRoute = {
   title: string;
   path: string;

--- a/packages/teleport/src/useStickyClusterId.ts
+++ b/packages/teleport/src/useStickyClusterId.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { useRouteMatch } from 'react-router';
 import { useRef } from 'react';
+import { StickyCluster } from 'teleport/types';
 import cfg from 'teleport/config';
 
 export default function useStickyClusterId(): StickyCluster {
@@ -23,20 +24,17 @@ export default function useStickyClusterId(): StickyCluster {
   const stickyCluster = useRef({
     clusterId: cfg.proxyCluster,
     hasClusterUrl: false,
+    isLeafCluster: false,
   });
 
   const match = useRouteMatch<{ clusterId: string }>(cfg.routes.cluster);
   const clusterId = match?.params?.clusterId;
   if (clusterId) {
     stickyCluster.current.clusterId = clusterId;
+    stickyCluster.current.isLeafCluster = clusterId !== cfg.proxyCluster;
   }
 
   stickyCluster.current.hasClusterUrl = !!clusterId;
 
   return stickyCluster.current;
 }
-
-export type StickyCluster = {
-  clusterId: string;
-  hasClusterUrl: boolean;
-};


### PR DESCRIPTION
A minor change that disables create buttons on leaf clusters