### PR TITLE
Change/Rename session storage to local storage

### DIFF
--- a/packages/teleport/src/components/AccessStrategy/AccessStrategy.test.tsx
+++ b/packages/teleport/src/components/AccessStrategy/AccessStrategy.test.tsx
@@ -21,13 +21,15 @@ import userService, {
   makeAccessRequest,
 } from 'teleport/services/user';
 import { render, screen, wait, fireEvent } from 'design/utils/testing';
-import sessionStorage from 'teleport/services/localStorage';
+import localStorage from 'teleport/services/localStorage';
 
 beforeEach(() => {
   jest.resetAllMocks();
-  sessionStorage.clear();
-
   jest.spyOn(console, 'error').mockImplementation();
+});
+
+afterEach(() => {
+  localStorage.clear();
 });
 
 test('stategy "optional" renders children', async () => {
@@ -117,7 +119,7 @@ test('strategy "always" renders pending dialogue, with request state empty', asy
   jest.spyOn(userService, 'fetchAccessRequest').mockResolvedValue(request);
   jest.spyOn(userService, 'fetchUser').mockResolvedValue(userContext);
 
-  expect(sessionStorage.getAccessRequestResult()).toBeNull();
+  expect(localStorage.getAccessRequestResult()).toBeNull();
 
   render(<AccessStrategy children={sample.children} checkerInterval={0} />);
   await wait(() => {
@@ -128,7 +130,7 @@ test('strategy "always" renders pending dialogue, with request state empty', asy
   // hook should auto create request before fetching request.
   expect(userService.createAccessRequest).toHaveBeenCalledTimes(1);
   expect(userService.fetchAccessRequest).toHaveBeenCalled();
-  expect(sessionStorage.getAccessRequestResult()).toStrictEqual(request);
+  expect(localStorage.getAccessRequestResult()).toStrictEqual(request);
 });
 
 test('strategy "always" renders pending dialogue, with request state PENDING', async () => {
@@ -140,8 +142,8 @@ test('strategy "always" renders pending dialogue, with request state PENDING', a
     state: 'PENDING',
     reason: '',
   });
-  sessionStorage.setAccessRequestResult(request);
-  expect(sessionStorage.getAccessRequestResult()).toStrictEqual(request);
+  localStorage.setAccessRequestResult(request);
+  expect(localStorage.getAccessRequestResult()).toStrictEqual(request);
 
   jest.spyOn(userService, 'createAccessRequest').mockResolvedValue(request);
   jest.spyOn(userService, 'fetchAccessRequest').mockResolvedValue(request);
@@ -165,8 +167,8 @@ test('strategy "always", renders pending then children, with request state APPRO
     state: 'APPROVED',
     reason: '',
   });
-  sessionStorage.setAccessRequestResult(request);
-  expect(sessionStorage.getAccessRequestResult()).toStrictEqual(request);
+  localStorage.setAccessRequestResult(request);
+  expect(localStorage.getAccessRequestResult()).toStrictEqual(request);
 
   jest.spyOn(userService, 'fetchAccessRequest').mockResolvedValue(request);
   jest.spyOn(userService, 'applyPermission').mockResolvedValue({});
@@ -182,7 +184,7 @@ test('strategy "always", renders pending then children, with request state APPRO
   );
   expect(userService.applyPermission).toHaveBeenCalledTimes(1);
   expect(window.location.reload).toHaveBeenCalledTimes(1);
-  expect(sessionStorage.getAccessRequestResult().state).toEqual('APPLIED');
+  expect(localStorage.getAccessRequestResult().state).toEqual('APPLIED');
 
   // Fetching access request happens with pending,
   // so this prooves pending dialogue was briefly rendered.
@@ -198,8 +200,8 @@ test('strategy "always", renders denied dialogue, with request state DENIED', as
     state: 'DENIED',
     reason: '',
   });
-  sessionStorage.setAccessRequestResult(request);
-  expect(sessionStorage.getAccessRequestResult()).toStrictEqual(request);
+  localStorage.setAccessRequestResult(request);
+  expect(localStorage.getAccessRequestResult()).toStrictEqual(request);
 
   jest.spyOn(userService, 'fetchUser').mockResolvedValue(userContext);
 
@@ -219,8 +221,8 @@ test('strategy "always", renders children, with request state APPLIED', async ()
     state: 'APPLIED',
     reason: '',
   });
-  sessionStorage.setAccessRequestResult(request);
-  expect(sessionStorage.getAccessRequestResult()).toStrictEqual(request);
+  localStorage.setAccessRequestResult(request);
+  expect(localStorage.getAccessRequestResult()).toStrictEqual(request);
 
   jest.spyOn(userService, 'fetchUser').mockResolvedValue(userContext);
 
@@ -240,8 +242,8 @@ test('strategy "always", on fetch request error, renders error dialogue', async 
     state: 'APPROVED',
     reason: '',
   });
-  sessionStorage.setAccessRequestResult(request);
-  expect(sessionStorage.getAccessRequestResult()).toStrictEqual(request);
+  localStorage.setAccessRequestResult(request);
+  expect(localStorage.getAccessRequestResult()).toStrictEqual(request);
 
   const err = new Error('some error');
   jest.spyOn(userService, 'fetchAccessRequest').mockRejectedValue(err);

--- a/packages/teleport/src/components/AccessStrategy/useAccessStrategy.ts
+++ b/packages/teleport/src/components/AccessStrategy/useAccessStrategy.ts
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import cfg from 'teleport/config';
-import sessionStorage from 'teleport/services/localStorage';
+import localStorage from 'teleport/services/localStorage';
 import useAttempt from 'shared/hooks/useAttempt';
 import userService, {
   AccessStrategy,
@@ -30,7 +30,7 @@ export default function useAccessStrategy() {
   const [strategy, setStrategy] = React.useState<AccessStrategy>(null);
 
   const [accessRequest, setAccessRequest] = React.useState<AccessRequest>(
-    makeAccessRequest(sessionStorage.getAccessRequestResult())
+    makeAccessRequest(localStorage.getAccessRequestResult())
   );
 
   React.useEffect(() => {
@@ -59,12 +59,12 @@ export default function useAccessStrategy() {
   }
 
   function updateState(result: AccessRequest) {
-    sessionStorage.setAccessRequestResult(result);
+    localStorage.setAccessRequestResult(result);
 
     if (result.state === 'APPROVED') {
       return userService.applyPermission(result.id).then(() => {
         result.state = 'APPLIED';
-        sessionStorage.setAccessRequestResult(result);
+        localStorage.setAccessRequestResult(result);
         window.location.reload();
       });
     }

--- a/packages/teleport/src/components/Authenticated/Authenticated.jsx
+++ b/packages/teleport/src/components/Authenticated/Authenticated.jsx
@@ -26,6 +26,7 @@ export default class Authenticated extends React.Component {
 
   componentDidMount() {
     if (!session.isValid()) {
+      session.clear();
       logger.warn('invalid session');
       const rememberLocation = true;
       history.goToLogin(rememberLocation);

--- a/packages/teleport/src/services/localStorage.js
+++ b/packages/teleport/src/services/localStorage.js
@@ -33,7 +33,6 @@ const storage = {
     storage.setAccessRequestResult(null);
     storage.setBearerToken(null);
     window.localStorage.clear();
-    window.sessionStorage.clear();
   },
 
   subscribe(fn) {
@@ -63,14 +62,14 @@ const storage = {
   },
 
   setAccessRequestResult(request) {
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       KeysEnum.ACCESS_REQUEST,
       JSON.stringify(request)
     );
   },
 
   getAccessRequestResult() {
-    const item = window.sessionStorage.getItem(KeysEnum.ACCESS_REQUEST);
+    const item = window.localStorage.getItem(KeysEnum.ACCESS_REQUEST);
     return item ? JSON.parse(item) : null;
   },
 


### PR DESCRIPTION
#### Description
Fixes the problem IBM encountered:

> We had a case with one of our teams where the plugin is being used.
> Using Firefox, when logging in via the UI, they are asked to provide a “reason” (as expected) and are able to login successfully.
> 
> However, once logged in and after selecting the desired Teleport Cluster, for any node they want to create an ssh session to, the “reason” is asked again.  
> After entering the “reason” they are able to get the session. This behaviour is only occurring in Firefox.  
> This is not something that is happening with other browsers (Chrome, Safari). 

It looks like firefox doesn't follow the same standards as google and safari stated in w3.org:

> When a new top-level browsing context is created by a script in an existing browsing context, or by the user following a link in an existing browsing context, or in some other way related to a specific Document, and the creation is not a new start for session storage, then the session storage area of the origin of that Document must be copied into the new browsing context when it is created. From that point on, however, the two session storage areas must be considered separate, not affecting each other in any way.
