### PR TITLE
Fix not being able to filter nodes by searching exact label

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,24 +118,42 @@ and iterate on shared functionality.
 
 ```js
 
-// Autoformat on save
-"editor.formatOnSave": false,
-
-// Specify prettier configuration file
-"prettier.configPath": ".prettierrc",
-
-"[javascript]": {
-    "editor.formatOnSave": true
-},
-
-"[javascriptreact]": {
+    // Set the default
+    "editor.formatOnSave": false,
+    // absolute config path
+    "prettier.configPath": ".prettierrc",
+    // enable per-language
+    "[html]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascript]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascriptreact]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
+    "[typescript]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
+    "[json]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "[jsonc]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "[markdown]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
     "editor.tabSize": 2,
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-},
-
-"[html]": {
-    "editor.tabSize": 2,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-}
 ```

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import DocumentNodes from './DocumentNodes';
 import ConsoleCtx from './../consoleContext';
 import { TestLayout } from './../Console.story';
+import {Node} from "teleport/services/nodes/types"
 
 export default {
   title: 'Teleport/Console/DocumentNodes',
@@ -90,7 +91,7 @@ const clusters = [
   },
 ];
 
-const nodes = [
+const nodes: Node[] = [
   {
     tunnel: false,
     id: '104',

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import DocumentNodes from './DocumentNodes';
 import ConsoleCtx from './../consoleContext';
 import { TestLayout } from './../Console.story';
-import {Node} from "teleport/services/nodes/types"
+import { Node } from 'teleport/services/nodes/types';
 
 export default {
   title: 'Teleport/Console/DocumentNodes',
@@ -98,7 +98,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'fujedu',
     addr: '172.10.1.20:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -106,7 +106,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'facuzguv',
     addr: '172.10.1.42:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: true,
@@ -114,7 +114,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'duzsevkig',
     addr: '172.10.1.156:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: true,
@@ -122,7 +122,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'kuhinur',
     addr: '172.10.1.145:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -130,6 +130,13 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'zebpecda',
     addr: '172.10.1.24:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic", "lortavma: one", "lenisret: 4.15.0-51-generic", "lofdevod: one", "llhurlaz: 4.15.0-51-generic"]
+    tagTexts: [
+      'cluster: one',
+      'kernel: 4.15.0-51-generic',
+      'lortavma: one',
+      'lenisret: 4.15.0-51-generic',
+      'lofdevod: one',
+      'llhurlaz: 4.15.0-51-generic',
+    ],
   },
 ];

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -97,10 +97,7 @@ const nodes = [
     clusterId: 'cluseter-1',
     hostname: 'fujedu',
     addr: '172.10.1.20:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: false,
@@ -108,10 +105,7 @@ const nodes = [
     clusterId: 'cluseter-1',
     hostname: 'facuzguv',
     addr: '172.10.1.42:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: true,
@@ -119,10 +113,7 @@ const nodes = [
     clusterId: 'cluseter-1',
     hostname: 'duzsevkig',
     addr: '172.10.1.156:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: true,
@@ -130,10 +121,7 @@ const nodes = [
     clusterId: 'cluseter-1',
     hostname: 'kuhinur',
     addr: '172.10.1.145:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: false,
@@ -141,13 +129,6 @@ const nodes = [
     clusterId: 'cluseter-1',
     hostname: 'zebpecda',
     addr: '172.10.1.24:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-      { name: 'lortavma', value: 'one' },
-      { name: 'lenisret', value: '4.15.0-51-generic' },
-      { name: 'lofdevod', value: 'one' },
-      { name: 'llhurlaz', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic", "lortavma: one", "lenisret: 4.15.0-51-generic", "lofdevod: one", "llhurlaz: 4.15.0-51-generic"]
   },
 ];

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -98,7 +98,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'fujedu',
     addr: '172.10.1.20:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -106,7 +106,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'facuzguv',
     addr: '172.10.1.42:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: true,
@@ -114,7 +114,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'duzsevkig',
     addr: '172.10.1.156:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: true,
@@ -122,7 +122,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'kuhinur',
     addr: '172.10.1.145:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -130,7 +130,7 @@ const nodes: Node[] = [
     clusterId: 'cluseter-1',
     hostname: 'zebpecda',
     addr: '172.10.1.24:3022',
-    tagTexts: [
+    tags: [
       'cluster: one',
       'kernel: 4.15.0-51-generic',
       'lortavma: one',

--- a/packages/teleport/src/Nodes/fixtures/index.ts
+++ b/packages/teleport/src/Nodes/fixtures/index.ts
@@ -23,7 +23,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'fujedu',
     addr: '172.10.1.20:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -31,7 +31,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'facuzguv',
     addr: '172.10.1.1:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -39,7 +39,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'duzsevkig',
     addr: '172.10.1.1:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -47,7 +47,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'kuhinur',
     addr: '172.10.1.1:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -55,7 +55,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: true,
@@ -63,7 +63,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: true,
@@ -71,7 +71,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
+    tags: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
 ];
 

--- a/packages/teleport/src/Nodes/fixtures/index.ts
+++ b/packages/teleport/src/Nodes/fixtures/index.ts
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export const nodes = [
+import { Node } from 'teleport/services/nodes';
+
+export const nodes: Node[] = [
   {
     tunnel: false,
     id: '104',

--- a/packages/teleport/src/Nodes/fixtures/index.ts
+++ b/packages/teleport/src/Nodes/fixtures/index.ts
@@ -21,10 +21,7 @@ export const nodes = [
     clusterId: 'one',
     hostname: 'fujedu',
     addr: '172.10.1.20:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: false,
@@ -32,10 +29,7 @@ export const nodes = [
     clusterId: 'one',
     hostname: 'facuzguv',
     addr: '172.10.1.1:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: false,
@@ -43,10 +37,7 @@ export const nodes = [
     clusterId: 'one',
     hostname: 'duzsevkig',
     addr: '172.10.1.1:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: false,
@@ -54,10 +45,7 @@ export const nodes = [
     clusterId: 'one',
     hostname: 'kuhinur',
     addr: '172.10.1.1:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: false,
@@ -65,10 +53,7 @@ export const nodes = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: true,
@@ -76,10 +61,7 @@ export const nodes = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
   {
     tunnel: true,
@@ -87,10 +69,7 @@ export const nodes = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tags: [
-      { name: 'cluster', value: 'one' },
-      { name: 'kernel', value: '4.15.0-51-generic' },
-    ],
+    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
   },
 ];
 

--- a/packages/teleport/src/Nodes/fixtures/index.ts
+++ b/packages/teleport/src/Nodes/fixtures/index.ts
@@ -23,7 +23,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'fujedu',
     addr: '172.10.1.20:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -31,7 +31,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'facuzguv',
     addr: '172.10.1.1:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -39,7 +39,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'duzsevkig',
     addr: '172.10.1.1:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -47,7 +47,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'kuhinur',
     addr: '172.10.1.1:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: false,
@@ -55,7 +55,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: true,
@@ -63,7 +63,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
   {
     tunnel: true,
@@ -71,7 +71,7 @@ export const nodes: Node[] = [
     clusterId: 'one',
     hostname: 'zebpecda',
     addr: '172.10.1.1:3022',
-    tagTexts: ["cluster: one", "kernel: 4.15.0-51-generic"]
+    tagTexts: ['cluster: one', 'kernel: 4.15.0-51-generic'],
   },
 ];
 

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -45,7 +45,7 @@ function NodeList(props: Props) {
   function sortAndFilter(search) {
     const filtered = nodes.filter(obj =>
       isMatch(obj, search, {
-        searchableProps: ['hostname', 'addr', 'tagTexts', 'tunnel'],
+        searchableProps: ['hostname', 'addr', 'tags', 'tunnel'],
         cb: searchAndFilterCb,
       })
     );
@@ -109,7 +109,7 @@ function searchAndFilterCb(
     return 'TUNNEL'.indexOf(searchValue) !== -1;
   }
 
-  if (propName === 'tagTexts') {
+  if (propName === 'tags') {
     return targetValue.some(item => {
       return item.toLocaleUpperCase().indexOf(searchValue) !== -1;
     });
@@ -156,8 +156,8 @@ const LoginCell: React.FC<Required<{
 
 export function LabelCell(props) {
   const { rowIndex, data } = props;
-  const { tagTexts } = data[rowIndex];
-  const $labels = tagTexts.map(label => (
+  const { tags } = data[rowIndex];
+  const $labels = tags.map(label => (
     <Label mb="1" mr="1" key={label} kind="secondary">
       {`${label}`}
     </Label>

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -105,7 +105,6 @@ function searchAndFilterCb(
   searchValue: string,
   propName: string
 ) {
-
   if (propName === 'tunnel') {
     return 'TUNNEL'.indexOf(searchValue) !== -1;
   }
@@ -113,7 +112,7 @@ function searchAndFilterCb(
   if (propName === 'tagTexts') {
     return targetValue.some(item => {
       return item.toLocaleUpperCase().indexOf(searchValue) !== -1;
-    })
+    });
   }
 }
 

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -45,7 +45,7 @@ function NodeList(props: Props) {
   function sortAndFilter(search) {
     const filtered = nodes.filter(obj =>
       isMatch(obj, search, {
-        searchableProps: ['hostname', 'addr', 'tags', 'tunnel'],
+        searchableProps: ['hostname', 'addr', 'tagTexts', 'tunnel'],
         cb: searchAndFilterCb,
       })
     );
@@ -105,18 +105,15 @@ function searchAndFilterCb(
   searchValue: string,
   propName: string
 ) {
+
   if (propName === 'tunnel') {
     return 'TUNNEL'.indexOf(searchValue) !== -1;
   }
 
-  if (propName === 'tags') {
+  if (propName === 'tagTexts') {
     return targetValue.some(item => {
-      const { name, value } = item;
-      return (
-        name.toLocaleUpperCase().indexOf(searchValue) !== -1 ||
-        value.toLocaleUpperCase().indexOf(searchValue) !== -1
-      );
-    });
+      return item.toLocaleUpperCase().indexOf(searchValue) !== -1;
+    })
   }
 }
 
@@ -160,10 +157,10 @@ const LoginCell: React.FC<Required<{
 
 export function LabelCell(props) {
   const { rowIndex, data } = props;
-  const { tags } = data[rowIndex];
-  const $labels = tags.map(({ name, value }) => (
-    <Label mb="1" mr="1" key={name} kind="secondary">
-      {`${name}: ${value}`}
+  const { tagTexts } = data[rowIndex];
+  const $labels = tagTexts.map(label => (
+    <Label mb="1" mr="1" key={label} kind="secondary">
+      {`${label}`}
     </Label>
   ));
 

--- a/packages/teleport/src/services/nodes/makeNode.ts
+++ b/packages/teleport/src/services/nodes/makeNode.ts
@@ -18,11 +18,11 @@ import { at } from 'lodash';
 import { Node } from './types';
 
 export default function makeNode(json): Node {
-  const [id, clusterId, hostname, tags = [], addr, tunnel = false] = at(json, [
+  const [id, clusterId, hostname, tagTexts = json.tags.map(tag => `${tag.name}: ${tag.value}`), addr, tunnel = false] = at(json, [
     'id',
     'siteId',
     'hostname',
-    'tags',
+    'tagTexts',
     'addr',
     'tunnel',
   ]);
@@ -31,7 +31,7 @@ export default function makeNode(json): Node {
     id,
     clusterId,
     hostname,
-    tags,
+    tagTexts,
     addr,
     tunnel,
   };

--- a/packages/teleport/src/services/nodes/makeNode.ts
+++ b/packages/teleport/src/services/nodes/makeNode.ts
@@ -17,9 +17,9 @@ limitations under the License.
 import { Node } from './types';
 
 export default function makeNode(json): Node {
-  const {id, clusterId, hostname, addr, tunnel, tags = [] } = json;
+  const { id, clusterId, hostname, addr, tunnel, tags = [] } = json;
 
-  const tagTexts = tags.map(tag => `${tag.name}: ${tag.value}`)
+  const tagTexts = tags.map(tag => `${tag.name}: ${tag.value}`);
 
   return {
     id,
@@ -28,5 +28,5 @@ export default function makeNode(json): Node {
     tagTexts,
     addr,
     tunnel,
-  }
+  };
 }

--- a/packages/teleport/src/services/nodes/makeNode.ts
+++ b/packages/teleport/src/services/nodes/makeNode.ts
@@ -14,18 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { at } from 'lodash';
 import { Node } from './types';
 
 export default function makeNode(json): Node {
-  const [id, clusterId, hostname, tagTexts = json.tags.map(tag => `${tag.name}: ${tag.value}`), addr, tunnel = false] = at(json, [
-    'id',
-    'siteId',
-    'hostname',
-    'tagTexts',
-    'addr',
-    'tunnel',
-  ]);
+  const {id, clusterId, hostname, addr, tunnel} = json;
+
+  const tags = json.tags || [];
+  const tagTexts = json.tagTexts || tags.map(tag => `${tag.name}: ${tag.value}`)
 
   return {
     id,
@@ -34,5 +29,5 @@ export default function makeNode(json): Node {
     tagTexts,
     addr,
     tunnel,
-  };
+  }
 }

--- a/packages/teleport/src/services/nodes/makeNode.ts
+++ b/packages/teleport/src/services/nodes/makeNode.ts
@@ -19,13 +19,11 @@ import { Node } from './types';
 export default function makeNode(json): Node {
   const { id, clusterId, hostname, addr, tunnel, tags = [] } = json;
 
-  const tagTexts = tags.map(tag => `${tag.name}: ${tag.value}`);
-
   return {
     id,
     clusterId,
     hostname,
-    tagTexts,
+    tags: tags.map(tag => `${tag.name}: ${tag.value}`),
     addr,
     tunnel,
   };

--- a/packages/teleport/src/services/nodes/makeNode.ts
+++ b/packages/teleport/src/services/nodes/makeNode.ts
@@ -17,10 +17,9 @@ limitations under the License.
 import { Node } from './types';
 
 export default function makeNode(json): Node {
-  const {id, clusterId, hostname, addr, tunnel} = json;
+  const {id, clusterId, hostname, addr, tunnel, tags = [] } = json;
 
-  const tags = json.tags || [];
-  const tagTexts = json.tagTexts || tags.map(tag => `${tag.name}: ${tag.value}`)
+  const tagTexts = tags.map(tag => `${tag.name}: ${tag.value}`)
 
   return {
     id,

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 export interface Node {
   id: string;
   clusterId: string;

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -14,16 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export interface Tag {
-  name: string;
-  value: string;
-}
 
 export interface Node {
   id: string;
   clusterId: string;
   hostname: string;
-  tags: Tag[];
+  tagTexts: string[];
   addr: string;
   tunnel: boolean;
 }

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -18,7 +18,7 @@ export interface Node {
   id: string;
   clusterId: string;
   hostname: string;
-  tagTexts: string[];
+  tags: string[];
   addr: string;
   tunnel: boolean;
 }


### PR DESCRIPTION
### Purpose

This PR addresses #268 

Users should be able to search through nodes by typing in the exact label/tag in the search bar. (eg. typing `arch: x86_64` in the search bar should return all nodes with `arch: x86_64` in its table column).

### Implementation

Instead of each node storing its labels as an array of objects (eg. `[{name: value}]`), it now stores them as an array of strings (eg. `["name: value"]`). This makes it possible for the labels to be directly compared against the string entered in the search bar, allowing for better and more predictable results when searching.

### Demo

![demo-search](https://user-images.githubusercontent.com/56373201/115791561-a09d0900-a396-11eb-9323-d07e051fcff0.gif)

