### PR TITLE
Check for browser u2f support

### DIFF
--- a/packages/shared/components/FormInvite/FormInvite.tsx
+++ b/packages/shared/components/FormInvite/FormInvite.tsx
@@ -164,7 +164,7 @@ type Props = {
 
 function ErrorMessage({ message = '' }) {
   // quick fix: check if error text has U2F substring
-  const browserSupported = !message.includes('not support FIDO U2F');
+  const browserSupported = !message.includes('does not support U2F');
   const showU2fErrorLink = browserSupported && message.includes('U2F');
 
   return (

--- a/packages/shared/components/FormInvite/FormInvite.tsx
+++ b/packages/shared/components/FormInvite/FormInvite.tsx
@@ -164,7 +164,9 @@ type Props = {
 
 function ErrorMessage({ message = '' }) {
   // quick fix: check if error text has U2F substring
-  const showU2fErrorLink = message.indexOf('U2F') !== -1;
+  const browserSupported = !message.includes('not support FIDO U2F');
+  const showU2fErrorLink = browserSupported && message.includes('U2F');
+
   return (
     <Alerts.Danger>
       <div>

--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -26,7 +26,9 @@ const auth = {
       return null;
     }
 
-    return new Error('your browser does not support FIDO U2F protocol');
+    return new Error(
+      'this browser does not support U2F required for hardware tokens, please try Chrome or Firefox instead'
+    );
   },
 
   login(userId, password, token) {

--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -26,7 +26,7 @@ const auth = {
       return null;
     }
 
-    return new Error('Your browser does not support FIDO U2F protocol.');
+    return new Error('your browser does not support FIDO U2F protocol');
   },
 
   login(userId, password, token) {

--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -21,6 +21,14 @@ import cfg from 'teleport/config';
 import makePasswordToken from './makePasswordToken';
 
 const auth = {
+  u2fBrowserSupported() {
+    if (window.u2f) {
+      return null;
+    }
+
+    return new Error('Your browser does not support FIDO U2F protocol.');
+  },
+
   login(userId, password, token) {
     const data = {
       user: userId,
@@ -32,6 +40,11 @@ const auth = {
   },
 
   loginWithU2f(name, password) {
+    const err = this.u2fBrowserSupported();
+    if (err) {
+      return Promise.reject(err);
+    }
+
     const data = {
       user: name,
       pass: password,
@@ -72,6 +85,11 @@ const auth = {
   },
 
   resetPasswordWithU2f(tokenId, password) {
+    const err = this.u2fBrowserSupported();
+    if (err) {
+      return Promise.reject(err);
+    }
+
     return auth._getU2FRegisterRes(tokenId).then(u2fRes => {
       return auth._resetPassword(tokenId, password, null, u2fRes);
     });

--- a/packages/teleport/src/services/auth/auth.test.js
+++ b/packages/teleport/src/services/auth/auth.test.js
@@ -38,14 +38,17 @@ describe('services/auth', () => {
   const email = 'user@example.com';
 
   test('undefined u2f object returns error', async () => {
-    const error = new Error('your browser does not support FIDO U2F protocol');
     global.u2f = undefined;
 
-    await expect(auth.loginWithU2f(email, password)).rejects.toEqual(error);
+    expect.assertions(2);
 
-    await expect(auth.resetPasswordWithU2f('any', password)).rejects.toEqual(
-      error
-    );
+    await auth.loginWithU2f(email, password).catch(err => {
+      expect(err.message).toContain('does not support U2F');
+    });
+
+    await auth.resetPasswordWithU2f('any', password).catch(err => {
+      expect(err.message).toContain('does not support U2F');
+    });
   });
 
   test('login()', async () => {

--- a/packages/teleport/src/services/auth/auth.test.js
+++ b/packages/teleport/src/services/auth/auth.test.js
@@ -38,7 +38,7 @@ describe('services/auth', () => {
   const email = 'user@example.com';
 
   test('undefined u2f object returns error', async () => {
-    const error = new Error('Your browser does not support FIDO U2F protocol.');
+    const error = new Error('your browser does not support FIDO U2F protocol');
     global.u2f = undefined;
 
     await expect(auth.loginWithU2f(email, password)).rejects.toEqual(error);

--- a/packages/teleport/src/services/auth/auth.test.js
+++ b/packages/teleport/src/services/auth/auth.test.js
@@ -37,6 +37,17 @@ describe('services/auth', () => {
   const password = 'sample_pass';
   const email = 'user@example.com';
 
+  test('undefined u2f object returns error', async () => {
+    const error = new Error('Your browser does not support FIDO U2F protocol.');
+    global.u2f = undefined;
+
+    await expect(auth.loginWithU2f(email, password)).rejects.toEqual(error);
+
+    await expect(auth.resetPasswordWithU2f('any', password)).rejects.toEqual(
+      error
+    );
+  });
+
   test('login()', async () => {
     jest.spyOn(api, 'post').mockImplementation(() => Promise.resolve());
 


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/5397

#### Description
For screens that used u2f (Login, Invite/Reset), on submit, checks if u2f object exists in browser window before making calls, and returns proper error message. 

From research, there is still no support for fido u2f on safari, however there is support for fido2//webauthn (as with other major browsers)

Tested u2f login on:
- mac browsers: safari, firefox, google
- linux browsers: firefox, google

#### Screenshot
safari
![image](https://user-images.githubusercontent.com/43280172/106032678-a334de80-6085-11eb-87bd-ab9aeb7e22a8.png)


![Screen Shot 2021-01-27 at 9 43 34 AM](https://user-images.githubusercontent.com/43280172/106031541-408f1300-6084-11eb-9e44-7361b7bcda94.png)


