### PR TITLE
Grab auth type from config

### DIFF
--- a/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
+++ b/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
@@ -53,7 +53,7 @@ export default function Manually({ user, version, onClose }: Props) {
             {' - Login to Teleport'}
             <TextSelectCopy
               mt="2"
-              text={`tsh login --proxy=${host} --auth=${cfg.auth.authType} --user=${user}`}
+              text={`tsh login --proxy=${host} --auth=${cfg.getAuthType()} --user=${user}`}
             />
           </Box>
           <Box mb={4}>

--- a/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
+++ b/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { Text, Box, ButtonSecondary, Link } from 'design';
 import { DialogContent, DialogFooter } from 'design/Dialog';
+import cfg from 'teleport/config';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import * as links from 'teleport/services/links';
 
@@ -52,7 +53,7 @@ export default function Manually({ user, version, onClose }: Props) {
             {' - Login to Teleport'}
             <TextSelectCopy
               mt="2"
-              text={`tsh login --proxy=${host} --auth=local --user=${user}`}
+              text={`tsh login --proxy=${host} --auth=${cfg.auth.authType} --user=${user}`}
             />
           </Box>
           <Box mb={4}>

--- a/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
+++ b/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
@@ -50,7 +50,7 @@ export default function Manually({ user, version, ...styles }: Props) {
         {' - Login to Teleport'}
         <TextSelectCopy
           mt="2"
-          text={`tsh login --proxy=${host} --auth=${cfg.auth.authType} --user=${user}`}
+          text={`tsh login --proxy=${host} --auth=${cfg.getAuthType()} --user=${user}`}
         />
       </Box>
       <Box mb={4}>

--- a/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
+++ b/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { Text, Box, Link } from 'design';
+import cfg from 'teleport/config';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import * as links from 'teleport/services/links';
 
@@ -49,7 +50,7 @@ export default function Manually({ user, version, ...styles }: Props) {
         {' - Login to Teleport'}
         <TextSelectCopy
           mt="2"
-          text={`tsh login --proxy=${host} --auth=local --user=${user}`}
+          text={`tsh login --proxy=${host} --auth=${cfg.auth.authType} --user=${user}`}
         />
       </Box>
       <Box mb={4}>

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -27,6 +27,7 @@ const cfg = {
     localAuthEnabled: true,
     providers: [],
     second_factor: 'off',
+    authType: 'local',
   },
 
   proxyCluster: 'localhost',

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -130,6 +130,10 @@ const cfg = {
     return cfg.auth.localAuthEnabled;
   },
 
+  getAuthType() {
+    return cfg.auth.authType;
+  },
+
   getSsoUrl(providerUrl, providerName, redirect) {
     return cfg.baseUrl + generatePath(providerUrl, { redirect, providerName });
   },


### PR DESCRIPTION
resolve https://github.com/gravitational/teleport/issues/4936

#### Description
- Add `authType` field to config
- Grab `authType` from config instead of hard coding for manual step flag `--auth`

#### Related PR
merge first https://github.com/gravitational/teleport/pull/4946

#### Screenshot
![Screenshot from 2020-11-19 17-36-34](https://user-images.githubusercontent.com/43280172/99745375-5f729700-2a8e-11eb-8b47-994d4b6501fd.png)
![Screenshot from 2020-11-19 17-25-11](https://user-images.githubusercontent.com/43280172/99745391-68636880-2a8e-11eb-8cf1-1eb5caacbf66.png)
![Screenshot from 2020-11-19 17-25-21](https://user-images.githubusercontent.com/43280172/99745394-68fbff00-2a8e-11eb-927c-16a7651ccca8.png)
