### PR TITLE
Set default role to 'admin' vs 'admins'

### DIFF
--- a/packages/teleport/src/AuthConnectors/templates/oidc.yaml
+++ b/packages/teleport/src/AuthConnectors/templates/oidc.yaml
@@ -17,4 +17,4 @@ spec:
   issuer_url: https://<issuer-url>
   scope: [<scope value>]
   claims_to_roles:
-    - {claim: "hd", value: "example.com", roles: ["admins"]}
+    - {claim: "hd", value: "example.com", roles: ["admin"]}

--- a/packages/teleport/src/AuthConnectors/templates/saml.yaml
+++ b/packages/teleport/src/AuthConnectors/templates/saml.yaml
@@ -15,7 +15,7 @@ spec:
   # cluster-url is the address the cluster UI is reachable at
   acs: https://<cluster-url>/v1/webapi/saml/acs
   attributes_to_roles:
-    - {name: "groups", value: "okta-admin", roles: ["admins"]}
+    - {name: "groups", value: "okta-admin", roles: ["admin"]}
     - {name: "groups", value: "okta-dev", roles: ["dev"]}
   # Note that the entire XML document is indented by 4 spaces. This is
   # required because the pipe symbol indicates what follows is raw text.


### PR DESCRIPTION
When we create a Teleport Cloud instance we've a default role `admin`, customers are getting stuck because the example contents points to `admins`.  

I think this should fix it? If not; let me know where to send the PR. 