### PR TITLE
Consistent day picker and prettified file

### DIFF
--- a/packages/teleport/src/components/EventRangePicker/Custom/Custom.jsx
+++ b/packages/teleport/src/components/EventRangePicker/Custom/Custom.jsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react'
+import React from 'react';
 import moment from 'moment';
 import styled from 'styled-components';
 import DayPicker, { DateUtils } from 'react-day-picker';
@@ -23,29 +23,28 @@ import { Flex } from 'design';
 import { Close as CloseIcon } from 'design/Icon';
 
 export default class CustomRange extends React.Component {
-
-  constructor(props){
+  constructor(props) {
     super();
     this.startSelecting = false;
     const { from, to } = props;
     this.state = {
       from,
       to,
-    }
+    };
   }
 
   handleDayClick = day => {
-    if(moment(day) > moment(new Date()).endOf('day')){
+    if (moment(day) > moment(new Date()).endOf('day')) {
       return;
     }
 
     let { from, end } = this.state;
 
-    if(moment(from).isSame(day)){
+    if (moment(from).isSame(day)) {
       return;
     }
 
-    if(this.startSelecting === false){
+    if (this.startSelecting === false) {
       // reset the range once a user starts a new selection
       end = undefined;
       from = undefined;
@@ -53,12 +52,25 @@ export default class CustomRange extends React.Component {
     }
 
     const range = DateUtils.addDayToRange(day, { from, end });
-    this.setState(range, this.onChange);
-  }
 
-  onChange(){
+    if (range.from) {
+      range.from = moment(range.from)
+        .startOf('day')
+        .toDate();
+    }
+
+    if (range.to) {
+      range.to = moment(range.to)
+        .endOf('day')
+        .toDate();
+    }
+
+    this.setState(range, this.onChange);
+  };
+
+  onChange() {
     const { from, to } = this.state;
-    if( from && to && this.startSelecting){
+    if (from && to && this.startSelecting) {
       this.props.onChange(from, to);
     }
   }
@@ -75,7 +87,9 @@ export default class CustomRange extends React.Component {
         <DayPicker
           className="Selectable"
           numberOfMonths={2}
-          month={moment(to).subtract(1, 'month').toDate()}
+          month={moment(to)
+            .subtract(1, 'month')
+            .toDate()}
           disabledDays={{
             after: new Date(),
           }}
@@ -92,25 +106,24 @@ const StyledCloseButton = styled.button`
   background: transparent;
   border-radius: 2px;
   border: none;
-  color: ${props => props.theme.colors.grey[900]}; 
+  color: ${props => props.theme.colors.grey[900]};
   cursor: pointer;
   height: 24px;
   width: 24px;
   outline: none;
   padding: 0;
   margin: 0 8px 0 0;
-  transition: all .3s;
-  position: absolute; 
+  transition: all 0.3s;
+  position: absolute;
   font-size: 20px;
   z-index: 100;
-  top: 8px; 
-  right: 0px; 
+  top: 8px;
+  right: 0px;
 
   &:hover {
     background: ${props => props.theme.colors.grey[200]};
   }
 `;
-
 
 const StyledDateRange = styled(Flex)`
   position: relative;
@@ -119,13 +132,13 @@ const StyledDateRange = styled(Flex)`
     line-height: initial;
     color: black;
     background-color: white;
-    box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.24);
     box-sizing: border-box;
     border-radius: 5px;
     padding: 24px;
   }
 
-  .DayPicker-Months{
+  .DayPicker-Months {
   }
 
   .DayPicker-Day--selected:not(.DayPicker-Day--start):not(.DayPicker-Day--end):not(.DayPicker-Day--outside) {
@@ -146,4 +159,4 @@ const StyledDateRange = styled(Flex)`
     border-top-right-radius: 50% !important;
     border-bottom-right-radius: 50% !important;
   }
-`
+`;


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/5427

#### Description
The `7 day` selector chose dates with clock at start of day and end of day. The react day picker library clock started (for me) at 12pm. So to fix the clock inconsitency, converted the time given back from library to `start` and `end` of day.

#### Screenshot
![image](https://user-images.githubusercontent.com/43280172/111215395-5a32de00-8590-11eb-9e24-3d544d7f6780.png)

