### PR TITLE
mfa: support multiple U2F devices on login

### DIFF
--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -54,7 +54,13 @@ const auth = {
 
     return api.post(cfg.api.u2fSessionChallengePath, data, false).then(data => {
       const promise = new Promise((resolve, reject) => {
-        window.u2f.sign(data.appId, data.challenge, [data], function(res) {
+        var devices = [data];
+        // u2f_challenges is a new field returned by post-6.0 auth servers.
+        // It contains all registered U2F devices.
+        if (data.u2f_challenges) {
+          devices = data.u2f_challenges;
+        }
+        window.u2f.sign(data.appId, data.challenge, devices, function(res) {
           if (res.errorCode) {
             const err = auth._getU2fErr(res.errorCode);
             reject(err);
@@ -118,8 +124,14 @@ const auth = {
     };
 
     return api.post(cfg.api.u2fChangePassChallengePath, data).then(data => {
+      var devices = [data];
+      // u2f_challenges is a new field returned by post-6.0 auth servers.
+      // It contains all registered U2F devices.
+      if (data.u2f_challenges) {
+        devices = data.u2f_challenges;
+      }
       return new Promise((resolve, reject) => {
-        window.u2f.sign(data.appId, data.challenge, [data], function(res) {
+        window.u2f.sign(data.appId, data.challenge, devices, function(res) {
           if (res.errorCode) {
             const err = auth._getU2fErr(res.errorCode);
             reject(err);


### PR DESCRIPTION
The API now returns `u2f_challenges`, a new field with details of all
registered devices. If this field is present, pass it through to the JS
U2F API to accept any of the registered keys.

Related: https://github.com/gravitational/teleport/pull/5837