### PR TITLE
Fix error handling on the Delete Role Dialog

### DIFF
--- a/packages/shared/hooks/useAttemptNext.ts
+++ b/packages/shared/hooks/useAttemptNext.ts
@@ -36,12 +36,15 @@ export default function useAttemptNext(status = '' as Attempt['status']) {
       return fn()
         .then(() => {
           setAttempt({ status: 'success' });
+          return true;
         })
         .catch(err => {
           handleError(err);
+          return false;
         });
     } catch (err) {
       handleError(err);
+      return Promise.resolve(false);
     }
   }
 

--- a/packages/teleport/src/Apps/AddApp/AddApp.story.tsx
+++ b/packages/teleport/src/Apps/AddApp/AddApp.story.tsx
@@ -53,7 +53,7 @@ const sample = {
     user: 'sam',
     automatic: true,
     setAutomatic: () => null,
-    createToken: () => Promise.resolve(),
+    createToken: () => Promise.resolve(true),
     onClose() {
       return null;
     },

--- a/packages/teleport/src/Roles/DeleteRole/DeleteRole.tsx
+++ b/packages/teleport/src/Roles/DeleteRole/DeleteRole.tsx
@@ -26,7 +26,7 @@ export default function DeleteRoleDialog(props: Props) {
   const isDisabled = attempt.status === 'processing';
 
   function onOk() {
-    run(() => onDelete()).then(() => onClose());
+    run(() => onDelete()).then(ok => ok && onClose());
   }
 
   return (


### PR DESCRIPTION
The run method of the `useAttemptNext` hook swallows the error thus preventing the Delete Role dialog to handle the error.