### PR TITLE
Set default on empty renew session request

### DIFF
--- a/packages/teleport/src/services/session/session.ts
+++ b/packages/teleport/src/services/session/session.ts
@@ -120,7 +120,7 @@ const session = {
     return this._timeLeft() < RENEW_TOKEN_TIME;
   },
 
-  _renewToken(req: RenewSessionRequest) {
+  _renewToken(req: RenewSessionRequest = {}) {
     this._setAndBroadcastIsRenewing(true);
     return api
       .post(cfg.getRenewTokenUrl(), req)


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/6890

### Description
the renew token endpoint expects a request body, sending an empty JSON object is equivalent to 

```
{
  requestId: '',
  switchback: false,
}
```