### PR TITLE
Store first session's expiry and roles

### DIFF
--- a/packages/shared/hooks/useAttemptNext.ts
+++ b/packages/shared/hooks/useAttemptNext.ts
@@ -54,3 +54,5 @@ export type Attempt = {
 };
 
 type Callback = (fn?: any) => Promise<any>;
+
+export type State = ReturnType<typeof useAttemptNext>;

--- a/packages/teleport/src/Console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/Console/useOnExitConfirmation.ts
@@ -17,10 +17,10 @@
 import React from 'react';
 import ConsoleContext from './consoleContext';
 import * as stores from './stores/types';
-import session from 'teleport/services/session';
+import session, { forceRefresh } from 'teleport/services/session';
 
 // TAB_MIN_AGE defines "active terminal" session in ms
-const TAB_MIN_AGE = 30000;
+const TAB_MIN_AGE = 0;
 
 /**
  * useOnExitConfirmation notifies users closing active terminal sessions by:
@@ -38,10 +38,11 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
      * of document opened and how long it has been active for.
      */
     const handleBeforeunload = event => {
-      // Do not ask for confirmation when session is expired, which may trigger prompt
+      // Do not ask for confirmation when forcing refresh or when
+      // session is expired, which may trigger prompt
       // when browser triggers page reload before it receives session.end event,
       // which is not guaranteed to happen in that order.
-      if (!session.isValid()) {
+      if (!session.isValid() || forceRefresh) {
         return;
       }
 

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -71,7 +71,7 @@ export function Main(props: State) {
       <RouterDOM.Switch>
         <Redirect exact={true} from={cfg.routes.root} to={indexRoute} />
       </RouterDOM.Switch>
-      <VerticalSplit>
+      <VerticalSplit className="teleport-main">
         <SideNav />
         <HorizontalSplit>
           <TopBar />

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -80,7 +80,7 @@ const cfg = {
     clusterEventsPath: `/v1/webapi/sites/:clusterId/events/search?from=:start?&to=:end?&limit=:limit?`,
     scp:
       '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
-    renewTokenPath: '/v1/webapi/sessions/renew/:requestId?',
+    renewTokenPath: '/v1/webapi/sessions/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
     sessionPath: '/v1/webapi/sessions',
     userContextPath: '/v1/webapi/sites/:clusterId/context',
@@ -263,8 +263,8 @@ const cfg = {
     });
   },
 
-  getRenewTokenUrl(requestId?: string) {
-    return generatePath(cfg.api.renewTokenPath, { requestId });
+  getRenewTokenUrl() {
+    return cfg.api.renewTokenPath;
   },
 
   getResourcesUrl(kind?: Resource['kind']) {

--- a/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/packages/teleport/src/services/localStorage/localStorage.ts
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BearerToken, KeysEnum } from './types';
+import { KeysEnum } from './types';
+import { BearerToken, Session } from 'teleport/services/session';
 
 const storage = {
   clear() {
@@ -50,6 +51,26 @@ const storage = {
   broadcast(messageType, messageBody) {
     window.localStorage.setItem(messageType, messageBody);
     window.localStorage.removeItem(messageType);
+  },
+
+  // setDefaultSession preserves the data from first session created after user logs in.
+  // This enables users who assumed additional roles from access requests,
+  // to switch back to their default roles and resume remaining ttl.
+  setDefaultSession(session: Session) {
+    if (this.getDefaultSession()) {
+      return;
+    }
+
+    window.localStorage.setItem(
+      KeysEnum.DEFAULT_SESSION,
+      JSON.stringify(session)
+    );
+  },
+
+  getDefaultSession(): Session {
+    const item = window.localStorage.getItem(KeysEnum.DEFAULT_SESSION);
+
+    return JSON.parse(item);
   },
 };
 

--- a/packages/teleport/src/services/localStorage/types.ts
+++ b/packages/teleport/src/services/localStorage/types.ts
@@ -17,16 +17,6 @@ limitations under the License.
 export const KeysEnum = {
   TOKEN: 'grv_teleport_token',
   TOKEN_RENEW: 'grv_teleport_token_renew',
+  DEFAULT_SESSION: 'grv_default_session',
+  RELOAD_TABS: 'grv_reload_tabs',
 };
-
-export class BearerToken {
-  accessToken: string;
-  expiresIn: string;
-  created: number;
-
-  constructor(json) {
-    this.accessToken = json.token;
-    this.expiresIn = json.expires_in;
-    this.created = new Date().getTime();
-  }
-}

--- a/packages/teleport/src/services/session/index.ts
+++ b/packages/teleport/src/services/session/index.ts
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-import session from './session';
+import session, { forceRefresh } from './session';
+
+export * from './types';
+export { forceRefresh };
 export default session;

--- a/packages/teleport/src/services/session/types.ts
+++ b/packages/teleport/src/services/session/types.ts
@@ -1,0 +1,28 @@
+export type RenewSessionRequest = {
+  requestId?: string;
+  expires?: Date;
+  roles?: string[];
+};
+
+export class BearerToken {
+  accessToken: string;
+  expiresIn: string;
+  created: number;
+  session: Session;
+
+  constructor(json) {
+    this.accessToken = json.token;
+    this.expiresIn = json.expires_in;
+    this.created = new Date().getTime();
+
+    this.session = {
+      expires: json.session.expires,
+      roles: json.session.roles,
+    };
+  }
+}
+
+export interface Session {
+  expires: Date;
+  roles: string[];
+}


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/4937

TODO: fix tests

#### Description
- Store first session's expiration and roles in local storage. This allows user to switchback to their default roles, and session lives for the remainder of the expiration
- After user assumes, or particularly when user switches back to lesser priveledged role, all opened tabs needs to be refreshed to apply new permission
- Moved BearerToken class/type to session.ts from localstorage.ts 
- Placed a class name for Main component, so that I can target the styling for banner from one location