### PR TITLE
Populate "Node" name in k8s session recordings

### DIFF
--- a/packages/teleport/src/Recordings/RecordList.tsx
+++ b/packages/teleport/src/Recordings/RecordList.tsx
@@ -125,6 +125,12 @@ const makeRows = (clusterId: string) => (event: SessionEnd) => {
     durationText = moment.duration(duration).humanize();
   }
 
+  let hostname = raw.server_hostname;
+  // For Kubernetes sessions, put the full pod name as 'hostname'.
+  if (raw.proto === 'kube') {
+    hostname = raw.kubernetes_cluster + '/' + raw.kubernetes_pod_namespace + '/' + raw.kubernetes_pod_name;
+  }
+
   return {
     clusterId,
     duration,
@@ -133,7 +139,7 @@ const makeRows = (clusterId: string) => (event: SessionEnd) => {
     created: time,
     createdText: displayDateTime(time),
     users: users.join(', '),
-    hostname: raw.server_hostname,
+    hostname: hostname,
   };
 };
 

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -177,6 +177,8 @@ export type RawEvents = {
       interactive: boolean;
       proto: string;
       kubernetes_cluster: string;
+      kubernetes_pod_namespace: string;
+      kubernetes_pod_name: string;
     }
   >;
   [CodeEnum.SESSION_LEAVE]: RawEvent<


### PR DESCRIPTION
![Screenshot_2021-01-04 Session Recordings](https://user-images.githubusercontent.com/1146263/103591913-5b67d080-4ea6-11eb-89e6-77c3c6e5b699.png)

Set the node to `$cluster/$namespace/$pod` instead of leaving it blank.

Updates https://github.com/gravitational/teleport/issues/5212