### PR TITLE
Support multiple MFA methods on login

### DIFF
--- a/packages/shared/components/FormInvite/FormInvite.tsx
+++ b/packages/shared/components/FormInvite/FormInvite.tsx
@@ -46,7 +46,10 @@ export default function FormInvite(props: Props) {
   const [passwordConfirmed, setPasswordConfirmed] = React.useState('');
   const [token, setToken] = React.useState('');
 
-  const otpEnabled = auth2faType === 'otp';
+  // Temporary hack: if cluster supports all 2FA types, require the user to
+  // sign up with OTP. We should ideally let the user choose a different 2FA
+  // method when there's engineering capacity to build this.
+  const otpEnabled = auth2faType === 'otp' || auth2faType === 'on' || auth2faType === 'optional';
   const u2fEnabled = auth2faType === 'u2f';
   const secondFactorEnabled = otpEnabled || u2fEnabled;
   const { isProcessing, isFailed, message } = attempt;

--- a/packages/shared/components/FormInvite/TwoFaInfo.tsx
+++ b/packages/shared/components/FormInvite/TwoFaInfo.tsx
@@ -23,7 +23,10 @@ const U2F_HELP_URL = 'https://support.google.com/accounts/answer/6103523?hl=en';
 export default function TwoFAData({ auth2faType, qr }: Props) {
   const imgSrc = `data:image/png;base64,${qr}`;
 
-  if (auth2faType === 'otp') {
+  // Temporary hack: if cluster supports all 2FA types, require the user to
+  // sign up with OTP. We should ideally let the user choose a different 2FA
+  // method when there's engineering capacity to build this.
+  if (auth2faType === 'otp' || auth2faType === 'on' || auth2faType === 'optional') {
     return (
       <div>
         <Text typography="paragraph2" mb={3}>

--- a/packages/shared/components/FormLogin/FormLogin.story.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.story.tsx
@@ -17,50 +17,37 @@ limitations under the License.
 import React from 'react';
 import FormLogin from './FormLogin';
 
-const defaultProps = {
+const props = {
+  title: 'Custom Title',
   attempt: {
     isFailed: false,
     isSuccess: undefined,
     isProcessing: undefined,
     message: undefined,
   },
-  cb() {},
+  authProviders: [],
+  onLoginWithSso: () => null,
+  onLoginWithU2f: () => null,
+  onLogin: () => null,
 };
 
 export default {
   title: 'Shared/FormLogin',
 };
 
-export const Basic = () => (
-  <FormLogin
-    title="Custom Title"
-    authProviders={[]}
-    auth2faType="otp"
-    onLoginWithSso={defaultProps.cb}
-    onLoginWithU2f={defaultProps.cb}
-    onLogin={defaultProps.cb}
-    attempt={defaultProps.attempt}
-  />
-);
+export const Basic = () => <FormLogin {...props} auth2faType="otp" />;
+
+export const Multi = () => <FormLogin {...props} auth2faType="optional" />;
 
 export const ServerError = () => {
   const attempt = {
-    ...defaultProps.attempt,
+    ...props.attempt,
     isFailed: true,
     message:
       'invalid credentials with looooooooooooooooooooooooooooooooong text',
   };
 
-  return (
-    <FormLogin
-      title="Welcome!"
-      authProviders={[]}
-      onLoginWithSso={defaultProps.cb}
-      onLoginWithU2f={defaultProps.cb}
-      onLogin={defaultProps.cb}
-      attempt={attempt}
-    />
-  );
+  return <FormLogin {...props} title="Welcome!" attempt={attempt} />;
 };
 
 export const SSOProviders = () => {
@@ -96,32 +83,20 @@ export const SSOProviders = () => {
     } as const,
   ];
 
-  return (
-    <FormLogin
-      title="Welcome!"
-      authProviders={ssoProvider}
-      onLoginWithSso={defaultProps.cb}
-      onLoginWithU2f={defaultProps.cb}
-      onLogin={defaultProps.cb}
-      attempt={defaultProps.attempt}
-    />
-  );
+  return <FormLogin {...props} title="Welcome!" authProviders={ssoProvider} />;
 };
 
 export const Universal2ndFactor = () => {
   const attempt = {
-    ...defaultProps.attempt,
+    ...props.attempt,
     isProcessing: true,
   };
 
   return (
     <FormLogin
+      {...props}
       title="Welcome!"
-      authProviders={[]}
       auth2faType="u2f"
-      onLoginWithSso={defaultProps.cb}
-      onLoginWithU2f={defaultProps.cb}
-      onLogin={defaultProps.cb}
       attempt={attempt}
     />
   );
@@ -135,24 +110,14 @@ export const LocalAuthDisabled = () => {
 
   return (
     <FormLogin
+      {...props}
       title="Welcome!"
       authProviders={ssoProvider}
-      onLoginWithSso={defaultProps.cb}
-      onLoginWithU2f={defaultProps.cb}
-      onLogin={defaultProps.cb}
-      attempt={defaultProps.attempt}
       isLocalAuthEnabled={false}
     />
   );
 };
 
 export const LocalAuthDisabledNoSSO = () => (
-  <FormLogin
-    title="Welcome!"
-    onLoginWithSso={defaultProps.cb}
-    onLoginWithU2f={defaultProps.cb}
-    onLogin={defaultProps.cb}
-    attempt={defaultProps.attempt}
-    isLocalAuthEnabled={false}
-  />
+  <FormLogin {...props} title="Welcome!" isLocalAuthEnabled={false} />
 );

--- a/packages/shared/services/types.ts
+++ b/packages/shared/services/types.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 export type AuthProviderType = 'oidc' | 'saml' | 'github';
 
-export type Auth2faType = 'u2f' | 'otp' | 'off';
+export type Auth2faType = 'u2f' | 'otp' | 'off' | 'optional' | 'on';
 
 export type AuthProvider = {
   displayName?: string;

--- a/packages/teleport/src/Invite/Invite.story.js
+++ b/packages/teleport/src/Invite/Invite.story.js
@@ -43,6 +43,22 @@ export function ResetPasswordScreen() {
   return <Component {...props} />;
 }
 
+export function AuthTfaOn() {
+  const props = {
+    ...defaultProps,
+    auth2faType: 'on',
+  };
+  return <Component {...props} />;
+}
+
+export function AuthTfaOptional() {
+  const props = {
+    ...defaultProps,
+    auth2faType: 'optional',
+  };
+  return <Component {...props} />;
+}
+
 const defaultProps = {
   auth2faType: 'off',
   submitAttempt: {},

--- a/packages/teleport/src/Invite/Invite.test.js
+++ b/packages/teleport/src/Invite/Invite.test.js
@@ -21,6 +21,7 @@ import { Logger } from 'shared/libs/logger';
 import auth from 'teleport/services/auth';
 import cfg from 'teleport/config';
 import Invite from './Invite';
+import { AuthTfaOn, AuthTfaOptional } from './Invite.story';
 
 describe('teleport/components/Invite', () => {
   beforeEach(() => {
@@ -123,6 +124,16 @@ describe('teleport/components/Invite', () => {
     });
 
     expect(screen.getByText('server_error')).toBeDefined();
+  });
+
+  it('should render form with token requirement when auth2fatype is on', async () => {
+    const { container } = render(<AuthTfaOn />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render form with token requirement when auth2fatype is optional', async () => {
+    const { container } = render(<AuthTfaOptional />);
+    expect(container).toMatchSnapshot();
   });
 });
 

--- a/packages/teleport/src/Invite/__snapshots__/Invite.test.js.snap
+++ b/packages/teleport/src/Invite/__snapshots__/Invite.test.js.snap
@@ -1,0 +1,715 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`teleport/components/Invite should render form with token requirement when auth2fatype is on 1`] = `
+.c3 {
+  box-sizing: border-box;
+  padding: 40px;
+  flex: 3;
+}
+
+.c6 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+}
+
+.c10 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  width: 50%;
+}
+
+.c12 {
+  box-sizing: border-box;
+  padding: 40px;
+  background-color: #1C254D;
+  flex: 1;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+.c11 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c11:active {
+  opacity: 0.56;
+}
+
+.c11:hover,
+.c11:focus {
+  background: #651FFF;
+}
+
+.c11:active {
+  background: #354AA4;
+}
+
+.c11:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c15 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  width: 100%;
+}
+
+.c15:active {
+  opacity: 0.56;
+}
+
+.c15:hover,
+.c15:focus {
+  background: #2C3A73;
+}
+
+.c15:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c14 {
+  color: #03a9f4;
+  font-weight: normal;
+  background: none;
+  text-decoration: underline;
+  text-transform: none;
+  padding: 0 8px;
+}
+
+.c14:hover,
+.c14:focus {
+  background: #222C59;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  width: 720px;
+  background-color: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-radius: 8px;
+}
+
+.c8 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  color: #324148;
+  background-color: #FFFFFF;
+}
+
+.c8::-ms-clear {
+  display: none;
+}
+
+.c8::placeholder {
+  opacity: 0.4;
+}
+
+.c8:read-only {
+  cursor: not-allowed;
+}
+
+.c7 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.c0 {
+  display: block;
+  outline: none;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  max-width: 200px;
+  max-height: 120px;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 28px;
+  line-height: 32px;
+  margin: 0px;
+  margin-bottom: 16px;
+  color: #FFFFFF;
+  text-align: center;
+}
+
+.c5 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 32px;
+  word-break: break-all;
+  margin: 0px;
+  margin-bottom: 16px;
+}
+
+.c13 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 12px;
+  line-height: 24px;
+  margin: 0px;
+  margin-bottom: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c9 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+}
+
+<div>
+  <img
+    class="c0"
+    src="file_stub"
+  />
+  <form
+    class="c1"
+    width="720px"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+          color="light"
+        >
+          Welcome to Teleport
+        </div>
+        <div
+          class="c5"
+        >
+          john@example.com
+        </div>
+        <div
+          class="c6"
+        >
+          <label
+            class="c7"
+            font-size="0"
+          >
+            Password
+          </label>
+          <input
+            autocomplete="off"
+            class="c8"
+            color="text.onLight"
+            placeholder="Password"
+            type="password"
+            value=""
+          />
+        </div>
+        <div
+          class="c6"
+        >
+          <label
+            class="c7"
+            font-size="0"
+          >
+            Confirm Password
+          </label>
+          <input
+            autocomplete="off"
+            class="c8"
+            color="text.onLight"
+            placeholder="Confirm Password"
+            type="password"
+            value=""
+          />
+        </div>
+        <div
+          class="c9"
+        >
+          <div
+            class="c10"
+            width="50%"
+          >
+            <label
+              class="c7"
+              font-size="0"
+            >
+              Two factor token
+            </label>
+            <input
+              autocomplete="off"
+              class="c8"
+              color="text.onLight"
+              placeholder="123 456"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          class="c11"
+          kind="primary"
+          width="100%"
+        >
+          Create Account
+        </button>
+      </div>
+      <div
+        class="c12"
+      >
+        <div>
+          <div
+            class="c13"
+          >
+            Scan the bar code with Google Authenticator to generate a two factor token.
+          </div>
+          <img
+            src="data:image/png;base64,undefined"
+            style="border: 8px solid;"
+            width="152"
+          />
+          <a
+            class="c14 c15"
+            href="https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DiOS&hl=en&oco=0"
+            kind="secondary"
+            rel="noreferrer"
+            target="_blank"
+            width="100%"
+          >
+            Download Google Authenticator
+          </a>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`teleport/components/Invite should render form with token requirement when auth2fatype is optional 1`] = `
+.c3 {
+  box-sizing: border-box;
+  padding: 40px;
+  flex: 3;
+}
+
+.c6 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+}
+
+.c10 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  width: 50%;
+}
+
+.c12 {
+  box-sizing: border-box;
+  padding: 40px;
+  background-color: #1C254D;
+  flex: 1;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+.c11 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c11:active {
+  opacity: 0.56;
+}
+
+.c11:hover,
+.c11:focus {
+  background: #651FFF;
+}
+
+.c11:active {
+  background: #354AA4;
+}
+
+.c11:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c15 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  width: 100%;
+}
+
+.c15:active {
+  opacity: 0.56;
+}
+
+.c15:hover,
+.c15:focus {
+  background: #2C3A73;
+}
+
+.c15:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c14 {
+  color: #03a9f4;
+  font-weight: normal;
+  background: none;
+  text-decoration: underline;
+  text-transform: none;
+  padding: 0 8px;
+}
+
+.c14:hover,
+.c14:focus {
+  background: #222C59;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  width: 720px;
+  background-color: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-radius: 8px;
+}
+
+.c8 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  color: #324148;
+  background-color: #FFFFFF;
+}
+
+.c8::-ms-clear {
+  display: none;
+}
+
+.c8::placeholder {
+  opacity: 0.4;
+}
+
+.c8:read-only {
+  cursor: not-allowed;
+}
+
+.c7 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.c0 {
+  display: block;
+  outline: none;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  max-width: 200px;
+  max-height: 120px;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 28px;
+  line-height: 32px;
+  margin: 0px;
+  margin-bottom: 16px;
+  color: #FFFFFF;
+  text-align: center;
+}
+
+.c5 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 32px;
+  word-break: break-all;
+  margin: 0px;
+  margin-bottom: 16px;
+}
+
+.c13 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 12px;
+  line-height: 24px;
+  margin: 0px;
+  margin-bottom: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c9 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+}
+
+<div>
+  <img
+    class="c0"
+    src="file_stub"
+  />
+  <form
+    class="c1"
+    width="720px"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+          color="light"
+        >
+          Welcome to Teleport
+        </div>
+        <div
+          class="c5"
+        >
+          john@example.com
+        </div>
+        <div
+          class="c6"
+        >
+          <label
+            class="c7"
+            font-size="0"
+          >
+            Password
+          </label>
+          <input
+            autocomplete="off"
+            class="c8"
+            color="text.onLight"
+            placeholder="Password"
+            type="password"
+            value=""
+          />
+        </div>
+        <div
+          class="c6"
+        >
+          <label
+            class="c7"
+            font-size="0"
+          >
+            Confirm Password
+          </label>
+          <input
+            autocomplete="off"
+            class="c8"
+            color="text.onLight"
+            placeholder="Confirm Password"
+            type="password"
+            value=""
+          />
+        </div>
+        <div
+          class="c9"
+        >
+          <div
+            class="c10"
+            width="50%"
+          >
+            <label
+              class="c7"
+              font-size="0"
+            >
+              Two factor token
+            </label>
+            <input
+              autocomplete="off"
+              class="c8"
+              color="text.onLight"
+              placeholder="123 456"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          class="c11"
+          kind="primary"
+          width="100%"
+        >
+          Create Account
+        </button>
+      </div>
+      <div
+        class="c12"
+      >
+        <div>
+          <div
+            class="c13"
+          >
+            Scan the bar code with Google Authenticator to generate a two factor token.
+          </div>
+          <img
+            src="data:image/png;base64,undefined"
+            style="border: 8px solid;"
+            width="152"
+          />
+          <a
+            class="c14 c15"
+            href="https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DiOS&hl=en&oco=0"
+            kind="secondary"
+            rel="noreferrer"
+            target="_blank"
+            width="100%"
+          >
+            Download Google Authenticator
+          </a>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;

--- a/packages/teleport/src/Login/Login.story.tsx
+++ b/packages/teleport/src/Login/Login.story.tsx
@@ -42,4 +42,5 @@ const sample = {
   authProviders: [],
   auth2faType: 'off' as any,
   isLocalAuthEnabled: true,
+  clearAttempt: () => null,
 };

--- a/packages/teleport/src/Login/Login.tsx
+++ b/packages/teleport/src/Login/Login.tsx
@@ -34,6 +34,7 @@ export function Login({
   authProviders,
   auth2faType,
   isLocalAuthEnabled,
+  clearAttempt,
 }: State) {
   return (
     <>
@@ -47,6 +48,7 @@ export function Login({
         onLoginWithU2f={onLoginWithU2f}
         onLogin={onLogin}
         attempt={attempt}
+        clearAttempt={clearAttempt}
       />
     </>
   );

--- a/packages/teleport/src/Login/useLogin.ts
+++ b/packages/teleport/src/Login/useLogin.ts
@@ -61,6 +61,7 @@ export default function useLogin() {
     authProviders,
     auth2faType,
     isLocalAuthEnabled,
+    clearAttempt: attemptActions.clear,
   };
 }
 

--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -183,7 +183,7 @@ const auth = {
   },
 
   _getU2fErr(errorCode) {
-    let errorMsg = '';
+    let errorMsg = `error code ${errorCode}`;
     // lookup error message...
     for (var msg in window.u2f.ErrorCodes) {
       if (window.u2f.ErrorCodes[msg] == errorCode) {


### PR DESCRIPTION
If both OTP and U2F are allowed by the server, give user a dropdown to
pick the right method.

During registration/reset, default to OTP when multiple MFA methods are
supported.

#### Related PR
bug fix: https://github.com/gravitational/teleport/pull/5995

#### Screenshot
Screenshots with `second_factor: optional`:
- none for users who dont have mfa enrolled
![image](https://user-images.githubusercontent.com/43280172/111201578-2059db80-8580-11eb-8133-af97932da960.png)

- login clicked with U2F
![image](https://user-images.githubusercontent.com/43280172/111201661-38c9f600-8580-11eb-8af2-7ac2779be145.png)

- login with TOTP
![image](https://user-images.githubusercontent.com/43280172/111201702-454e4e80-8580-11eb-9778-056a8a90344e.png)

