### PR TITLE
Disable use of web workers in ace editor

### DIFF
--- a/packages/shared/components/TextEditor/TextEditor.jsx
+++ b/packages/shared/components/TextEditor/TextEditor.jsx
@@ -57,7 +57,7 @@ class TextEditor extends React.Component {
     session.setUndoManager(undoManager);
     session.setUseWrapMode(false);
     session.setMode(mode);
-    session.setOptions({ tabSize, useSoftTabs: true });
+    session.setOptions({ tabSize, useSoftTabs: true, useWorker: false });
     return session;
   }
 

--- a/packages/shared/components/TextEditor/TextEditor.jsx
+++ b/packages/shared/components/TextEditor/TextEditor.jsx
@@ -37,10 +37,6 @@ class TextEditor extends React.Component {
     }
   };
 
-  getData() {
-    return this.sessions.map(s => s.getValue());
-  }
-
   componentDidUpdate(prevProps) {
     if (prevProps.activeIndex !== this.props.activeIndex) {
       this.setActiveSession(this.props.activeIndex);
@@ -50,14 +46,23 @@ class TextEditor extends React.Component {
   }
 
   createSession({ content, type, tabSize = 2 }) {
-    const mode = getMode(type);
-    let session = new ace.EditSession(content);
-    let undoManager = new UndoManager();
+    const session = new ace.EditSession(content);
+    const undoManager = new UndoManager();
     undoManager.markClean();
     session.setUndoManager(undoManager);
     session.setUseWrapMode(false);
-    session.setMode(mode);
     session.setOptions({ tabSize, useSoftTabs: true });
+    session.setMode(getMode(type));
+    return session;
+  }
+
+  createSessionReadOnly({ content, type }) {
+    const session = new ace.EditSession(content);
+
+    // Workers are syntax validators which isn't needed in read only mode.
+    session.setOptions({ useWorker: false });
+    session.setUseWrapMode(false);
+    session.setMode(getMode(type));
     return session;
   }
 
@@ -72,8 +77,12 @@ class TextEditor extends React.Component {
   }
 
   initSessions(data = []) {
-    this.isDirty = false;
     this.sessions = data.map(item => this.createSession(item));
+    this.setActiveSession(0);
+  }
+
+  initSessionsReadOnly(data = []) {
+    this.sessions = data.map(item => this.createSessionReadOnly(item));
     this.setActiveSession(0);
   }
 
@@ -90,8 +99,13 @@ class TextEditor extends React.Component {
     this.editor.on('input', this.onChange);
     this.editor.setReadOnly(readOnly);
     this.editor.setTheme(theme);
+
+    if (readOnly) {
+      this.initSessionsReadOnly(data);
+      return;
+    }
+
     this.initSessions(data);
-    this.editor.focus();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
#### Description
Fixes error messages produced when clicking on "Details" on event dialogue:
![image](https://user-images.githubusercontent.com/43280172/109088599-93c8a580-76c4-11eb-8be6-a01bb7553271.png)

![image](https://user-images.githubusercontent.com/43280172/109089555-5107cd00-76c6-11eb-92a4-91bcd4aaf9e9.png)

Disable use of web workers (syntax validators) b/c they are not used. Currently, we only use two modes json and yaml. json is used as read only mode, and yaml doesn't have syntax validating workers