### PR TITLE
Mfa fixes

### DIFF
--- a/packages/shared/components/FieldSelect/FieldSelect.tsx
+++ b/packages/shared/components/FieldSelect/FieldSelect.tsx
@@ -67,4 +67,6 @@ type Props = SelectProps & {
   autoFocus?: boolean;
   label?: string;
   rule?: Function;
+  // styles
+  [key: string]: any;
 };

--- a/packages/shared/components/FormLogin/FormLogin.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.tsx
@@ -150,11 +150,11 @@ export default function LoginForm(props: Props) {
               {mfaEnabled && (
                 <Flex alignItems="flex-end" mb={4}>
                   <Box width="50%" data-testid="mfa-select">
-                    <MfaSelect
+                    <FieldSelect
                       label="Second factor"
                       value={mfaType}
                       options={mfaOptions}
-                      onChange={opt => onSetMfaOption(opt, validator)}
+                      onChange={opt => onSetMfaOption(opt as Option, validator)}
                       mr={3}
                       mb={0}
                       isDisabled={isProcessing}
@@ -264,27 +264,6 @@ const StyledOr = styled.div`
   border-radius: 50%;
   position: absolute;
   z-index: 1;
-`;
-
-const MfaSelect = styled(FieldSelect)`
-  .react-select__control {
-    border-radius: 4px;
-    border-color: rgba(255, 255, 255, 0.24);
-    background-color: #28325e;
-
-    &:hover {
-      border-color: rgba(255, 255, 255, 0.24);
-      background-color: #39436d;
-      .react-select__dropdown-indicator {
-        color: #fff;
-      }
-    }
-  }
-
-  .react-select__single-value,
-  .react-select__dropdown-indicator {
-    color: #fff;
-  }
 `;
 
 type Props = {

--- a/packages/shared/components/FormPassword/FormPassword.story.tsx
+++ b/packages/shared/components/FormPassword/FormPassword.story.tsx
@@ -15,36 +15,27 @@ limitations under the License.
 */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import FormPassword from './FormPassword';
 
-const onChangePass = () => Promise.resolve();
-const onChangePassWithU2f = () => Promise.reject(new Error('server error'));
+export default {
+  title: 'Shared/FormPassword',
+};
 
-storiesOf('Shared/FormPassword', module)
-  .add('FormPassword', () => {
-    return (
-      <FormPassword
-        onChangePass={onChangePass}
-        onChangePassWithU2f={onChangePassWithU2f}
-      />
-    );
-  })
-  .add('With OTP', () => {
-    return (
-      <FormPassword
-        auth2faType="otp"
-        onChangePass={onChangePass}
-        onChangePassWithU2f={onChangePassWithU2f}
-      />
-    );
-  })
-  .add('With U2F', () => {
-    return (
-      <FormPassword
-        auth2faType="u2f"
-        onChangePass={onChangePass}
-        onChangePassWithU2f={onChangePassWithU2f}
-      />
-    );
-  });
+export const Local = () => <FormPassword {...props} />;
+
+export const OTP = () => <FormPassword auth2faType="otp" {...props} />;
+
+export const Universal2ndFactor = () => (
+  <FormPassword auth2faType="u2f" {...props} />
+);
+
+export const On = () => <FormPassword auth2faType="on" {...props} />;
+
+export const Optional = () => (
+  <FormPassword auth2faType="optional" {...props} />
+);
+
+const props = {
+  onChangePass: () => Promise.resolve(),
+  onChangePassWithU2f: () => Promise.reject(new Error('server error')),
+};

--- a/packages/shared/components/FormPassword/FormPassword.test.tsx
+++ b/packages/shared/components/FormPassword/FormPassword.test.tsx
@@ -16,7 +16,8 @@
 
 import React from 'react';
 import FormPassword from './FormPassword';
-import { render, fireEvent, wait } from 'design/utils/testing';
+import { On, Optional } from './FormPassword.story';
+import { render, fireEvent, wait, screen } from 'design/utils/testing';
 
 jest.mock('../../libs/logger', () => {
   const mockLogger = {
@@ -175,4 +176,48 @@ test('prop auth2faType: U2f form with mocked error', async () => {
     'value',
     ''
   );
+});
+
+test('auth2faType "optional", has correct select options', async () => {
+  render(<Optional />);
+
+  // default mfa dropdown is set to none
+  expect(screen.getByTestId('mfa-select').textContent).toMatch(/none/i);
+
+  // select u2f from mfa dropdown
+  let selectEl = screen.getByTestId('mfa-select').querySelector('input');
+  fireEvent.focus(selectEl);
+  fireEvent.keyDown(selectEl, { key: 'ArrowDown', keyCode: 40 });
+  fireEvent.click(screen.getByText(/u2f/i));
+  screen.getByText(/u2f/i);
+
+  // select totp from mfa dropdown
+  selectEl = screen.getByTestId('mfa-select').querySelector('input');
+  fireEvent.focus(selectEl);
+  fireEvent.keyDown(selectEl, { key: 'ArrowDown', keyCode: 40 });
+  fireEvent.click(screen.getByText(/totp/i));
+  screen.getByText(/totp/i);
+
+  // test totp requirement
+  fireEvent.click(screen.getByText(/update password/i));
+  screen.getByText(/token is require/i);
+});
+
+test('auth2faType "on", has correct select options', async () => {
+  render(<On />);
+
+  // default mfa dropdown is set to u2f
+  expect(screen.getByTestId('mfa-select').textContent).toMatch(/u2f/i);
+
+  // select totp from mfa dropdown
+  const selectEl = screen.getByTestId('mfa-select').querySelector('input');
+  fireEvent.focus(selectEl);
+  fireEvent.keyDown(selectEl, { key: 'ArrowDown', keyCode: 40 });
+  fireEvent.click(screen.getByText(/totp/i));
+  screen.getByText(/totp/i);
+
+  // none type is not part of mfa dropdown
+  fireEvent.focus(selectEl);
+  fireEvent.keyDown(selectEl, { key: 'ArrowDown', keyCode: 40 });
+  expect(screen.queryAllByText(/none/i)).toHaveLength(0);
 });

--- a/packages/shared/components/FormPassword/FormPassword.tsx
+++ b/packages/shared/components/FormPassword/FormPassword.tsx
@@ -15,10 +15,12 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Card, ButtonPrimary } from 'design';
+import { Card, ButtonPrimary, Flex, Box } from 'design';
 import * as Alerts from 'design/Alert';
 import useAttempt from 'shared/hooks/useAttempt';
+import { Option } from 'shared/components/Select';
 import FieldInput from '../FieldInput';
+import FieldSelect from '../FieldSelect';
 import Validation, { Validator } from '../Validation';
 import {
   requiredToken,
@@ -30,18 +32,31 @@ import { Auth2faType } from 'shared/services';
 
 function FormPassword(props: Props) {
   const { onChangePassWithU2f, onChangePass, auth2faType = 'off' } = props;
+  const mfaEnabled = auth2faType === 'on' || auth2faType === 'optional';
+  const otpEnabled = auth2faType === 'otp';
+  const u2fEnabled = auth2faType === 'u2f';
+
   const [attempt, attemptActions] = useAttempt({});
   const [token, setToken] = React.useState('');
   const [oldPass, setOldPass] = React.useState('');
   const [newPass, setNewPass] = React.useState('');
   const [newPassConfirmed, setNewPassConfirmed] = React.useState('');
+  const [mfaOptions] = React.useState(() => {
+    let mfaOptions = [
+      { value: 'u2f', label: 'U2F' },
+      { value: 'otp', label: 'TOTP' },
+    ];
+    if (auth2faType === 'optional') {
+      mfaOptions = [{ value: 'none', label: 'NONE' }, ...mfaOptions];
+    }
+    return mfaOptions;
+  });
+  const [mfaType, setMfaType] = React.useState(mfaOptions[0]);
 
-  const otpEnabled = auth2faType === 'otp';
-  const u2fEnabled = auth2faType === 'u2f';
   const { isProcessing } = attempt;
 
   function submit() {
-    if (u2fEnabled) {
+    if (u2fEnabled || (mfaEnabled && mfaType.value === 'u2f')) {
       return onChangePassWithU2f(oldPass, newPass);
     }
 
@@ -77,11 +92,21 @@ function FormPassword(props: Props) {
       });
   }
 
+  function onSetMfaOption(option: Option, validator: Validator) {
+    setToken('');
+    attemptActions.clear();
+    validator.reset();
+    setMfaType(option);
+  }
+
   return (
     <Validation>
       {({ validator }) => (
         <Card as="form" bg="primary.light" width="456px" p="6">
-          <Status isU2F={u2fEnabled} attempt={attempt} />
+          <Status
+            isU2F={u2fEnabled || (mfaEnabled && mfaType.value === 'u2f')}
+            attempt={attempt}
+          />
           <FieldInput
             rule={requiredField('Current Password is required')}
             label="Current Password"
@@ -90,6 +115,34 @@ function FormPassword(props: Props) {
             type="password"
             placeholder="Password"
           />
+          {mfaEnabled && (
+            <Flex alignItems="flex-end" mb={4}>
+              <Box width="50%" data-testid="mfa-select">
+                <FieldSelect
+                  label="Second factor"
+                  value={mfaType}
+                  options={mfaOptions}
+                  onChange={opt => onSetMfaOption(opt as Option, validator)}
+                  mr={3}
+                  mb={0}
+                  isDisabled={isProcessing}
+                />
+              </Box>
+              <Box width="50%">
+                {mfaType.value === 'otp' && (
+                  <FieldInput
+                    label="Two factor token"
+                    rule={requiredToken}
+                    autoComplete="off"
+                    value={token}
+                    onChange={e => setToken(e.target.value)}
+                    placeholder="123 456"
+                    mb={0}
+                  />
+                )}
+              </Box>
+            </Flex>
+          )}
           {otpEnabled && (
             <FieldInput
               label="2nd factor token"

--- a/packages/shared/components/FormPassword/FormPassword.tsx
+++ b/packages/shared/components/FormPassword/FormPassword.tsx
@@ -54,9 +54,10 @@ function FormPassword(props: Props) {
   const [mfaType, setMfaType] = React.useState(mfaOptions[0]);
 
   const { isProcessing } = attempt;
+  const isU2fSelected = u2fEnabled || (mfaEnabled && mfaType.value === 'u2f');
 
   function submit() {
-    if (u2fEnabled || (mfaEnabled && mfaType.value === 'u2f')) {
+    if (isU2fSelected) {
       return onChangePassWithU2f(oldPass, newPass);
     }
 
@@ -103,10 +104,7 @@ function FormPassword(props: Props) {
     <Validation>
       {({ validator }) => (
         <Card as="form" bg="primary.light" width="456px" p="6">
-          <Status
-            isU2F={u2fEnabled || (mfaEnabled && mfaType.value === 'u2f')}
-            attempt={attempt}
-          />
+          <Status isU2F={isU2fSelected} attempt={attempt} />
           <FieldInput
             rule={requiredField('Current Password is required')}
             label="Current Password"

--- a/packages/teleport/src/Console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/Console/useOnExitConfirmation.ts
@@ -64,17 +64,6 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
   }, []);
 
   /**
-   * confirmCloseSession prompts user to confirm to close.
-   */
-  function confirmCloseSession(participants: number) {
-    if (participants > 1) {
-      return window.confirm('Are you sure you want to leave this session?');
-    }
-
-    return window.confirm('Are you sure you want to terminate this session?');
-  }
-
-  /**
    * hasLastingSshConnection calculates the milliseconds between given date
    * from when fn was called.
    *
@@ -104,9 +93,15 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
     if (hasLastingSshConnection(doc)) {
       const sid = (doc as stores.DocumentSsh).sid;
       const participants = ctx.storeParties.state[sid];
-      if (participants) {
-        return confirmCloseSession(participants.length);
+      if (!participants) {
+        return true;
       }
+
+      if (participants.length > 1) {
+        return window.confirm('Are you sure you want to leave this session?');
+      }
+
+      return window.confirm('Are you sure you want to terminate this session?');
     }
 
     return true;

--- a/packages/teleport/src/Console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/Console/useOnExitConfirmation.ts
@@ -66,11 +66,8 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
   /**
    * confirmCloseSession prompts user to confirm to close.
    */
-  function confirmCloseSession(doc) {
-    if (!doc || !doc.sid) return false;
-
-    const numUsers = ctx.storeParties.state[doc.sid];
-    if (numUsers.length > 1) {
+  function confirmCloseSession(participants: number) {
+    if (participants > 1) {
       return window.confirm('Are you sure you want to leave this session?');
     }
 
@@ -98,11 +95,18 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
    * verifyAndConfirm verifies the document is of type terminal,
    * and based on how long it was active for, prompts users to confirm closing.
    *
+   * A return value of true either means, user has confirmed or confirmation
+   * is not required.
+   *
    * @param doc the document in context
    */
   function verifyAndConfirm(doc: stores.Document) {
     if (hasLastingSshConnection(doc)) {
-      return confirmCloseSession(doc);
+      const sid = (doc as stores.DocumentSsh).sid;
+      const participants = ctx.storeParties.state[sid];
+      if (participants) {
+        return confirmCloseSession(participants.length);
+      }
     }
 
     return true;

--- a/packages/teleport/src/lib/term/terminal.js
+++ b/packages/teleport/src/lib/term/terminal.js
@@ -68,7 +68,10 @@ class TtyTerminal {
     this.tty.on(TermEventEnum.RESET, this.reset.bind(this));
     this.tty.on(TermEventEnum.CONN_CLOSE, this._processClose.bind(this));
     this.tty.on(TermEventEnum.DATA, this._processData.bind(this));
-    this.tty.on(TermEventEnum.U2F_CHALLENGE, this._processU2FChallenge.bind(this));
+    this.tty.on(
+      TermEventEnum.U2F_CHALLENGE,
+      this._processU2FChallenge.bind(this)
+    );
 
     // subscribe tty resize event (used by session player)
     this.tty.on(TermEventEnum.RESIZE, ({ h, w }) => this.resize(w, h));
@@ -181,12 +184,23 @@ class TtyTerminal {
 
   _processU2FChallenge(payload) {
     if (!window.u2f) {
-      const termMsg = 'This browser does not support U2F required for hardware tokens, please try Chrome or Firefox instead.';
+      const termMsg =
+        'This browser does not support U2F required for hardware tokens, please try Chrome or Firefox instead.';
       this.term.write(`\x1b[31m${termMsg}\x1b[m\r\n`);
       return;
     }
+
     const data = JSON.parse(payload);
-    window.u2f.sign(data.appId, data.challenge, data.u2f_challenges, this._processU2FResponse.bind(this));
+    window.u2f.sign(
+      data.appId,
+      data.challenge,
+      data.u2f_challenges,
+      this._processU2FResponse.bind(this)
+    );
+
+    const actionMsg =
+      'Authentication is required. Tap any *registered* security key.';
+    this.term.write(`\x1b[37m${actionMsg}\x1b[m\r\n`);
   }
 
   _processU2FResponse(res) {

--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -118,8 +118,12 @@ const auth = {
   },
 
   changePasswordWithU2f(oldPass, newPass) {
+    const err = this.u2fBrowserSupported();
+    if (err) {
+      return Promise.reject(err);
+    }
+
     const data = {
-      user: name,
       pass: oldPass,
     };
 


### PR DESCRIPTION
fixes https://github.com/gravitational/webapps/issues/250
fixes https://github.com/gravitational/teleport/issues/6156
fixes https://github.com/gravitational/teleport/issues/6139

#### Description
- Removed special styling to mfa dropdown
- FormPassword now checks for auth2faTypes on and optional
  - Place a check for `window.u2f` being null for safari
- Prompt user to tap their u2f key when connecting to a node with require_session_mfa turned on
- useOnExitConfrimation checks if there is any participants before accessing length
- Update e-ref

#### Test
firefox worked as same as before

safari:

`require_session_mfa` turned on
![image](https://user-images.githubusercontent.com/43280172/112676859-368c5500-8e26-11eb-9fc6-713b3fb528a0.png)

`auth2faType` set to on or optional
![image](https://user-images.githubusercontent.com/43280172/112676870-3be99f80-8e26-11eb-8a88-555e61a8cd15.png)

chrome:
![image](https://user-images.githubusercontent.com/43280172/112677025-70f5f200-8e26-11eb-90b2-c42e91bc805e.png)
