### PR TITLE
Create useDatabases hook, container, Register feature and update Main.story

### DIFF
--- a/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
+++ b/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
@@ -29,7 +29,7 @@ import {
 import Table from 'design/DataTable/Paged';
 import isMatch from 'design/utils/match';
 import InputSearch from 'teleport/components/InputSearch';
-import { Database } from 'teleport/services/database';
+import { Database } from 'teleport/services/databases';
 
 function DatabaseList(props: Props) {
   const { databases = [], pageSize = 20 } = props;

--- a/packages/teleport/src/Databases/Databases.story.tsx
+++ b/packages/teleport/src/Databases/Databases.story.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import Databases from './Databases';
+import { Databases } from './Databases';
 import { databases } from './fixtures';
 
 export const Loaded = () => (

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -34,7 +34,7 @@ export default function Container() {
   return <Databases {...data} />;
 }
 
-export function Databases(props: Props) {
+export function Databases(props: ReturnType<typeof useDatabases>) {
   const { databases, attempt } = props;
 
   return (
@@ -52,8 +52,3 @@ export function Databases(props: Props) {
     </FeatureBox>
   );
 }
-
-type Props = {
-  databases: Database[];
-  attempt: Attempt;
-};

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -17,15 +17,13 @@ limitations under the License.
 import React from 'react';
 import { Indicator, Box } from 'design';
 import { Danger } from 'design/Alert';
+import useTeleport from 'teleport/useTeleport';
 import {
   FeatureBox,
   FeatureHeader,
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
-import useTeleport from 'teleport/useTeleport';
-import { Attempt } from 'shared/hooks/useAttemptNext';
 import DatabaseList from './DatabaseList';
-import { Database } from 'teleport/services/databases';
 import useDatabases from './useDatabases';
 
 export default function Container() {

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -24,7 +24,7 @@ import {
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
 import DatabaseList from './DatabaseList';
-import useDatabases from './useDatabases';
+import useDatabases, { Props } from './useDatabases';
 
 export default function Container() {
   const ctx = useTeleport();
@@ -32,7 +32,7 @@ export default function Container() {
   return <Databases {...data} />;
 }
 
-export function Databases(props: ReturnType<typeof useDatabases>) {
+export function Databases(props: Props) {
   const { databases, attempt } = props;
 
   return (

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -22,13 +22,15 @@ import {
   FeatureHeader,
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
+import useTeleport from 'teleport/useTeleport';
+import { Attempt } from 'shared/hooks/useAttemptNext';
 import DatabaseList from './DatabaseList';
 import { Database } from 'teleport/services/databases';
-import { Attempt } from 'shared/hooks/useAttemptNext';
 import useDatabases from './useDatabases';
 
 export default function Container() {
-  const data = useDatabases();
+  const ctx = useTeleport();
+  const data = useDatabases(ctx);
   return <Databases {...data} />;
 }
 

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -25,8 +25,14 @@ import {
 import DatabaseList from './DatabaseList';
 import { Database } from 'teleport/services/database';
 import { Attempt } from 'shared/hooks/useAttemptNext';
+import useDatabases from './useDatabases';
 
-export default function Databases(props: Props) {
+export default function Container() {
+  const data = useDatabases();
+  return <Databases {...data} />;
+}
+
+export function Databases(props: Props) {
   const { databases, attempt } = props;
 
   return (

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -23,7 +23,7 @@ import {
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
 import DatabaseList from './DatabaseList';
-import { Database } from 'teleport/services/database';
+import { Database } from 'teleport/services/databases';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 import useDatabases from './useDatabases';
 

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -1,25 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`failed 1`] = `
+exports[`enterprise can create loaded 1`] = `
 .c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 2px;
-  box-sizing: border-box;
-  box-shadow: 0 1px 4px rgba(0,0,0,.24);
-  margin: 0 0 24px 0;
-  min-height: 40px;
-  padding: 8px 16px;
-  overflow: auto;
-  word-break: break-all;
   line-height: 1.5;
-  background: #f50057;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c13 {
+  display: inline-block;
+  transition: color .3s;
   color: #FFFFFF;
 }
 
-.c3 a {
+.c14 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
   color: #FFFFFF;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .c1 {
@@ -63,28 +136,363 @@ exports[`failed 1`] = `
   padding-bottom: 24px;
 }
 
+.c11 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  border-radius: 8px;
+  font-size: 12px;
+  width: 100%;
+}
+
+.c11 > thead > tr > th,
+.c11 > tbody > tr > th,
+.c11 > tfoot > tr > th,
+.c11 > thead > tr > td,
+.c11 > tbody > tr > td,
+.c11 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c11 > thead > tr > th:first-child,
+.c11 > tbody > tr > th:first-child,
+.c11 > tfoot > tr > th:first-child,
+.c11 > thead > tr > td:first-child,
+.c11 > tbody > tr > td:first-child,
+.c11 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c11 > thead > tr > th:last-child,
+.c11 > tbody > tr > th:last-child,
+.c11 > tfoot > tr > th:last-child,
+.c11 > thead > tr > td:last-child,
+.c11 > tbody > tr > td:last-child,
+.c11 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c11 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c11 > thead > tr > th .c9 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c11 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c11 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c11 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c11 tbody > tr:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c11 tbody > tr:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c8 button {
+  background: none;
+  border: none;
+  border-radius: 200px;
+  cursor: pointer;
+  padding: 0;
+  margin: 0 0 0 8px;
+  outline: none;
+  transition: all 0.3s;
+  text-align: center;
+}
+
+.c8 button:hover,
+.c8 button:focus {
+  background: #1C254D;
+}
+
+.c8 button:hover .c9,
+.c8 button:focus .c9 {
+  opacity: 1;
+}
+
+.c8 button .c9 {
+  opacity: 0.4;
+  font-size: 20px;
+  transition: all 0.3s;
+}
+
+.c6 {
+  padding: 8px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c5 {
+  box-sizing: border-box;
+  font-size: 12px;
+  min-width: 200px;
+  outline: none;
+  border: none;
+  border-radius: 200px;
+  height: 32px;
+  transition: all .2s;
+  background: #222C59;
+  margin-right: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+}
+
+.c5:hover {
+  background: #2C3A73;
+}
+
+.c5:focus,
+.c5:active {
+  background: #2C3A73;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c5::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+.c12 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 <div
-  class="sc-AxirZ sc-fzqBZW c0"
+  class="sc-AxirZ c0"
 >
   <div
-    class="sc-AxirZ sc-fzqBZW c1"
+    class="sc-AxirZ c1"
   >
     <div
-      class="sc-fznZeY c2"
+      class="c2"
     >
       Databases
     </div>
+    <button
+      class="c3"
+      kind="primary"
+      title="Add a database to the root cluster"
+      width="240px"
+    >
+      Add Database
+    </button>
   </div>
   <div
-    class="c3"
-    kind="danger"
+    class="sc-AxirZ c4"
   >
-    Server Error
+    <input
+      class="c5"
+      color="text.primary"
+      placeholder="SEARCH..."
+      value=""
+    />
+  </div>
+  <div>
+    <nav
+      class="c6"
+    >
+      <div
+        class="c7"
+        color="primary.contrastText"
+      >
+        SHOWING 
+        <strong>
+          1
+        </strong>
+         - 
+        <strong>
+          3
+        </strong>
+         
+        of 
+        <strong>
+          3
+        </strong>
+      </div>
+      <div
+        class="sc-AxirZ c8"
+      >
+        <button
+          disabled=""
+          title="Previous Page"
+        >
+          <span
+            class="c9 c10 icon icon-arrow-left-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+        <button
+          disabled=""
+          title="Next Page"
+        >
+          <span
+            class="c9 c10 icon icon-arrow-right-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+      </div>
+    </nav>
+    <table
+      class="c11 c12"
+    >
+      <thead>
+        <tr>
+          <th>
+            <a>
+              Name
+              <span
+                class="c9 c13 icon icon-chevron-down "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            <a>
+              Description
+              <span
+                class="c9 c13 icon icon-chevrons-expand-vertical "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            <a>
+              Type
+              <span
+                class="c9 c13 icon icon-chevrons-expand-vertical "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            Labels
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            aurora
+          </td>
+          <td>
+            PostgreSQL 11.6: AWS Aurora 
+          </td>
+          <td>
+            RDS PostgreSQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: root
+            </div>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              env: aws
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            mysql-aurora-56
+          </td>
+          <td>
+            MySQL 5.6: AWS Aurora Longname For SQL
+          </td>
+          <td>
+            Self-hosted MySQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: root
+            </div>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              env: aws
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            postgres-gcp
+          </td>
+          <td>
+            MPostgreSQL 9.6: Google Cloud SQL
+          </td>
+          <td>
+            Cloud SQL PostgreSQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: env
+            </div>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              value: gcp
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
 
-exports[`loaded 1`] = `
+exports[`enterprise cant create loaded 1`] = `
 .c9 {
   display: inline-block;
   transition: color .3s;
@@ -511,6 +919,1132 @@ exports[`loaded 1`] = `
             </div>
             <div
               class="c13"
+              kind="secondary"
+            >
+              value: gcp
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`enterprise leaf cluster loaded 1`] = `
+.c3 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c13 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c14 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  color: #FFFFFF;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+.c11 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  border-radius: 8px;
+  font-size: 12px;
+  width: 100%;
+}
+
+.c11 > thead > tr > th,
+.c11 > tbody > tr > th,
+.c11 > tfoot > tr > th,
+.c11 > thead > tr > td,
+.c11 > tbody > tr > td,
+.c11 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c11 > thead > tr > th:first-child,
+.c11 > tbody > tr > th:first-child,
+.c11 > tfoot > tr > th:first-child,
+.c11 > thead > tr > td:first-child,
+.c11 > tbody > tr > td:first-child,
+.c11 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c11 > thead > tr > th:last-child,
+.c11 > tbody > tr > th:last-child,
+.c11 > tfoot > tr > th:last-child,
+.c11 > thead > tr > td:last-child,
+.c11 > tbody > tr > td:last-child,
+.c11 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c11 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c11 > thead > tr > th .c9 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c11 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c11 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c11 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c11 tbody > tr:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c11 tbody > tr:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c8 button {
+  background: none;
+  border: none;
+  border-radius: 200px;
+  cursor: pointer;
+  padding: 0;
+  margin: 0 0 0 8px;
+  outline: none;
+  transition: all 0.3s;
+  text-align: center;
+}
+
+.c8 button:hover,
+.c8 button:focus {
+  background: #1C254D;
+}
+
+.c8 button:hover .c9,
+.c8 button:focus .c9 {
+  opacity: 1;
+}
+
+.c8 button .c9 {
+  opacity: 0.4;
+  font-size: 20px;
+  transition: all 0.3s;
+}
+
+.c6 {
+  padding: 8px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c5 {
+  box-sizing: border-box;
+  font-size: 12px;
+  min-width: 200px;
+  outline: none;
+  border: none;
+  border-radius: 200px;
+  height: 32px;
+  transition: all .2s;
+  background: #222C59;
+  margin-right: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+}
+
+.c5:hover {
+  background: #2C3A73;
+}
+
+.c5:focus,
+.c5:active {
+  background: #2C3A73;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c5::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+.c12 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+<div
+  class="sc-AxirZ c0"
+>
+  <div
+    class="sc-AxirZ c1"
+  >
+    <div
+      class="c2"
+    >
+      Databases
+    </div>
+    <button
+      class="c3"
+      disabled=""
+      kind="primary"
+      title="Adding a database to a leaf cluster is not supported"
+      width="240px"
+    >
+      Add Database
+    </button>
+  </div>
+  <div
+    class="sc-AxirZ c4"
+  >
+    <input
+      class="c5"
+      color="text.primary"
+      placeholder="SEARCH..."
+      value=""
+    />
+  </div>
+  <div>
+    <nav
+      class="c6"
+    >
+      <div
+        class="c7"
+        color="primary.contrastText"
+      >
+        SHOWING 
+        <strong>
+          1
+        </strong>
+         - 
+        <strong>
+          3
+        </strong>
+         
+        of 
+        <strong>
+          3
+        </strong>
+      </div>
+      <div
+        class="sc-AxirZ c8"
+      >
+        <button
+          disabled=""
+          title="Previous Page"
+        >
+          <span
+            class="c9 c10 icon icon-arrow-left-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+        <button
+          disabled=""
+          title="Next Page"
+        >
+          <span
+            class="c9 c10 icon icon-arrow-right-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+      </div>
+    </nav>
+    <table
+      class="c11 c12"
+    >
+      <thead>
+        <tr>
+          <th>
+            <a>
+              Name
+              <span
+                class="c9 c13 icon icon-chevron-down "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            <a>
+              Description
+              <span
+                class="c9 c13 icon icon-chevrons-expand-vertical "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            <a>
+              Type
+              <span
+                class="c9 c13 icon icon-chevrons-expand-vertical "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            Labels
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            aurora
+          </td>
+          <td>
+            PostgreSQL 11.6: AWS Aurora 
+          </td>
+          <td>
+            RDS PostgreSQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: root
+            </div>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              env: aws
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            mysql-aurora-56
+          </td>
+          <td>
+            MySQL 5.6: AWS Aurora Longname For SQL
+          </td>
+          <td>
+            Self-hosted MySQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: root
+            </div>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              env: aws
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            postgres-gcp
+          </td>
+          <td>
+            MPostgreSQL 9.6: Google Cloud SQL
+          </td>
+          <td>
+            Cloud SQL PostgreSQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: env
+            </div>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              value: gcp
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`failed 1`] = `
+.c4 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  box-sizing: border-box;
+  box-shadow: 0 1px 4px rgba(0,0,0,.24);
+  margin: 0 0 24px 0;
+  min-height: 40px;
+  padding: 8px 16px;
+  overflow: auto;
+  word-break: break-all;
+  line-height: 1.5;
+  background: #f50057;
+  color: #FFFFFF;
+}
+
+.c4 a {
+  color: #FFFFFF;
+}
+
+.c3 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+<div
+  class="sc-AxirZ sc-fzqBZW c0"
+>
+  <div
+    class="sc-AxirZ sc-fzqBZW c1"
+  >
+    <div
+      class="sc-fznZeY c2"
+    >
+      Databases
+    </div>
+    <a
+      class="c3"
+      href="https://goteleport.com/docs/database-access/getting-started/"
+      kind="primary"
+      rel="noreferrer"
+      target="_blank"
+      width="240px"
+    >
+      View Documentation
+    </a>
+  </div>
+  <div
+    class="c4"
+    kind="danger"
+  >
+    Server Error
+  </div>
+</div>
+`;
+
+exports[`open source loaded 1`] = `
+.c3 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c13 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c14 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  color: #FFFFFF;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+.c11 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  border-radius: 8px;
+  font-size: 12px;
+  width: 100%;
+}
+
+.c11 > thead > tr > th,
+.c11 > tbody > tr > th,
+.c11 > tfoot > tr > th,
+.c11 > thead > tr > td,
+.c11 > tbody > tr > td,
+.c11 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c11 > thead > tr > th:first-child,
+.c11 > tbody > tr > th:first-child,
+.c11 > tfoot > tr > th:first-child,
+.c11 > thead > tr > td:first-child,
+.c11 > tbody > tr > td:first-child,
+.c11 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c11 > thead > tr > th:last-child,
+.c11 > tbody > tr > th:last-child,
+.c11 > tfoot > tr > th:last-child,
+.c11 > thead > tr > td:last-child,
+.c11 > tbody > tr > td:last-child,
+.c11 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c11 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c11 > thead > tr > th .c9 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c11 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c11 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c11 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c11 tbody > tr:last-child td:first-child {
+  border-bottom-left-radius: 8px;
+}
+
+.c11 tbody > tr:last-child td:last-child {
+  border-bottom-right-radius: 8px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c8 button {
+  background: none;
+  border: none;
+  border-radius: 200px;
+  cursor: pointer;
+  padding: 0;
+  margin: 0 0 0 8px;
+  outline: none;
+  transition: all 0.3s;
+  text-align: center;
+}
+
+.c8 button:hover,
+.c8 button:focus {
+  background: #1C254D;
+}
+
+.c8 button:hover .c9,
+.c8 button:focus .c9 {
+  opacity: 1;
+}
+
+.c8 button .c9 {
+  opacity: 0.4;
+  font-size: 20px;
+  transition: all 0.3s;
+}
+
+.c6 {
+  padding: 8px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c5 {
+  box-sizing: border-box;
+  font-size: 12px;
+  min-width: 200px;
+  outline: none;
+  border: none;
+  border-radius: 200px;
+  height: 32px;
+  transition: all .2s;
+  background: #222C59;
+  margin-right: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+}
+
+.c5:hover {
+  background: #2C3A73;
+}
+
+.c5:focus,
+.c5:active {
+  background: #2C3A73;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c5::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+.c12 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+<div
+  class="sc-AxirZ c0"
+>
+  <div
+    class="sc-AxirZ c1"
+  >
+    <div
+      class="c2"
+    >
+      Databases
+    </div>
+    <a
+      class="c3"
+      href="https://goteleport.com/docs/database-access/getting-started/"
+      kind="primary"
+      rel="noreferrer"
+      target="_blank"
+      width="240px"
+    >
+      View Documentation
+    </a>
+  </div>
+  <div
+    class="sc-AxirZ c4"
+  >
+    <input
+      class="c5"
+      color="text.primary"
+      placeholder="SEARCH..."
+      value=""
+    />
+  </div>
+  <div>
+    <nav
+      class="c6"
+    >
+      <div
+        class="c7"
+        color="primary.contrastText"
+      >
+        SHOWING 
+        <strong>
+          1
+        </strong>
+         - 
+        <strong>
+          3
+        </strong>
+         
+        of 
+        <strong>
+          3
+        </strong>
+      </div>
+      <div
+        class="sc-AxirZ c8"
+      >
+        <button
+          disabled=""
+          title="Previous Page"
+        >
+          <span
+            class="c9 c10 icon icon-arrow-left-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+        <button
+          disabled=""
+          title="Next Page"
+        >
+          <span
+            class="c9 c10 icon icon-arrow-right-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+      </div>
+    </nav>
+    <table
+      class="c11 c12"
+    >
+      <thead>
+        <tr>
+          <th>
+            <a>
+              Name
+              <span
+                class="c9 c13 icon icon-chevron-down "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            <a>
+              Description
+              <span
+                class="c9 c13 icon icon-chevrons-expand-vertical "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            <a>
+              Type
+              <span
+                class="c9 c13 icon icon-chevrons-expand-vertical "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            Labels
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            aurora
+          </td>
+          <td>
+            PostgreSQL 11.6: AWS Aurora 
+          </td>
+          <td>
+            RDS PostgreSQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: root
+            </div>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              env: aws
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            mysql-aurora-56
+          </td>
+          <td>
+            MySQL 5.6: AWS Aurora Longname For SQL
+          </td>
+          <td>
+            Self-hosted MySQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: root
+            </div>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              env: aws
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            postgres-gcp
+          </td>
+          <td>
+            MPostgreSQL 9.6: Google Cloud SQL
+          </td>
+          <td>
+            Cloud SQL PostgreSQL
+          </td>
+          <td>
+            <div
+              class="c14"
+              kind="secondary"
+            >
+              cluster: env
+            </div>
+            <div
+              class="c14"
               kind="secondary"
             >
               value: gcp

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -34,3 +34,5 @@ export default function useDatabases(ctx) {
     attempt,
   };
 }
+
+export type Props = ReturnType<typeof useDatabases>;

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { useState, useEffect } from 'react';
+import useTeleport from 'teleport/useTeleport';
+import useAttemptNext from 'shared/hooks/useAttemptNext';
+import useStickyClusterId from 'teleport/useStickyClusterId';
+import { Database } from 'teleport/services/database';
+
+export default function useDatabases() {
+  const ctx = useTeleport();
+  const { attempt, run } = useAttemptNext('processing');
+  const { clusterId } = useStickyClusterId();
+
+  const [databases, setDatabases] = useState<Database[]>([]);
+
+  useEffect(() => {
+    run(() => ctx.databaseService.fetchDatabases(clusterId).then(setDatabases));
+  }, [clusterId]);
+
+  return {
+    databases,
+    attempt,
+  };
+}

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -15,14 +15,12 @@ limitations under the License.
 */
 
 import { useState, useEffect } from 'react';
-import useTeleport from 'teleport/useTeleport';
-import useAttemptNext from 'shared/hooks/useAttemptNext';
+import useAttempt from 'shared/hooks/useAttemptNext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import { Database } from 'teleport/services/databases';
 
-export default function useDatabases() {
-  const ctx = useTeleport();
-  const { attempt, run } = useAttemptNext('processing');
+export default function useDatabases(ctx) {
+  const { attempt, run } = useAttempt('processing');
   const { clusterId } = useStickyClusterId();
 
   const [databases, setDatabases] = useState<Database[]>([]);
@@ -32,6 +30,7 @@ export default function useDatabases() {
   }, [clusterId]);
 
   return {
+    ctx,
     databases,
     attempt,
   };

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -18,7 +18,7 @@ import { useState, useEffect } from 'react';
 import useTeleport from 'teleport/useTeleport';
 import useAttemptNext from 'shared/hooks/useAttemptNext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
-import { Database } from 'teleport/services/database';
+import { Database } from 'teleport/services/databases';
 
 export default function useDatabases() {
   const ctx = useTeleport();

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -30,7 +30,6 @@ export default function useDatabases(ctx) {
   }, [clusterId]);
 
   return {
-    ctx,
     databases,
     attempt,
   };

--- a/packages/teleport/src/Main/Main.story.tsx
+++ b/packages/teleport/src/Main/Main.story.tsx
@@ -26,6 +26,7 @@ import { nodes } from 'teleport/Nodes/fixtures';
 import { events } from 'teleport/Audit/fixtures';
 import { sessions } from 'teleport/Sessions/fixtures';
 import { apps } from 'teleport/Apps/fixtures';
+import { databases } from 'teleport/Databases/fixtures';
 import { userContext } from './fixtures';
 
 export function OSS() {
@@ -64,6 +65,7 @@ function useMainStory() {
     ctx.nodeService.fetchNodes = () => Promise.resolve(nodes);
     ctx.sshService.fetchSessions = () => Promise.resolve(sessions);
     ctx.appService.fetchApps = () => Promise.resolve(apps);
+    ctx.databaseService.fetchDatabases = () => Promise.resolve(databases);
     ctx.storeUser.setState(userContext);
     getFeatures().forEach(f => f.register(ctx));
     return ctx;

--- a/packages/teleport/src/Main/fixtures/index.ts
+++ b/packages/teleport/src/Main/fixtures/index.ts
@@ -78,7 +78,7 @@ export const userContext = makeUserContext({
       create: true,
       remove: true,
     },
-    databases: {
+    dbServers: {
       list: true,
       read: true,
       edit: true,

--- a/packages/teleport/src/Main/fixtures/index.ts
+++ b/packages/teleport/src/Main/fixtures/index.ts
@@ -78,6 +78,13 @@ export const userContext = makeUserContext({
       create: true,
       remove: true,
     },
+    databases: {
+      list: true,
+      read: true,
+      edit: true,
+      create: true,
+      remove: true,
+    },
   },
   cluster: {
     name: 'aws',

--- a/packages/teleport/src/features.ts
+++ b/packages/teleport/src/features.ts
@@ -29,6 +29,7 @@ import Users from './Users';
 import Roles from './Roles';
 import Recordings from './Recordings';
 import AuthConnectors from './AuthConnectors';
+import Databases from './Databases';
 
 export class FeatureClusters {
   getTopNavTitle() {
@@ -376,10 +377,37 @@ export class FeatureTrust {
   }
 }
 
+export class FeatureDatabases {
+  getTopNavTitle() {
+    return 'Databases';
+  }
+
+  route = {
+    title: 'Databases',
+    path: cfg.routes.databases,
+    exact: true,
+    component: Databases,
+  };
+
+  register(ctx: Ctx) {
+    ctx.storeNav.addSideItem({
+      title: 'Databases',
+      Icon: Icons.Database,
+      exact: true,
+      getLink(clusterId: string) {
+        return cfg.getDatabasesRoute(clusterId);
+      },
+    });
+
+    ctx.features.push(this);
+  }
+}
+
 export default function getFeatures() {
   return [
     new FeatureNodes(),
     new FeatureApps(),
+    new FeatureDatabases(),
     new FeatureSessions(),
     new FeatureRecordings(),
     new FeatureAudit(),

--- a/packages/teleport/src/features.ts
+++ b/packages/teleport/src/features.ts
@@ -379,7 +379,7 @@ export class FeatureTrust {
 
 export class FeatureDatabases {
   getTopNavTitle() {
-    return 'Databases';
+    return '';
   }
 
   route = {
@@ -390,6 +390,10 @@ export class FeatureDatabases {
   };
 
   register(ctx: Ctx) {
+    if (!ctx.getFeatureFlags().databases) {
+      return;
+    }
+
     ctx.storeNav.addSideItem({
       title: 'Databases',
       Icon: Icons.Database,

--- a/packages/teleport/src/services/databases/databases.test.ts
+++ b/packages/teleport/src/services/databases/databases.test.ts
@@ -67,6 +67,24 @@ describe('correct formatting of all type and protocol combos', () => {
   );
 });
 
+test('null labels field in database fetch response', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue([{ labels: null }]);
+
+  const database = new DatabaseService();
+  const response = await database.fetchDatabases('im-a-cluster');
+
+  expect(response[0].tags).toEqual([]);
+});
+
+test('undefined labels field in database fetch response', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue([{ labels: undefined }]);
+
+  const database = new DatabaseService();
+  const response = await database.fetchDatabases('im-a-cluster');
+
+  expect(response[0].tags).toEqual([]);
+});
+
 const mockResponse = [
   {
     name: 'aurora',

--- a/packages/teleport/src/services/databases/databases.test.ts
+++ b/packages/teleport/src/services/databases/databases.test.ts
@@ -76,15 +76,6 @@ test('null labels field in database fetch response', async () => {
   expect(response[0].tags).toEqual([]);
 });
 
-test('undefined labels field in database fetch response', async () => {
-  jest.spyOn(api, 'get').mockResolvedValue([{ labels: undefined }]);
-
-  const database = new DatabaseService();
-  const response = await database.fetchDatabases('im-a-cluster');
-
-  expect(response[0].tags).toEqual([]);
-});
-
 const mockResponse = [
   {
     name: 'aurora',

--- a/packages/teleport/src/services/databases/databases.ts
+++ b/packages/teleport/src/services/databases/databases.ts
@@ -22,7 +22,7 @@ import makeDatabase from './makeDatabase';
 class DatabaseService {
   fetchDatabases(clusterId?: string) {
     return api
-      .get(cfg.getDatabasesRoute(clusterId))
+      .get(cfg.getDatabasesUrl(clusterId))
       .then(json => map(json, makeDatabase));
   }
 }

--- a/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/packages/teleport/src/services/databases/makeDatabase.ts
@@ -17,7 +17,9 @@ limitations under the License.
 import { Database } from './types';
 
 export default function makeDatabase(json): Database {
-  const { name, desc, protocol, type, labels = [] } = json;
+  const { name, desc, protocol, type } = json;
+
+  const labels = json.labels || [];
 
   return {
     name,

--- a/packages/teleport/src/services/user/makeAcl.ts
+++ b/packages/teleport/src/services/user/makeAcl.ts
@@ -30,7 +30,7 @@ export default function makeAcl(json): Acl {
   const tokens = json.tokens || defaultAccess;
   const accessRequests = json.accessRequests || defaultAccess;
   const billing = json.billing || defaultAccess;
-  const databases = json.databases || defaultAccess;
+  const dbServers = json.dbServers || defaultAccess;
 
   return {
     logins,
@@ -44,7 +44,7 @@ export default function makeAcl(json): Acl {
     tokens,
     accessRequests,
     billing,
-    databases,
+    dbServers,
   };
 }
 

--- a/packages/teleport/src/services/user/makeAcl.ts
+++ b/packages/teleport/src/services/user/makeAcl.ts
@@ -30,6 +30,7 @@ export default function makeAcl(json): Acl {
   const tokens = json.tokens || defaultAccess;
   const accessRequests = json.accessRequests || defaultAccess;
   const billing = json.billing || defaultAccess;
+  const databases = json.databases || defaultAccess;
 
   return {
     logins,
@@ -43,6 +44,7 @@ export default function makeAcl(json): Acl {
     tokens,
     accessRequests,
     billing,
+    databases,
   };
 }
 

--- a/packages/teleport/src/services/user/types.ts
+++ b/packages/teleport/src/services/user/types.ts
@@ -57,7 +57,7 @@ export interface Acl {
   appServers: Access;
   accessRequests: Access;
   billing: Access;
-  databases: Access;
+  dbServers: Access;
 }
 
 export interface User {

--- a/packages/teleport/src/services/user/types.ts
+++ b/packages/teleport/src/services/user/types.ts
@@ -57,6 +57,7 @@ export interface Acl {
   appServers: Access;
   accessRequests: Access;
   billing: Access;
+  databases: Access;
 }
 
 export interface User {

--- a/packages/teleport/src/services/user/user.test.ts
+++ b/packages/teleport/src/services/user/user.test.ts
@@ -120,6 +120,13 @@ test('undefined values in context response gives proper default values', async (
         create: false,
         remove: false,
       },
+      dbServers: {
+        list: false,
+        read: false,
+        edit: false,
+        create: false,
+        remove: false,
+      },
     },
     cluster: {
       clusterId: 'aws',

--- a/packages/teleport/src/stores/storeUserContext.ts
+++ b/packages/teleport/src/stores/storeUserContext.ts
@@ -76,4 +76,8 @@ export default class StoreUserContext extends Store<UserContext> {
   getBillingAccess() {
     return this.state.acl.billing;
   }
+
+  getDatabaseAccess() {
+    return this.state.acl.databases;
+  }
 }

--- a/packages/teleport/src/stores/storeUserContext.ts
+++ b/packages/teleport/src/stores/storeUserContext.ts
@@ -78,6 +78,6 @@ export default class StoreUserContext extends Store<UserContext> {
   }
 
   getDatabaseAccess() {
-    return this.state.acl.databases;
+    return this.state.acl.dbServers;
   }
 }

--- a/packages/teleport/src/teleportContext.tsx
+++ b/packages/teleport/src/teleportContext.tsx
@@ -62,6 +62,7 @@ class TeleportContext implements types.Context {
       users: userContext.getUserAccess().list,
       applications: userContext.getAppServerAccess().list,
       billing: userContext.getBillingAccess().list,
+      databases: userContext.getDatabaseAccess().list,
     };
   }
 }


### PR DESCRIPTION
### Purpose

This PR resolves #272  

Create a custom `useDatabases` hook. Create `Container` component. Register databases as a feature and add it to the side nav. Update Main.story to include it and to use the hook. Updated the enterprise submodule as well.

### Implementation

Created a `useDatabases` hook that uses `useAttemptNext` to set the `attempt` state based on the success of the database fetching, in order to display an error or a loading icon. Registered databases as a feature by creating a `FeatureDatabases` class in `features.ts`, which also adds it to the side nav. Also added it to `Main.story`. Updated the `feature.ts` and `Main.story` of `webapps.e` and made a PR to that repo which you can find [here](https://github.com/gravitational/webapps.e/pull/47). The e-ref will be updated later when merging.

Also added support for the edge case where the `labels` field is `null` because of a quirk with Go that causes responses to contain `null` for arrays instead of `undefined`. 

### Demo

![image](https://user-images.githubusercontent.com/56373201/116488851-6da8b880-a861-11eb-82ed-7c0879a9362c.png)






