### PR TITLE
Use filter `session.end` to retrieve events for session recording screen

### DIFF
--- a/packages/teleport/src/Recordings/RecordList.tsx
+++ b/packages/teleport/src/Recordings/RecordList.tsx
@@ -22,8 +22,9 @@ import { ButtonBorder } from 'design';
 import { displayDateTime } from 'shared/services/loc';
 import * as Table from 'design/DataTable';
 import PagedTable from 'design/DataTable/Paged';
-import { Event, SessionEnd } from 'teleport/services/audit/types';
+import { SessionEnd } from 'teleport/services/audit/types';
 import cfg from 'teleport/config';
+import { State } from 'teleport/useAuditEvents';
 
 type SortCols = 'created' | 'duration';
 type SortState = {
@@ -31,7 +32,14 @@ type SortState = {
 };
 
 export default function RecordList(props: Props) {
-  const { clusterId, searchValue, pageSize, events } = props;
+  const {
+    clusterId,
+    searchValue,
+    pageSize,
+    events,
+    fetchMore,
+    fetchStatus,
+  } = props;
   const [colSortDirs, setSort] = React.useState<SortState>(() => {
     return {
       created: Table.SortTypes.ASC,
@@ -70,7 +78,7 @@ export default function RecordList(props: Props) {
     setSort({ [columnKey]: sortDir });
   }
 
-  const tableProps = { pageSize, data };
+  const tableProps = { pageSize, data, fetchMore, fetchStatus };
 
   return (
     <PagedTable {...tableProps}>
@@ -186,10 +194,12 @@ const PlayCell = props => {
 };
 
 type Props = {
-  searchValue: string;
-  events: Event[];
   pageSize?: number;
-  clusterId: string;
+  searchValue: State['searchValue'];
+  events: State['events'];
+  clusterId: State['clusterId'];
+  fetchMore: State['fetchMore'];
+  fetchStatus: State['fetchStatus'];
 };
 
 const searchableProps = [

--- a/packages/teleport/src/Recordings/Recordings.tsx
+++ b/packages/teleport/src/Recordings/Recordings.tsx
@@ -28,19 +28,17 @@ import InputSearch from 'teleport/components/InputSearch';
 import useTeleport from 'teleport/useTeleport';
 import useAuditEvents from 'teleport/useAuditEvents';
 import useStickyClusterId from 'teleport/useStickyClusterId';
-
-const MAX_EVENT_FETCH = 9999;
+import { eventCodes } from 'teleport/services/audit';
 
 export default function Container() {
   const teleCtx = useTeleport();
   const { clusterId } = useStickyClusterId();
-  const state = useAuditEvents(teleCtx, clusterId, MAX_EVENT_FETCH);
+  const state = useAuditEvents(teleCtx, clusterId, eventCodes.SESSION_END);
   return <Recordings {...state} />;
 }
 
 export function Recordings(props: ReturnType<typeof useAuditEvents>) {
   const {
-    fetchStartKey,
     attempt,
     range,
     rangeOptions,
@@ -49,6 +47,8 @@ export function Recordings(props: ReturnType<typeof useAuditEvents>) {
     searchValue,
     clusterId,
     setSearchValue,
+    fetchMore,
+    fetchStatus,
   } = props;
 
   return (
@@ -70,12 +70,6 @@ export function Recordings(props: ReturnType<typeof useAuditEvents>) {
       >
         <InputSearch mr="3" onChange={setSearchValue} />
       </Flex>
-      {fetchStartKey && (
-        <Danger>
-          number of events retrieved for specified date range has exceeded the
-          maximum limit of {MAX_EVENT_FETCH} events
-        </Danger>
-      )}
       {attempt.status === 'failed' && <Danger> {attempt.statusText} </Danger>}
       {attempt.status === 'processing' && (
         <Box textAlign="center" m={10}>
@@ -88,6 +82,8 @@ export function Recordings(props: ReturnType<typeof useAuditEvents>) {
           events={events}
           clusterId={clusterId}
           pageSize={50}
+          fetchMore={fetchMore}
+          fetchStatus={fetchStatus}
         />
       )}
     </FeatureBox>

--- a/packages/teleport/src/Recordings/__snapshots__/Recordings.story.test.tsx.snap
+++ b/packages/teleport/src/Recordings/__snapshots__/Recordings.story.test.tsx.snap
@@ -610,7 +610,6 @@ exports[`rendering of Session Recordings 1`] = `
         value=""
       />
     </div>
-    
     <div>
       <nav
         class="c7"

--- a/packages/teleport/src/services/audit/audit.ts
+++ b/packages/teleport/src/services/audit/audit.ts
@@ -29,8 +29,9 @@ class AuditService {
     const url = cfg.getClusterEventsUrl(clusterId, {
       start,
       end,
-      limit: params.limit ? params.limit : this.maxFetchLimit,
-      startKey: params.startKey ? params.startKey : undefined,
+      limit: this.maxFetchLimit,
+      include: params.filterBy || undefined,
+      startKey: params.startKey || undefined,
     });
 
     return api.get(url).then(json => {

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -548,6 +548,7 @@ export type EventQuery = {
   to: Date;
   limit?: number;
   startKey?: string;
+  filterBy?: string;
 };
 
 export type EventResponse = {


### PR DESCRIPTION
backport of (#339)