### PR TITLE
Fix trusted cluster title styling

### DIFF
--- a/packages/teleport/src/TrustedClusters/TrustedClusters.story.tsx
+++ b/packages/teleport/src/TrustedClusters/TrustedClusters.story.tsx
@@ -81,8 +81,8 @@ const trustedClusters = [
   {
     id: 'role:admin',
     kind: 'trusted_cluster' as const,
-    name: 'admin',
-    displayName: 'admin',
+    name: 'georgewashington.gravitational.io',
+    displayName: 'georgewashington.gravitational.io',
     content:
       "kind: role\nmetadata:\n  name: admin\nspec:\n  allow:\n    kubernetes_groups:\n    - '{{internal.kubernetes_groups}}'\n    logins:\n    - '{{internal.logins}}'\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - role\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - auth_connector\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - session\n      verbs:\n      - list\n      - read\n    - resources:\n      - trusted_cluster\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: true\n    max_session_ttl: 30h0m0s\n    port_forwarding: true\nversion: v3\n",
   },

--- a/packages/teleport/src/TrustedClusters/TrustedList/TrustedListItem.tsx
+++ b/packages/teleport/src/TrustedClusters/TrustedList/TrustedListItem.tsx
@@ -60,7 +60,15 @@ export default function TrustedListItem(props: Props) {
           fontSize="48px"
           color="text.primary"
         />
-        <Text typography="p" bold caps mb="1">
+        <Text
+          typography="p"
+          bold
+          caps
+          mb="1"
+          textAlign="center"
+          title={name}
+          style={{ width: '200px' }}
+        >
           {name}
         </Text>
       </Flex>


### PR DESCRIPTION
#### Description
Fix over flowing of long cluster name

before:

![image](https://user-images.githubusercontent.com/43280172/126720474-f7412216-bc69-4095-bcdf-440170a3f4b7.png)


after:

![image](https://user-images.githubusercontent.com/43280172/126720511-d9863d32-5210-4213-a88f-b00f83e4e385.png)

