### PR TITLE
Allow webapps to build without e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ COPY packages/shared/package.json web-apps/packages/shared/
 COPY packages/teleport/package.json web-apps/packages/teleport/
 
 # copy enterprise package.json files if present
-COPY README.md packages/webapps.e/gravity/package.jso[n] web-apps/packages/webapps.e/gravity/
-COPY README.md packages/webapps.e/teleport/package.jso[n] web-apps/packages/webapps.e/teleport/
+COPY README.md packages/webapps.e/gravit[y]/package.json web-apps/packages/webapps.e/gravity/
+COPY README.md packages/webapps.e/telepor[t]/package.json web-apps/packages/webapps.e/teleport/
 
 # download and install npm dependencies
 WORKDIR web-apps


### PR DESCRIPTION
Fix a character class workaround in the Dockerfile so the repository builds correctly without `packages/webapps.e/`.

Fixes #351.