### PR TITLE
Add database table attempt states (Success, Loading, Failed)

### DIFF
--- a/packages/teleport/src/Databases/Databases.story.test.tsx
+++ b/packages/teleport/src/Databases/Databases.story.test.tsx
@@ -16,9 +16,14 @@ limitations under the License.
 
 import React from 'react';
 import { render } from 'design/utils/testing';
-import { Loaded } from './Databases.story';
+import { Loaded, Failed } from './Databases.story';
 
 test('loaded', () => {
   const { container } = render(<Loaded />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('failed', () => {
+  const { container } = render(<Failed />);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/packages/teleport/src/Databases/Databases.story.tsx
+++ b/packages/teleport/src/Databases/Databases.story.tsx
@@ -18,8 +18,28 @@ import React from 'react';
 import Databases from './Databases';
 import { databases } from './fixtures';
 
-export const Loaded = () => <Databases databases={databases} />;
+type PropTypes = Parameters<typeof Databases>[0];
+
+export const Loaded = () => render({ status: 'success' });
+
+export const Loading = () => render({ status: 'processing' });
+
+export const Failed = () =>
+  render({ status: 'failed', statusText: 'Server Error' });
 
 export default {
   title: 'Teleport/Databases',
 };
+
+function render(attemptOptions: Partial<PropTypes['attempt']>) {
+  const props = {
+    databases,
+    attempt: {
+      status: '' as any,
+      statusText: '',
+      ...attemptOptions,
+    },
+  };
+
+  return <Databases {...props} />;
+}

--- a/packages/teleport/src/Databases/Databases.story.tsx
+++ b/packages/teleport/src/Databases/Databases.story.tsx
@@ -18,28 +18,21 @@ import React from 'react';
 import Databases from './Databases';
 import { databases } from './fixtures';
 
-type PropTypes = Parameters<typeof Databases>[0];
+export const Loaded = () => (
+  <Databases databases={databases} attempt={{ status: 'success' }} />
+);
 
-export const Loaded = () => render({ status: 'success' });
+export const Loading = () => (
+  <Databases databases={databases} attempt={{ status: 'processing' }} />
+);
 
-export const Loading = () => render({ status: 'processing' });
-
-export const Failed = () =>
-  render({ status: 'failed', statusText: 'Server Error' });
+export const Failed = () => (
+  <Databases
+    databases={databases}
+    attempt={{ status: 'failed', statusText: 'Server Error' }}
+  />
+);
 
 export default {
   title: 'Teleport/Databases',
 };
-
-function render(attemptOptions: Partial<PropTypes['attempt']>) {
-  const props = {
-    databases,
-    attempt: {
-      status: '' as any,
-      statusText: '',
-      ...attemptOptions,
-    },
-  };
-
-  return <Databases {...props} />;
-}

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 import React from 'react';
+import { Indicator, Box } from 'design';
+import { Danger } from 'design/Alert';
 import {
   FeatureBox,
   FeatureHeader,
@@ -22,20 +24,28 @@ import {
 } from 'teleport/components/Layout';
 import DatabaseList from 'teleport/components/DatabaseList';
 import { Database } from 'teleport/services/database';
+import { Attempt } from 'shared/hooks/useAttemptNext';
 
 export default function Databases(props: Props) {
-  const { databases } = props;
+  const { databases, attempt } = props;
 
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Databases</FeatureHeaderTitle>
       </FeatureHeader>
-      <DatabaseList databases={databases} />
+      {attempt.status === 'processing' && (
+        <Box textAlign="center" m={10}>
+          <Indicator />
+        </Box>
+      )}
+      {attempt.status === 'failed' && <Danger>{attempt.statusText} </Danger>}
+      {attempt.status === 'success' && <DatabaseList databases={databases} />}
     </FeatureBox>
   );
 }
 
 type Props = {
   databases: Database[];
+  attempt: Attempt;
 };

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -39,7 +39,7 @@ export default function Databases(props: Props) {
           <Indicator />
         </Box>
       )}
-      {attempt.status === 'failed' && <Danger>{attempt.statusText} </Danger>}
+      {attempt.status === 'failed' && <Danger>{attempt.statusText}</Danger>}
       {attempt.status === 'success' && <DatabaseList databases={databases} />}
     </FeatureBox>
   );

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -1,5 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`failed 1`] = `
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  box-sizing: border-box;
+  box-shadow: 0 1px 4px rgba(0,0,0,.24);
+  margin: 0 0 24px 0;
+  min-height: 40px;
+  padding: 8px 16px;
+  overflow: auto;
+  word-break: break-all;
+  line-height: 1.5;
+  background: #f50057;
+  color: #FFFFFF;
+}
+
+.c3 a {
+  color: #FFFFFF;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+<div
+  class="sc-AxirZ sc-fzqBZW c0"
+>
+  <div
+    class="sc-AxirZ sc-fzqBZW c1"
+  >
+    <div
+      class="sc-fznZeY c2"
+    >
+      Databases
+    </div>
+  </div>
+  <div
+    class="c3"
+    kind="danger"
+  >
+    Server Error
+     
+  </div>
+</div>
+`;
+
 exports[`loaded 1`] = `
 .c9 {
   display: inline-block;


### PR DESCRIPTION
### Purpose

This PR resolves #270 

Add attempt states for the Database table. If the state is `Success`, display the list of databases. If the state is `Loading`, display  an animated loading indicator. If the state is `Failed` display an alert box with the error message. Add snapshot for `Failed` state.

### Implementation

Use prop `attempt` to contain information about the attempt (eg. status, statusText). When rendering the `Databases`, render the appropriate UI based on the `attempt.state`. Create a snapshot test for `Failed` state.

### Demo

#### Loaded State

![successState](https://user-images.githubusercontent.com/56373201/116157433-f89b7e80-a6ba-11eb-866b-de9041b49283.png)

#### Loading State

![loadingState](https://user-images.githubusercontent.com/56373201/116157449-005b2300-a6bb-11eb-972a-9b807cd923d3.png)

#### Failed State

![failedState](https://user-images.githubusercontent.com/56373201/116157467-06510400-a6bb-11eb-97a9-4d1db6ccb588.png)


