### PR TITLE
Refactor services get link return value

### DIFF
--- a/packages/teleport/src/services/links.ts
+++ b/packages/teleport/src/services/links.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const DOMAIN_NAME = 'https://get.gravitational.com/';
+export const DOWNLOAD_BASE_URL = 'https://get.gravitational.com/';
 
 export function getLinux64(version: string, isEnterprise = true) {
   return getLink('linux64', version, isEnterprise);
@@ -38,7 +38,7 @@ function getLink(type: Arch, version: string, isEnterprise: boolean) {
     infix = 'linux-386';
   }
 
-  return `${DOMAIN_NAME}${prefix}-v${version}-${infix}-bin.tar.gz`;
+  return `${DOWNLOAD_BASE_URL}${prefix}-v${version}-${infix}-bin.tar.gz`;
 }
 
 type Arch = 'mac' | 'linux32' | 'linux64';

--- a/packages/teleport/src/services/links.ts
+++ b/packages/teleport/src/services/links.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export const DOMAIN_NAME = 'https://get.gravitational.com/';
+
 export function getLinux64(version: string, isEnterprise = true) {
   return getLink('linux64', version, isEnterprise);
 }
@@ -36,7 +38,7 @@ function getLink(type: Arch, version: string, isEnterprise: boolean) {
     infix = 'linux-386';
   }
 
-  return `https://get.gravitational.com/${prefix}-v${version}-${infix}-bin.tar.gz`;
+  return `${DOMAIN_NAME}${prefix}-v${version}-${infix}-bin.tar.gz`;
 }
 
 type Arch = 'mac' | 'linux32' | 'linux64';


### PR DESCRIPTION
This PR contains minor refactoring of `getLink` function return value in services.
The reason for the change is to export the defined const and use it for filtering purposes in webapps.e.