### PR TITLE
Clear local storage on invite login form

### DIFF
--- a/packages/teleport/src/Invite/Invite.jsx
+++ b/packages/teleport/src/Invite/Invite.jsx
@@ -19,6 +19,7 @@ import { useParams } from 'react-router';
 import { useAttempt, withState } from 'shared/hooks';
 import cfg from 'teleport/config';
 import auth from 'teleport/services/auth';
+import session from 'teleport/services/session';
 import history from 'teleport/services/history';
 import Logger from 'shared/libs/logger';
 import InviteForm, { Expired } from 'shared/components/FormInvite';
@@ -82,9 +83,11 @@ function mapState() {
 
   React.useEffect(() => {
     fetchAttemptActions.do(() => {
-      return auth
-        .fetchPasswordToken(tokenId)
-        .then(resetToken => setPswToken(resetToken));
+      return auth.fetchPasswordToken(tokenId).then(resetToken => {
+        // Remove any previous session/request access information from local storage.
+        session.clear();
+        setPswToken(resetToken);
+      });
     });
   }, []);
 


### PR DESCRIPTION
#### Description
Clears local storage when user goes to a invite link.

If a previous user was logged in and didn't log out, it leads to a bug where if this invited user required a waiting room and the previous user required a waiting room, it will bypass the auto request creation b/c of what existed in the local storage.