### PR TITLE
Update renew session response and renew URL

### DIFF
--- a/packages/shared/hooks/useAttemptNext.ts
+++ b/packages/shared/hooks/useAttemptNext.ts
@@ -57,3 +57,5 @@ export type Attempt = {
 };
 
 type Callback = (fn?: any) => Promise<any>;
+
+export type State = ReturnType<typeof useAttemptNext>;

--- a/packages/teleport/src/Console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/Console/useOnExitConfirmation.ts
@@ -17,7 +17,7 @@
 import React from 'react';
 import ConsoleContext from './consoleContext';
 import * as stores from './stores/types';
-import session from 'teleport/services/session';
+import session, { forceReload } from 'teleport/services/session';
 
 // TAB_MIN_AGE defines "active terminal" session in ms
 const TAB_MIN_AGE = 30000;
@@ -38,10 +38,11 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
      * of document opened and how long it has been active for.
      */
     const handleBeforeunload = event => {
-      // Do not ask for confirmation when session is expired, which may trigger prompt
+      // Do not ask for confirmation when forcing refresh or when
+      // session is expired, which may trigger prompt
       // when browser triggers page reload before it receives session.end event,
       // which is not guaranteed to happen in that order.
-      if (!session.isValid()) {
+      if (!session.isValid() || forceReload) {
         return;
       }
 

--- a/packages/teleport/src/Console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/Console/useOnExitConfirmation.ts
@@ -17,7 +17,7 @@
 import React from 'react';
 import ConsoleContext from './consoleContext';
 import * as stores from './stores/types';
-import session, { forceReload } from 'teleport/services/session';
+import session from 'teleport/services/session';
 
 // TAB_MIN_AGE defines "active terminal" session in ms
 const TAB_MIN_AGE = 30000;
@@ -38,11 +38,10 @@ function useOnExitConfirmation(ctx: ConsoleContext) {
      * of document opened and how long it has been active for.
      */
     const handleBeforeunload = event => {
-      // Do not ask for confirmation when forcing refresh or when
-      // session is expired, which may trigger prompt
+      // Do not ask for confirmation when session is expired, which may trigger prompt
       // when browser triggers page reload before it receives session.end event,
       // which is not guaranteed to happen in that order.
-      if (!session.isValid() || forceReload) {
+      if (!session.isValid()) {
         return;
       }
 

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -90,7 +90,7 @@ export const StyledMain = styled.div`
   display: flex;
   flex: 1;
   position: absolute;
-  min-width: 900px;
+  min-width: 1000px;
 `;
 
 const HorizontalSplit = styled.div`
@@ -98,6 +98,9 @@ const HorizontalSplit = styled.div`
   flex-direction: column;
   width: 100%;
   height: 100%;
+
+  // Allows shrinking beyond content size on flexed childrens.
+  min-width: 0;
 `;
 
 const StyledIndicator = styled(HorizontalSplit)`

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -73,18 +73,18 @@ export function Main(props: State) {
       <RouterDOM.Switch>
         <Redirect exact={true} from={cfg.routes.root} to={indexRoute} />
       </RouterDOM.Switch>
-      <VerticalSplit className="teleport-main">
+      <StyledMain>
         <SideNav />
         <HorizontalSplit>
           <TopBar />
           <Switch>{$features}</Switch>
         </HorizontalSplit>
-      </VerticalSplit>
+      </StyledMain>
     </>
   );
 }
 
-const VerticalSplit = styled.div`
+export const StyledMain = styled.div`
   width: 100%;
   height: 100%;
   display: flex;

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -73,7 +73,7 @@ export function Main(props: State) {
       <RouterDOM.Switch>
         <Redirect exact={true} from={cfg.routes.root} to={indexRoute} />
       </RouterDOM.Switch>
-      <VerticalSplit>
+      <VerticalSplit className="teleport-main">
         <SideNav />
         <HorizontalSplit>
           <TopBar />

--- a/packages/teleport/src/Main/index.ts
+++ b/packages/teleport/src/Main/index.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { hot } from 'react-hot-loader/root';
-import Main from './Main';
+import Main, { StyledMain } from './Main';
 
+export { StyledMain };
 export default hot(Main);

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -81,7 +81,7 @@ const cfg = {
     clusterEventsPath: `/v1/webapi/sites/:clusterId/events/search?from=:start?&to=:end?&limit=:limit?`,
     scp:
       '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
-    renewTokenPath: '/v1/webapi/sessions/renew/:requestId?',
+    renewTokenPath: '/v1/webapi/sessions/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
     sessionPath: '/v1/webapi/sessions',
     userContextPath: '/v1/webapi/sites/:clusterId/context',
@@ -266,8 +266,8 @@ const cfg = {
     });
   },
 
-  getRenewTokenUrl(requestId?: string) {
-    return generatePath(cfg.api.renewTokenPath, { requestId });
+  getRenewTokenUrl() {
+    return cfg.api.renewTokenPath;
   },
 
   getGithubConnectorsUrl(name?: string) {

--- a/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/packages/teleport/src/services/localStorage/localStorage.ts
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BearerToken, KeysEnum } from './types';
+import { BearerToken } from 'teleport/services/session';
+import { KeysEnum } from './types';
 
 const storage = {
   clear() {

--- a/packages/teleport/src/services/localStorage/types.ts
+++ b/packages/teleport/src/services/localStorage/types.ts
@@ -19,15 +19,3 @@ export const KeysEnum = {
   TOKEN_RENEW: 'grv_teleport_token_renew',
   RELOAD_TABS: 'grv_reload_tabs',
 };
-
-export class BearerToken {
-  accessToken: string;
-  expiresIn: string;
-  created: number;
-
-  constructor(json) {
-    this.accessToken = json.token;
-    this.expiresIn = json.expires_in;
-    this.created = new Date().getTime();
-  }
-}

--- a/packages/teleport/src/services/localStorage/types.ts
+++ b/packages/teleport/src/services/localStorage/types.ts
@@ -17,6 +17,7 @@ limitations under the License.
 export const KeysEnum = {
   TOKEN: 'grv_teleport_token',
   TOKEN_RENEW: 'grv_teleport_token_renew',
+  RELOAD_TABS: 'grv_reload_tabs',
 };
 
 export class BearerToken {

--- a/packages/teleport/src/services/session/index.ts
+++ b/packages/teleport/src/services/session/index.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import session, { forceReload } from './session';
+import session from './session';
 
-export { forceReload };
 export * from './types';
 export default session;

--- a/packages/teleport/src/services/session/index.ts
+++ b/packages/teleport/src/services/session/index.ts
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-import session from './session';
+import session, { forceReload } from './session';
+
+export { forceReload };
+export * from './types';
 export default session;

--- a/packages/teleport/src/services/session/makeSession.ts
+++ b/packages/teleport/src/services/session/makeSession.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2021 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Session, BearerToken } from './types';
+
+export function makeSession(json: any): Session {
+  return {
+    token: makeBearerToken(json),
+    expires: json.sessionExpires,
+  };
+}
+
+export function makeBearerToken(json: any): BearerToken {
+  return {
+    accessToken: json.token,
+    expiresIn: json.expires_in,
+    created: new Date().getTime(),
+  };
+}

--- a/packages/teleport/src/services/session/session.ts
+++ b/packages/teleport/src/services/session/session.ts
@@ -30,10 +30,6 @@ const logger = Logger.create('services/session');
 
 let sesstionCheckerTimerId = null;
 
-// forceReload is a global flag used to prevent beforeunload
-// event listeners from stopping a page reload (ie: terminal).
-export let forceReload = false;
-
 const session = {
   logout() {
     api.delete(cfg.api.sessionPath).finally(() => {
@@ -75,14 +71,6 @@ const session = {
   // absolute time the new session expires.
   renewSession(req: RenewSessionRequest): Promise<Date> {
     return this._renewToken(req);
-  },
-
-  // reload triggers reloads on all opened tabs to apply new permissions.
-  // Triggers when user switches back to their default roles,
-  // or when assuming roles.
-  reload() {
-    localStorage.broadcast(KeysEnum.RELOAD_TABS, 'reload');
-    history.reload();
   },
 
   isValid() {
@@ -225,12 +213,6 @@ const session = {
 
 function receiveMessage(event) {
   const { key, newValue } = event;
-
-  // check if page reload was triggered from another tab.
-  if (key === KeysEnum.RELOAD_TABS && newValue) {
-    forceReload = true;
-    history.reload();
-  }
 
   // check if logout was triggered from other tabs
   if (localStorage.getBearerToken() === null) {

--- a/packages/teleport/src/services/session/types.ts
+++ b/packages/teleport/src/services/session/types.ts
@@ -1,0 +1,4 @@
+export type RenewSessionRequest = {
+  requestId?: string;
+  switchback?: boolean;
+};

--- a/packages/teleport/src/services/session/types.ts
+++ b/packages/teleport/src/services/session/types.ts
@@ -2,3 +2,14 @@ export type RenewSessionRequest = {
   requestId?: string;
   switchback?: boolean;
 };
+
+export type BearerToken = {
+  accessToken: string;
+  expiresIn: string;
+  created: number;
+};
+
+export type Session = {
+  token: BearerToken;
+  expires: Date;
+};


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/4937

#### Description
- Renew session endpoint now returns a new field `sessionExpires`. This is the absolute time the web session will expire for the most recently consumed access request. This is the value used in the switchback countdown
- Refactored how bearer token is being set

~~- Added local storage reload broadcaster to be able to reload opened tabs after user assumes a role or switches back to their default roles. This will be important when user switches back from higher privilege to lower privilege especially when they are connected to a node.~~
~~- Added ability to force reload to prevent confirmation pages (terminal) from reloading tabs~~