### PR TITLE
MFA-related Language Changes & Move MFA logic to OSS 

### DIFF
--- a/packages/shared/components/FormInvite/FormInvite.story.tsx
+++ b/packages/shared/components/FormInvite/FormInvite.story.tsx
@@ -51,7 +51,9 @@ export const U2fError = () => (
   />
 );
 
-U2fError.storyName = 'U2fError';
+U2fError.storyName = 'U2f Error';
+
+export const Optional = () => <FormInvite {...props} auth2faType="optional" />;
 
 const props: Props = {
   auth2faType: 'otp',

--- a/packages/shared/components/FormInvite/FormInvite.tsx
+++ b/packages/shared/components/FormInvite/FormInvite.tsx
@@ -59,7 +59,7 @@ export default function FormInvite(props: Props) {
     const mfaOptions: MFAOption[] = [];
 
     if (auth2faType === 'optional' || auth2faType === 'off') {
-      mfaOptions.push({ value: 'optional', label: 'NONE' });
+      mfaOptions.push({ value: 'optional', label: 'None' });
     }
 
     if (mfaEnabled || u2fEnabled) {

--- a/packages/shared/components/FormInvite/FormInvite.tsx
+++ b/packages/shared/components/FormInvite/FormInvite.tsx
@@ -120,40 +120,38 @@ export default function FormInvite(props: Props) {
                 placeholder="Confirm Password"
               />
               {secondFactorEnabled && (
-                <Flex alignItems="flex-end" mb={4}>
-                  <Box width="50%" data-testid="mfa-select">
-                    <FieldSelect
-                      label="Two-factor type"
-                      value={mfaType}
-                      options={mfaOptions}
-                      onChange={opt =>
-                        onSetMfaOption(opt as MfaOption, validator)
-                      }
-                      mr={3}
-                      mb={0}
-                      isDisabled={attempt.status === 'processing'}
+                <Flex alignItems="center">
+                  <FieldSelect
+                    maxWidth="50%"
+                    width="100%"
+                    data-testid="mfa-select"
+                    label="Two-factor type"
+                    value={mfaType}
+                    options={mfaOptions}
+                    onChange={opt =>
+                      onSetMfaOption(opt as MfaOption, validator)
+                    }
+                    mr={3}
+                    isDisabled={attempt.status === 'processing'}
+                  />
+                  {mfaType.value === 'otp' && (
+                    <FieldInput
+                      width="50%"
+                      label="Authenticator code"
+                      rule={requiredToken}
+                      autoComplete="off"
+                      value={token}
+                      onChange={e => setToken(e.target.value)}
+                      placeholder="123 456"
                     />
-                  </Box>
-                  <Box width="50%">
-                    {mfaType.value === 'otp' && (
-                      <FieldInput
-                        label="Authenticator code"
-                        rule={requiredToken}
-                        autoComplete="off"
-                        value={token}
-                        onChange={e => setToken(e.target.value)}
-                        placeholder="123 456"
-                        mb={0}
-                      />
+                  )}
+                  {mfaType.value === 'u2f' &&
+                    attempt.status === 'processing' && (
+                      <Text typography="body2">
+                        Insert your hardware key and press the button on the
+                        key.
+                      </Text>
                     )}
-                    {mfaType.value === 'u2f' &&
-                      attempt.status === 'processing' && (
-                        <Text typography="body2" mb={1}>
-                          Insert your hardware key and press the button on the
-                          key.
-                        </Text>
-                      )}
-                  </Box>
                 </Flex>
               )}
               <ButtonPrimary

--- a/packages/shared/components/FormInvite/FormInvite.tsx
+++ b/packages/shared/components/FormInvite/FormInvite.tsx
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 import { Text, Card, ButtonPrimary, Flex, Box, Link } from 'design';
 import * as Alerts from 'design/Alert';
 import { Auth2faType } from 'shared/services';
-import { Option } from 'shared/components/Select';
+import { getMfaOptions, MfaOption } from 'teleport/services/mfa/utils';
 import FieldSelect from '../FieldSelect';
 import FieldInput from '../FieldInput';
 import Validation, { Validator } from '../Validation';
@@ -55,23 +55,7 @@ export default function FormInvite(props: Props) {
   const [passwordConfirmed, setPasswordConfirmed] = useState('');
   const [token, setToken] = useState('');
 
-  const [mfaOptions] = useState<MFAOption[]>(() => {
-    const mfaOptions: MFAOption[] = [];
-
-    if (auth2faType === 'optional' || auth2faType === 'off') {
-      mfaOptions.push({ value: 'optional', label: 'None' });
-    }
-
-    if (mfaEnabled || u2fEnabled) {
-      mfaOptions.push({ value: 'u2f', label: 'Hardware Key' });
-    }
-
-    if (mfaEnabled || otpEnabled) {
-      mfaOptions.push({ value: 'otp', label: 'Authenticator App' });
-    }
-
-    return mfaOptions;
-  });
+  const mfaOptions = useMemo<MfaOption[]>(() => getMfaOptions(auth2faType), []);
 
   const [mfaType, setMfaType] = useState(mfaOptions[0]);
 
@@ -94,7 +78,7 @@ export default function FormInvite(props: Props) {
     }
   }
 
-  function onSetMfaOption(option: MFAOption, validator: Validator) {
+  function onSetMfaOption(option: MfaOption, validator: Validator) {
     setToken('');
     clearSubmitAttempt();
     validator.reset();
@@ -143,7 +127,7 @@ export default function FormInvite(props: Props) {
                       value={mfaType}
                       options={mfaOptions}
                       onChange={opt =>
-                        onSetMfaOption(opt as MFAOption, validator)
+                        onSetMfaOption(opt as MfaOption, validator)
                       }
                       mr={3}
                       mb={0}
@@ -238,5 +222,3 @@ function ErrorMessage({ message = '' }) {
     </Alerts.Danger>
   );
 }
-
-type MFAOption = Option<Auth2faType>;

--- a/packages/shared/components/FormInvite/FormInvite.tsx
+++ b/packages/shared/components/FormInvite/FormInvite.tsx
@@ -63,11 +63,11 @@ export default function FormInvite(props: Props) {
     }
 
     if (mfaEnabled || u2fEnabled) {
-      mfaOptions.push({ value: 'u2f', label: 'U2F' });
+      mfaOptions.push({ value: 'u2f', label: 'Hardware Key' });
     }
 
     if (mfaEnabled || otpEnabled) {
-      mfaOptions.push({ value: 'otp', label: 'TOTP' });
+      mfaOptions.push({ value: 'otp', label: 'Authenticator App' });
     }
 
     return mfaOptions;
@@ -139,7 +139,7 @@ export default function FormInvite(props: Props) {
                 <Flex alignItems="flex-end" mb={4}>
                   <Box width="50%" data-testid="mfa-select">
                     <FieldSelect
-                      label="Second factor"
+                      label="Two-factor type"
                       value={mfaType}
                       options={mfaOptions}
                       onChange={opt =>
@@ -153,7 +153,7 @@ export default function FormInvite(props: Props) {
                   <Box width="50%">
                     {mfaType.value === 'otp' && (
                       <FieldInput
-                        label="two-factor token"
+                        label="Authenticator code"
                         rule={requiredToken}
                         autoComplete="off"
                         value={token}
@@ -165,7 +165,8 @@ export default function FormInvite(props: Props) {
                     {mfaType.value === 'u2f' &&
                       attempt.status === 'processing' && (
                         <Text typography="body2" mb={1}>
-                          Insert your U2F key and press the button on the key.
+                          Insert your hardware key and press the button on the
+                          key.
                         </Text>
                       )}
                   </Box>

--- a/packages/shared/components/FormInvite/TwoFaInfo.tsx
+++ b/packages/shared/components/FormInvite/TwoFaInfo.tsx
@@ -15,10 +15,8 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Box, Text, ButtonLink, Link } from 'design';
+import { Box, Text, Link } from 'design';
 import { Auth2faType } from 'shared/services';
-
-const U2F_HELP_URL = 'https://support.google.com/accounts/answer/6103523?hl=en';
 
 export default function TwoFAData({ auth2faType, qr, submitBtnText }: Props) {
   const imgSrc = `data:image/png;base64,${qr}`;
@@ -27,20 +25,17 @@ export default function TwoFAData({ auth2faType, qr, submitBtnText }: Props) {
     return (
       <Box width="168px">
         <Text typography="paragraph2" mb={3}>
-          Scan the bar code with Google Authenticator to generate a two-factor
-          token.
+          Scan the QR Code with any authenticator app and enter the generated
+          code.
         </Text>
         <img width="152px" src={imgSrc} style={{ border: '8px solid' }} />
-        <ButtonLink
-          width="100%"
-          kind="secondary"
-          target="_blank"
-          size="small"
-          href="https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DiOS&hl=en&oco=0"
-          rel="noreferrer"
-        >
-          Download Google Authenticator
-        </ButtonLink>
+        <Text typography="paragraph2" color="text.secondary">
+          We recommend{' '}
+          <Link href="https://authy.com/download/" target="_blank">
+            Authy
+          </Link>
+          .
+        </Text>
       </Box>
     );
   }
@@ -49,23 +44,15 @@ export default function TwoFAData({ auth2faType, qr, submitBtnText }: Props) {
     return (
       <Box width="168px">
         <Text typography="h5" mb="2">
-          Insert your U2F key
+          Insert your hardware key
         </Text>
-        <Box color="text.primary">
-          <Text typography="paragraph2" mb={3}>
-            Press the button on the U2F key after you press the{' '}
-            <Text as="span" style={{ textTransform: 'uppercase' }} bold>
-              {submitBtnText}
-            </Text>{' '}
-            button.
-          </Text>
-          <Text typography="paragraph2" mb={3}>
-            <Link color="light" target="_blank" href={U2F_HELP_URL}>
-              Learn more
-            </Link>{' '}
-            about U2F 2-Step Verification.
-          </Text>
-        </Box>
+        <Text typography="paragraph2" mb={3}>
+          Press the button on the hardware key after you press the{' '}
+          <Text as="span" style={{ textTransform: 'uppercase' }} bold>
+            {submitBtnText}
+          </Text>{' '}
+          button.
+        </Text>
       </Box>
     );
   }

--- a/packages/shared/components/FormInvite/TwoFaInfo.tsx
+++ b/packages/shared/components/FormInvite/TwoFaInfo.tsx
@@ -48,7 +48,7 @@ export default function TwoFAData({ auth2faType, qr, submitBtnText }: Props) {
         </Text>
         <Text typography="paragraph2" mb={3}>
           Press the button on the hardware key after you press the{' '}
-          <Text as="span" style={{ textTransform: 'uppercase' }} bold>
+          <Text as="span" caps bold>
             {submitBtnText}
           </Text>{' '}
           button.

--- a/packages/shared/components/FormInvite/__snapshots__/FormInvite.story.test.tsx.snap
+++ b/packages/shared/components/FormInvite/__snapshots__/FormInvite.story.test.tsx.snap
@@ -14,18 +14,496 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
 
 .c9 {
   box-sizing: border-box;
+  max-width: 50%;
+  margin-bottom: 24px;
+  margin-right: 16px;
+  width: 100%;
+}
+
+.c11 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
   width: 50%;
+}
+
+.c13 {
+  box-sizing: border-box;
+  padding: 40px;
+  background-color: #1C254D;
+  flex: 1;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+.c14 {
+  box-sizing: border-box;
+  width: 168px;
+}
+
+.c12 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c12:active {
+  opacity: 0.56;
+}
+
+.c12:hover,
+.c12:focus {
+  background: #651FFF;
+}
+
+.c12:active {
+  background: #354AA4;
+}
+
+.c12:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c0 {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  width: 720px;
+  background-color: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-radius: 8px;
+}
+
+.c7 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  color: #324148;
+  background-color: #FFFFFF;
+}
+
+.c7::-ms-clear {
+  display: none;
+}
+
+.c7::placeholder {
+  opacity: 0.4;
+}
+
+.c7:read-only {
+  cursor: not-allowed;
+}
+
+.c6 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.c17 {
+  color: #03a9f4;
+  font-weight: normal;
+  background: none;
+  text-decoration: underline;
+  text-transform: none;
+}
+
+.c3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 28px;
+  line-height: 32px;
+  margin: 0px;
+  margin-bottom: 16px;
+  color: #FFFFFF;
+  text-align: center;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 32px;
+  word-break: break-all;
+  margin: 0px;
+  margin-bottom: 16px;
+}
+
+.c15 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 12px;
+  line-height: 24px;
+  margin: 0px;
+  margin-bottom: 16px;
+}
+
+.c16 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 12px;
+  line-height: 24px;
+  margin: 0px;
+  color: rgba(255,255,255,0.56);
+}
+
+.c1 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c8 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+}
+
+.c10 .react-select-container {
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
+  box-sizing: border-box;
+  border: none;
+  display: block;
+  font-size: 14px;
+  outline: none;
+  width: 100%;
+  color: rgba(0,0,0,0.87);
+  background-color: #ffffff;
+  margin-bottom: 0px;
+  border-radius: 4px;
+}
+
+.c10 .react-select__control,
+.c10 .react-select__control--is-focused {
+  min-height: 40px;
+  height: 40px;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+}
+
+.c10 .react-select__control:hover,
+.c10 .react-select__control--is-focused:hover {
+  border-color: transparent;
+  cursor: pointer;
+}
+
+.c10 .react-select__option:hover {
+  cursor: pointer;
+  background-color: #eceff1;
+}
+
+.c10 .react-select__option--is-focused {
+  background-color: #eceff1;
+}
+
+.c10 .react-select__option--is-selected {
+  background-color: #cfd8dc;
+  color: inherit;
+}
+
+.c10 .react-select__option--is-selected:hover {
+  background-color: #cfd8dc;
+}
+
+.c10 .react-select__menu {
+  margin-top: 0px;
+}
+
+.c10 .react-select__indicator-separator {
+  display: none;
+}
+
+.c10 .react-select__loading-indicator {
+  display: none;
+}
+
+.c10 .react-select--is-disabled .react-select__single-value,
+.c10 .react-select--is-disabled .react-select__placeholder {
+  color: rgba(0,0,0,0.24);
+}
+
+.c10 .react-select--is-disabled .react-select__indicator {
+  color: rgba(0,0,0,0.14);
+}
+
+<form
+  class="c0"
+  width="720px"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+        color="light"
+      />
+      <div
+        class="c4"
+      >
+        test@gravitational.com
+      </div>
+      <div
+        class="c5"
+      >
+        <label
+          class="c6"
+          font-size="0"
+        >
+          Password
+        </label>
+        <input
+          autocomplete="off"
+          class="c7"
+          color="text.onLight"
+          placeholder="Password"
+          type="password"
+          value=""
+        />
+      </div>
+      <div
+        class="c5"
+      >
+        <label
+          class="c6"
+          font-size="0"
+        >
+          Confirm Password
+        </label>
+        <input
+          autocomplete="off"
+          class="c7"
+          color="text.onLight"
+          placeholder="Confirm Password"
+          type="password"
+          value=""
+        />
+      </div>
+      <div
+        class="c8"
+      >
+        <div
+          class="c9"
+          data-testid="mfa-select"
+          width="100%"
+        >
+          <label
+            class="c6"
+            font-size="0"
+          >
+            Two-factor type
+          </label>
+          <div
+            class="c10"
+          >
+            <div
+              class="react-select-container css-2b097c-container"
+            >
+              <div
+                class="react-select__control css-yk16xz-control"
+              >
+                <div
+                  class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                >
+                  <div
+                    class="react-select__single-value css-1uccc91-singleValue"
+                  >
+                    Authenticator App
+                  </div>
+                  <input
+                    aria-autocomplete="list"
+                    class="css-62g3xt-dummyInput"
+                    id="react-select-2-input"
+                    readonly=""
+                    tabindex="0"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
+                    >
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c11"
+          width="50%"
+        >
+          <label
+            class="c6"
+            font-size="0"
+          >
+            Authenticator code
+          </label>
+          <input
+            autocomplete="off"
+            class="c7"
+            color="text.onLight"
+            placeholder="123 456"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <button
+        class="c12"
+        kind="primary"
+        width="100%"
+      >
+        Submit
+      </button>
+    </div>
+    <div
+      class="c13"
+    >
+      <div
+        class="c14"
+        width="168px"
+      >
+        <div
+          class="c15"
+        >
+          Scan the QR Code with any authenticator app and enter the generated code.
+        </div>
+        <img
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAcgAAAHIEAAAAAC/Wvl1AAAJV0lEQVR4nOzdsW4jORZA0fbC///LXowVTFIWmqAefUtzTrDJeEtltS+YPDx+fn39ASL+99svAPzr85//+fj47df4ycr5ff1bXD9h/2f3vcenTf0LrTzh2tnvd9/jfZ2QECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgI+fz5P50dOz870rT/u3VH0VZ+dv+32B9mW1H41vc9e18nJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp6Mzl0rjCkV9stNjYytvG9hkOzs+F5nxO3vrL+vExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSHLo3M8nB1bOztItv9pU8N3+59W54SEEEFCiCAhRJAQIkgIESSECBJCBAkhgoQQQULIG43OvcdOs7NDZ9cKQ3L7o4n3HKhzQkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIWR5dO5uA0lT42Vnnzu1427/Hfaf0B2H+42/dSckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCnozOTQ1mTdnfLzd1UenZcbjumF3hZ691/tadkBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPkenbvbJrlrZwez9t9h39khubPvcPY763BCQoggIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5OPrq3FJ6LWpS0L3nzD1PUxdatp936l3uNZ9swcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQkYvbN3f8FW4SPPs1aErule+Fi6u7Xr2PTghIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQ8jF5geV/b1Tq7Ja8qecW9vedvVi1s4vOCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJDl0bnCoNOUs/vaCjv5pv7d9jfUrTy3MGb3qt/CCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJAnF7ZeK1zFWbgA9ezPrji7HW7F1PfQHai7Zusc3IQgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5Hvr3NTw0oqzI3nda1GvFS65feffbZ+tc/CGBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSFPRudWnL189OwQ177uOxQGFqeeULhEeP3NnJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5vrC1cLXlylDU2R13+084O1h47exut8K1viumBgvXn+CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyMfqWFdhO9yUV126+Xc/u/8OK+52Ke/KE/adHXm0dQ5uQpAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZHTu7KjU3a58LexKu3Z2QO09LnedYusc3JogIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhZHnr3A+PGdppdvYJ+wq76M5+k1MDliu6G/XWOSEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDy+eclQ1z7g0P7G+qmRqWmhu9WfuPCpr53VtiPaOsc5AgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn/+T91NZ/tP2B9buzY1QrjvbtfOrpgafPuNPXtOSAgRJIQIEkIECSGChBBBQoggIUSQECJICBEkhHyPznV2bv3dz147O+g0NV5WGFub+nvY36jX/Xu4tv4bOyEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZOvcvpUxpf2RpsJY1bWpa2f3P23f2VG/qUtup76z9Sc4ISFEkBAiSAgRJIQIEkIECSGChBBBQoggIUSQELI8Ojc1KlXYZjd1mefUtbN3GzecGt87+/3uf9o1W+cgR5AQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyPTp3dlyrMII19Q5TQ1wr9sfA7vZvPLXVb2pI7hknJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp5snfuNnVt/94SzV5IWLnfdf0JhoG7f2b/JFa96ByckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn4e+Tm7I2xFYbdbYYPa1BNWFEbRrp39Hl71Dk5ICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSELF/YOmV/09nUvraz9rfDXetu6iu8w9Snrf9uTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ82Tr3w//hZteBvvM+vLtt1Fv5tMLw3bWpa4gfP+uEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLWucKOsKnhu6kxu8IVqiufdnbccF/3r2SdExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGfr3nM1GWpZwe+zm4v23d2f9/+O+x/v1NPKFwl++CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLoXGEo6m5jdlNb3N5jb92KwuWus+/ghIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjH11fjQtF93QG199gD173q9D2+3wcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQj7udknpn8Ehrv19Yt1Pu3Z2i9vZ8b2zI4+v+h6ckBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPm+sPXs1q4V1wNJ++NlZ6282f4w28oTCpfcFnYe7n8Pr/rWnZAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5/Pk/nd1Hd3a8rKCw7+/sHrizQ3LXpj7tVc91QkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIeTJ6Ny1qctSu87+xvvby1Z20Z21/y/f/Y1fNRbohIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FzX1IjbynOnriQtvMOK7vewb2rn4eMJTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIS80ejc1IWtZy+CvdtOvmtTg3pTY3b772DrHLwhQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FxhtGvlHaY2yV1beW7hCtV93d1uUz879WkPTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ8GZ3rjnbtD76d3X92ber60v0xsClnB9/OsnUO3pAgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5KMwdgQ8OCEhRJAQ8v8AAAD//1QuL6EmJFBiAAAAAElFTkSuQmCC"
+          style="border: 8px solid;"
+          width="152px"
+        />
+        <div
+          class="c16"
+          color="text.secondary"
+        >
+          We recommend
+           
+          <a
+            class="c17"
+            href="https://authy.com/download/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Authy
+          </a>
+          .
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`shared/components/Invite.story story.OtpError 1`] = `
+.c4 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  box-sizing: border-box;
+  box-shadow: 0 1px 4px rgba(0,0,0,.24);
+  margin: 0 0 24px 0;
+  min-height: 40px;
+  padding: 8px 16px;
+  overflow: auto;
+  word-break: break-all;
+  line-height: 1.5;
+  background: #f50057;
+  color: #FFFFFF;
+}
+
+.c4 a {
+  color: #FFFFFF;
+}
+
+.c2 {
+  box-sizing: border-box;
+  padding: 40px;
+  flex: 3;
+}
+
+.c6 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
 }
 
 .c10 {
   box-sizing: border-box;
-  margin-bottom: 0px;
+  max-width: 50%;
+  margin-bottom: 24px;
   margin-right: 16px;
+  width: 100%;
 }
 
 .c12 {
   box-sizing: border-box;
-  margin-bottom: 0px;
+  margin-bottom: 24px;
+  width: 50%;
 }
 
 .c14 {
@@ -100,7 +578,7 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
   border-radius: 8px;
 }
 
-.c7 {
+.c8 {
   appearance: none;
   border: none;
   border-radius: 4px;
@@ -116,19 +594,19 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
   background-color: #FFFFFF;
 }
 
-.c7::-ms-clear {
+.c8::-ms-clear {
   display: none;
 }
 
-.c7::placeholder {
+.c8::placeholder {
   opacity: 0.4;
 }
 
-.c7:read-only {
+.c8:read-only {
   cursor: not-allowed;
 }
 
-.c6 {
+.c7 {
   color: #FFFFFF;
   display: block;
   font-size: 11px;
@@ -158,7 +636,7 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
   text-align: center;
 }
 
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -194,11 +672,10 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
   display: flex;
 }
 
-.c8 {
+.c9 {
   box-sizing: border-box;
-  margin-bottom: 24px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
 }
 
 .c11 .react-select-container {
@@ -269,497 +746,6 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
 }
 
 .c11 .react-select--is-disabled .react-select__indicator {
-  color: rgba(0,0,0,0.14);
-}
-
-<form
-  class="c0"
-  width="720px"
->
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-        color="light"
-      />
-      <div
-        class="c4"
-      >
-        test@gravitational.com
-      </div>
-      <div
-        class="c5"
-      >
-        <label
-          class="c6"
-          font-size="0"
-        >
-          Password
-        </label>
-        <input
-          autocomplete="off"
-          class="c7"
-          color="text.onLight"
-          placeholder="Password"
-          type="password"
-          value=""
-        />
-      </div>
-      <div
-        class="c5"
-      >
-        <label
-          class="c6"
-          font-size="0"
-        >
-          Confirm Password
-        </label>
-        <input
-          autocomplete="off"
-          class="c7"
-          color="text.onLight"
-          placeholder="Confirm Password"
-          type="password"
-          value=""
-        />
-      </div>
-      <div
-        class="c8"
-      >
-        <div
-          class="c9"
-          data-testid="mfa-select"
-          width="50%"
-        >
-          <div
-            class="c10"
-          >
-            <label
-              class="c6"
-              font-size="0"
-            >
-              Two-factor type
-            </label>
-            <div
-              class="c11"
-            >
-              <div
-                class="react-select-container css-2b097c-container"
-              >
-                <div
-                  class="react-select__control css-yk16xz-control"
-                >
-                  <div
-                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
-                  >
-                    <div
-                      class="react-select__single-value css-1uccc91-singleValue"
-                    >
-                      Authenticator App
-                    </div>
-                    <input
-                      aria-autocomplete="list"
-                      class="css-62g3xt-dummyInput"
-                      id="react-select-2-input"
-                      readonly=""
-                      tabindex="0"
-                      value=""
-                    />
-                  </div>
-                  <div
-                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
-                  >
-                    <span
-                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
-                    />
-                    <div
-                      aria-hidden="true"
-                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-6q0nyr-Svg"
-                        focusable="false"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        width="20"
-                      >
-                        <path
-                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="c9"
-          width="50%"
-        >
-          <div
-            class="c12"
-          >
-            <label
-              class="c6"
-              font-size="0"
-            >
-              Authenticator code
-            </label>
-            <input
-              autocomplete="off"
-              class="c7"
-              color="text.onLight"
-              placeholder="123 456"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <button
-        class="c13"
-        kind="primary"
-        width="100%"
-      >
-        Submit
-      </button>
-    </div>
-    <div
-      class="c14"
-    >
-      <div
-        class="c15"
-        width="168px"
-      >
-        <div
-          class="c16"
-        >
-          Scan the QR Code with any authenticator app and enter the generated code.
-        </div>
-        <img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAcgAAAHIEAAAAAC/Wvl1AAAJV0lEQVR4nOzdsW4jORZA0fbC///LXowVTFIWmqAefUtzTrDJeEtltS+YPDx+fn39ASL+99svAPzr85//+fj47df4ycr5ff1bXD9h/2f3vcenTf0LrTzh2tnvd9/jfZ2QECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgI+fz5P50dOz870rT/u3VH0VZ+dv+32B9mW1H41vc9e18nJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp6Mzl0rjCkV9stNjYytvG9hkOzs+F5nxO3vrL+vExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSHLo3M8nB1bOztItv9pU8N3+59W54SEEEFCiCAhRJAQIkgIESSECBJCBAkhgoQQQULIG43OvcdOs7NDZ9cKQ3L7o4n3HKhzQkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIWR5dO5uA0lT42Vnnzu1427/Hfaf0B2H+42/dSckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCnozOTQ1mTdnfLzd1UenZcbjumF3hZ691/tadkBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPkenbvbJrlrZwez9t9h39khubPvcPY763BCQoggIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5OPrq3FJ6LWpS0L3nzD1PUxdatp936l3uNZ9swcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQkYvbN3f8FW4SPPs1aErule+Fi6u7Xr2PTghIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQ8jF5geV/b1Tq7Ja8qecW9vedvVi1s4vOCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJDl0bnCoNOUs/vaCjv5pv7d9jfUrTy3MGb3qt/CCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJAnF7ZeK1zFWbgA9ezPrji7HW7F1PfQHai7Zusc3IQgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5Hvr3NTw0oqzI3nda1GvFS65feffbZ+tc/CGBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSFPRudWnL189OwQ177uOxQGFqeeULhEeP3NnJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5vrC1cLXlylDU2R13+084O1h47exut8K1viumBgvXn+CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyMfqWFdhO9yUV126+Xc/u/8OK+52Ke/KE/adHXm0dQ5uQpAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZHTu7KjU3a58LexKu3Z2QO09LnedYusc3JogIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhZHnr3A+PGdppdvYJ+wq76M5+k1MDliu6G/XWOSEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDy+eclQ1z7g0P7G+qmRqWmhu9WfuPCpr53VtiPaOsc5AgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn/+T91NZ/tP2B9buzY1QrjvbtfOrpgafPuNPXtOSAgRJIQIEkIECSGChBBBQoggIUSQECJICBEkhHyPznV2bv3dz147O+g0NV5WGFub+nvY36jX/Xu4tv4bOyEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZOvcvpUxpf2RpsJY1bWpa2f3P23f2VG/qUtup76z9Sc4ISFEkBAiSAgRJIQIEkIECSGChBBBQoggIUSQELI8Ojc1KlXYZjd1mefUtbN3GzecGt87+/3uf9o1W+cgR5AQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyPTp3dlyrMII19Q5TQ1wr9sfA7vZvPLXVb2pI7hknJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp5snfuNnVt/94SzV5IWLnfdf0JhoG7f2b/JFa96ByckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn4e+Tm7I2xFYbdbYYPa1BNWFEbRrp39Hl71Dk5ICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSELF/YOmV/09nUvraz9rfDXetu6iu8w9Snrf9uTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ82Tr3w//hZteBvvM+vLtt1Fv5tMLw3bWpa4gfP+uEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLWucKOsKnhu6kxu8IVqiufdnbccF/3r2SdExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGfr3nM1GWpZwe+zm4v23d2f9/+O+x/v1NPKFwl++CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLoXGEo6m5jdlNb3N5jb92KwuWus+/ghIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjH11fjQtF93QG199gD173q9D2+3wcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQj7udknpn8Ehrv19Yt1Pu3Z2i9vZ8b2zI4+v+h6ckBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPm+sPXs1q4V1wNJ++NlZ6282f4w28oTCpfcFnYe7n8Pr/rWnZAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5/Pk/nd1Hd3a8rKCw7+/sHrizQ3LXpj7tVc91QkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIeTJ6Ny1qctSu87+xvvby1Z20Z21/y/f/Y1fNRbohIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FzX1IjbynOnriQtvMOK7vewb2rn4eMJTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIS80ejc1IWtZy+CvdtOvmtTg3pTY3b772DrHLwhQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FxhtGvlHaY2yV1beW7hCtV93d1uUz879WkPTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ8GZ3rjnbtD76d3X92ber60v0xsClnB9/OsnUO3pAgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5KMwdgQ8OCEhRJAQ8v8AAAD//1QuL6EmJFBiAAAAAElFTkSuQmCC"
-          style="border: 8px solid;"
-          width="152px"
-        />
-        <div
-          class="c17"
-          color="text.secondary"
-        >
-          We recommend
-           
-          <a
-            class="c18"
-            href="https://authy.com/download/"
-            rel="noreferrer"
-            target="_blank"
-          >
-            Authy
-          </a>
-          .
-        </div>
-      </div>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`shared/components/Invite.story story.OtpError 1`] = `
-.c4 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 2px;
-  box-sizing: border-box;
-  box-shadow: 0 1px 4px rgba(0,0,0,.24);
-  margin: 0 0 24px 0;
-  min-height: 40px;
-  padding: 8px 16px;
-  overflow: auto;
-  word-break: break-all;
-  line-height: 1.5;
-  background: #f50057;
-  color: #FFFFFF;
-}
-
-.c4 a {
-  color: #FFFFFF;
-}
-
-.c2 {
-  box-sizing: border-box;
-  padding: 40px;
-  flex: 3;
-}
-
-.c6 {
-  box-sizing: border-box;
-  margin-bottom: 24px;
-}
-
-.c10 {
-  box-sizing: border-box;
-  width: 50%;
-}
-
-.c11 {
-  box-sizing: border-box;
-  margin-bottom: 0px;
-  margin-right: 16px;
-}
-
-.c13 {
-  box-sizing: border-box;
-  margin-bottom: 0px;
-}
-
-.c15 {
-  box-sizing: border-box;
-  padding: 40px;
-  background-color: #1C254D;
-  flex: 1;
-  border-top-right-radius: 8px;
-  border-bottom-right-radius: 8px;
-}
-
-.c16 {
-  box-sizing: border-box;
-  width: 168px;
-}
-
-.c14 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 40px;
-  font-size: 12px;
-  padding: 0px 40px;
-  margin-top: 16px;
-  width: 100%;
-}
-
-.c14:active {
-  opacity: 0.56;
-}
-
-.c14:hover,
-.c14:focus {
-  background: #651FFF;
-}
-
-.c14:active {
-  background: #354AA4;
-}
-
-.c14:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c0 {
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 40px;
-  margin-bottom: 40px;
-  width: 720px;
-  background-color: #222C59;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
-  border-radius: 8px;
-}
-
-.c8 {
-  appearance: none;
-  border: none;
-  border-radius: 4px;
-  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
-  box-sizing: border-box;
-  display: block;
-  height: 40px;
-  font-size: 16px;
-  padding: 0 16px;
-  outline: none;
-  width: 100%;
-  color: #324148;
-  background-color: #FFFFFF;
-}
-
-.c8::-ms-clear {
-  display: none;
-}
-
-.c8::placeholder {
-  opacity: 0.4;
-}
-
-.c8:read-only {
-  cursor: not-allowed;
-}
-
-.c7 {
-  color: #FFFFFF;
-  display: block;
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  width: 100%;
-  margin-bottom: 4px;
-}
-
-.c19 {
-  color: #03a9f4;
-  font-weight: normal;
-  background: none;
-  text-decoration: underline;
-  text-transform: none;
-}
-
-.c3 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 300;
-  font-size: 28px;
-  line-height: 32px;
-  margin: 0px;
-  margin-bottom: 16px;
-  color: #FFFFFF;
-  text-align: center;
-}
-
-.c5 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 400;
-  font-size: 18px;
-  line-height: 32px;
-  word-break: break-all;
-  margin: 0px;
-  margin-bottom: 16px;
-}
-
-.c17 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 300;
-  font-size: 12px;
-  line-height: 24px;
-  margin: 0px;
-  margin-bottom: 16px;
-}
-
-.c18 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 300;
-  font-size: 12px;
-  line-height: 24px;
-  margin: 0px;
-  color: rgba(255,255,255,0.56);
-}
-
-.c1 {
-  box-sizing: border-box;
-  display: flex;
-}
-
-.c9 {
-  box-sizing: border-box;
-  margin-bottom: 24px;
-  display: flex;
-  align-items: flex-end;
-}
-
-.c12 .react-select-container {
-  box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
-  box-sizing: border-box;
-  border: none;
-  display: block;
-  font-size: 14px;
-  outline: none;
-  width: 100%;
-  color: rgba(0,0,0,0.87);
-  background-color: #ffffff;
-  margin-bottom: 0px;
-  border-radius: 4px;
-}
-
-.c12 .react-select__control,
-.c12 .react-select__control--is-focused {
-  min-height: 40px;
-  height: 40px;
-  background-color: transparent;
-  border-color: transparent;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: none;
-}
-
-.c12 .react-select__control:hover,
-.c12 .react-select__control--is-focused:hover {
-  border-color: transparent;
-  cursor: pointer;
-}
-
-.c12 .react-select__option:hover {
-  cursor: pointer;
-  background-color: #eceff1;
-}
-
-.c12 .react-select__option--is-focused {
-  background-color: #eceff1;
-}
-
-.c12 .react-select__option--is-selected {
-  background-color: #cfd8dc;
-  color: inherit;
-}
-
-.c12 .react-select__option--is-selected:hover {
-  background-color: #cfd8dc;
-}
-
-.c12 .react-select__menu {
-  margin-top: 0px;
-}
-
-.c12 .react-select__indicator-separator {
-  display: none;
-}
-
-.c12 .react-select__loading-indicator {
-  display: none;
-}
-
-.c12 .react-select--is-disabled .react-select__single-value,
-.c12 .react-select--is-disabled .react-select__placeholder {
-  color: rgba(0,0,0,0.24);
-}
-
-.c12 .react-select--is-disabled .react-select__indicator {
   color: rgba(0,0,0,0.14);
 }
 
@@ -832,66 +818,62 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
         <div
           class="c10"
           data-testid="mfa-select"
-          width="50%"
+          width="100%"
         >
+          <label
+            class="c7"
+            font-size="0"
+          >
+            Two-factor type
+          </label>
           <div
             class="c11"
           >
-            <label
-              class="c7"
-              font-size="0"
-            >
-              Two-factor type
-            </label>
             <div
-              class="c12"
+              class="react-select-container css-2b097c-container"
             >
               <div
-                class="react-select-container css-2b097c-container"
+                class="react-select__control css-yk16xz-control"
               >
                 <div
-                  class="react-select__control css-yk16xz-control"
+                  class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
                 >
                   <div
-                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                    class="react-select__single-value css-1uccc91-singleValue"
                   >
-                    <div
-                      class="react-select__single-value css-1uccc91-singleValue"
-                    >
-                      Authenticator App
-                    </div>
-                    <input
-                      aria-autocomplete="list"
-                      class="css-62g3xt-dummyInput"
-                      id="react-select-4-input"
-                      readonly=""
-                      tabindex="0"
-                      value=""
-                    />
+                    Authenticator App
                   </div>
+                  <input
+                    aria-autocomplete="list"
+                    class="css-62g3xt-dummyInput"
+                    id="react-select-4-input"
+                    readonly=""
+                    tabindex="0"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                  />
                   <div
-                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                    aria-hidden="true"
+                    class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
                   >
-                    <span
-                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
-                    />
-                    <div
+                    <svg
                       aria-hidden="true"
-                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="css-6q0nyr-Svg"
-                        focusable="false"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        width="20"
-                      >
-                        <path
-                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                        />
-                      </svg>
-                    </div>
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
@@ -899,31 +881,27 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
           </div>
         </div>
         <div
-          class="c10"
+          class="c12"
           width="50%"
         >
-          <div
-            class="c13"
+          <label
+            class="c7"
+            font-size="0"
           >
-            <label
-              class="c7"
-              font-size="0"
-            >
-              Authenticator code
-            </label>
-            <input
-              autocomplete="off"
-              class="c8"
-              color="text.onLight"
-              placeholder="123 456"
-              type="text"
-              value=""
-            />
-          </div>
+            Authenticator code
+          </label>
+          <input
+            autocomplete="off"
+            class="c8"
+            color="text.onLight"
+            placeholder="123 456"
+            type="text"
+            value=""
+          />
         </div>
       </div>
       <button
-        class="c14"
+        class="c13"
         kind="primary"
         width="100%"
       >
@@ -931,14 +909,14 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
       </button>
     </div>
     <div
-      class="c15"
+      class="c14"
     >
       <div
-        class="c16"
+        class="c15"
         width="168px"
       >
         <div
-          class="c17"
+          class="c16"
         >
           Scan the QR Code with any authenticator app and enter the generated code.
         </div>
@@ -948,13 +926,13 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
           width="152px"
         />
         <div
-          class="c18"
+          class="c17"
           color="text.secondary"
         >
           We recommend
            
           <a
-            class="c19"
+            class="c18"
             href="https://authy.com/download/"
             rel="noreferrer"
             target="_blank"
@@ -983,16 +961,13 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
 
 .c9 {
   box-sizing: border-box;
-  width: 50%;
-}
-
-.c10 {
-  box-sizing: border-box;
-  margin-bottom: 0px;
+  max-width: 50%;
+  margin-bottom: 24px;
   margin-right: 16px;
+  width: 100%;
 }
 
-.c14 {
+.c13 {
   box-sizing: border-box;
   padding: 40px;
   background-color: #1C254D;
@@ -1001,12 +976,12 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   border-bottom-right-radius: 8px;
 }
 
-.c15 {
+.c14 {
   box-sizing: border-box;
   width: 168px;
 }
 
-.c13 {
+.c12 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -1034,20 +1009,20 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   width: 100%;
 }
 
-.c13:active {
+.c12:active {
   opacity: 0.56;
 }
 
-.c13:hover,
-.c13:focus {
+.c12:hover,
+.c12:focus {
   background: #651FFF;
 }
 
-.c13:active {
+.c12:active {
   background: #354AA4;
 }
 
-.c13:disabled {
+.c12:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -1125,17 +1100,16 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   margin-bottom: 16px;
 }
 
-.c12 {
+.c11 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
   font-size: 12px;
   line-height: 16px;
   margin: 0px;
-  margin-bottom: 4px;
 }
 
-.c16 {
+.c15 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -1145,7 +1119,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   margin-bottom: 8px;
 }
 
-.c17 {
+.c16 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -1155,7 +1129,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   margin-bottom: 16px;
 }
 
-.c18 {
+.c17 {
   overflow: hidden;
   text-overflow: ellipsis;
   text-transform: uppercase;
@@ -1170,12 +1144,11 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
 
 .c8 {
   box-sizing: border-box;
-  margin-bottom: 24px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
 }
 
-.c11 .react-select-container {
+.c10 .react-select-container {
   box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
   box-sizing: border-box;
   border: none;
@@ -1189,8 +1162,8 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   border-radius: 4px;
 }
 
-.c11 .react-select__control,
-.c11 .react-select__control--is-focused {
+.c10 .react-select__control,
+.c10 .react-select__control--is-focused {
   min-height: 40px;
   height: 40px;
   background-color: transparent;
@@ -1201,48 +1174,48 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   box-shadow: none;
 }
 
-.c11 .react-select__control:hover,
-.c11 .react-select__control--is-focused:hover {
+.c10 .react-select__control:hover,
+.c10 .react-select__control--is-focused:hover {
   border-color: transparent;
   cursor: pointer;
 }
 
-.c11 .react-select__option:hover {
+.c10 .react-select__option:hover {
   cursor: pointer;
   background-color: #eceff1;
 }
 
-.c11 .react-select__option--is-focused {
+.c10 .react-select__option--is-focused {
   background-color: #eceff1;
 }
 
-.c11 .react-select__option--is-selected {
+.c10 .react-select__option--is-selected {
   background-color: #cfd8dc;
   color: inherit;
 }
 
-.c11 .react-select__option--is-selected:hover {
+.c10 .react-select__option--is-selected:hover {
   background-color: #cfd8dc;
 }
 
-.c11 .react-select__menu {
+.c10 .react-select__menu {
   margin-top: 0px;
 }
 
-.c11 .react-select__indicator-separator {
+.c10 .react-select__indicator-separator {
   display: none;
 }
 
-.c11 .react-select__loading-indicator {
+.c10 .react-select__loading-indicator {
   display: none;
 }
 
-.c11 .react-select--is-disabled .react-select__single-value,
-.c11 .react-select--is-disabled .react-select__placeholder {
+.c10 .react-select--is-disabled .react-select__single-value,
+.c10 .react-select--is-disabled .react-select__placeholder {
   color: rgba(0,0,0,0.24);
 }
 
-.c11 .react-select--is-disabled .react-select__indicator {
+.c10 .react-select--is-disabled .react-select__indicator {
   color: rgba(0,0,0,0.14);
 }
 
@@ -1307,67 +1280,63 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
         <div
           class="c9"
           data-testid="mfa-select"
-          width="50%"
+          width="100%"
         >
+          <label
+            class="c6"
+            font-size="0"
+          >
+            Two-factor type
+          </label>
           <div
             class="c10"
           >
-            <label
-              class="c6"
-              font-size="0"
-            >
-              Two-factor type
-            </label>
             <div
-              class="c11"
+              class="react-select-container react-select--is-disabled css-14jk2my-container"
             >
               <div
-                class="react-select-container react-select--is-disabled css-14jk2my-container"
+                class="react-select__control react-select__control--is-disabled css-1fhf3k1-control"
               >
                 <div
-                  class="react-select__control react-select__control--is-disabled css-1fhf3k1-control"
+                  class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
                 >
                   <div
-                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                    class="react-select__single-value react-select__single-value--is-disabled css-107lb6w-singleValue"
                   >
-                    <div
-                      class="react-select__single-value react-select__single-value--is-disabled css-107lb6w-singleValue"
-                    >
-                      Hardware Key
-                    </div>
-                    <input
-                      aria-autocomplete="list"
-                      class="css-62g3xt-dummyInput"
-                      disabled=""
-                      id="react-select-3-input"
-                      readonly=""
-                      tabindex="0"
-                      value=""
-                    />
+                    Hardware Key
                   </div>
+                  <input
+                    aria-autocomplete="list"
+                    class="css-62g3xt-dummyInput"
+                    disabled=""
+                    id="react-select-3-input"
+                    readonly=""
+                    tabindex="0"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="react-select__indicator-separator css-109onse-indicatorSeparator"
+                  />
                   <div
-                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                    aria-hidden="true"
+                    class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
                   >
-                    <span
-                      class="react-select__indicator-separator css-109onse-indicatorSeparator"
-                    />
-                    <div
+                    <svg
                       aria-hidden="true"
-                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="css-6q0nyr-Svg"
-                        focusable="false"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        width="20"
-                      >
-                        <path
-                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                        />
-                      </svg>
-                    </div>
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
@@ -1375,18 +1344,13 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
           </div>
         </div>
         <div
-          class="c9"
-          width="50%"
+          class="c11"
         >
-          <div
-            class="c12"
-          >
-            Insert your hardware key and press the button on the key.
-          </div>
+          Insert your hardware key and press the button on the key.
         </div>
       </div>
       <button
-        class="c13"
+        class="c12"
         disabled=""
         kind="primary"
         width="100%"
@@ -1395,24 +1359,24 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
       </button>
     </div>
     <div
-      class="c14"
+      class="c13"
     >
       <div
-        class="c15"
+        class="c14"
         width="168px"
       >
         <div
-          class="c16"
+          class="c15"
         >
           Insert your hardware key
         </div>
         <div
-          class="c17"
+          class="c16"
         >
           Press the button on the hardware key after you press the
            
           <span
-            class="c18"
+            class="c17"
           >
             Submit
           </span>

--- a/packages/shared/components/FormInvite/__snapshots__/FormInvite.story.test.tsx.snap
+++ b/packages/shared/components/FormInvite/__snapshots__/FormInvite.story.test.tsx.snap
@@ -1158,6 +1158,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
 .c18 {
   overflow: hidden;
   text-overflow: ellipsis;
+  text-transform: uppercase;
   font-weight: 600;
   margin: 0px;
 }
@@ -1412,7 +1413,6 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
            
           <span
             class="c18"
-            style="text-transform: uppercase;"
           >
             Submit
           </span>

--- a/packages/shared/components/FormInvite/__snapshots__/FormInvite.story.test.tsx.snap
+++ b/packages/shared/components/FormInvite/__snapshots__/FormInvite.story.test.tsx.snap
@@ -88,61 +88,6 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c18 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #222C59;
-  color: rgba(255,255,255,0.87);
-  font-size: 10px;
-  min-height: 24px;
-  padding: 0px 16px;
-  width: 100%;
-}
-
-.c18:active {
-  opacity: 0.56;
-}
-
-.c18:hover,
-.c18:focus {
-  background: #2C3A73;
-}
-
-.c18:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c17 {
-  color: #03a9f4;
-  font-weight: normal;
-  background: none;
-  text-decoration: underline;
-  text-transform: none;
-  padding: 0 8px;
-}
-
-.c17:hover,
-.c17:focus {
-  background: #222C59;
-}
-
 .c0 {
   box-sizing: border-box;
   margin-left: auto;
@@ -193,6 +138,14 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
   margin-bottom: 4px;
 }
 
+.c18 {
+  color: #03a9f4;
+  font-weight: normal;
+  background: none;
+  text-decoration: underline;
+  text-transform: none;
+}
+
 .c3 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -224,6 +177,16 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
   line-height: 24px;
   margin: 0px;
   margin-bottom: 16px;
+}
+
+.c17 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 12px;
+  line-height: 24px;
+  margin: 0px;
+  color: rgba(255,255,255,0.56);
 }
 
 .c1 {
@@ -379,7 +342,7 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
               class="c6"
               font-size="0"
             >
-              Second factor
+              Two-factor type
             </label>
             <div
               class="c11"
@@ -396,7 +359,7 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
                     <div
                       class="react-select__single-value css-1uccc91-singleValue"
                     >
-                      TOTP
+                      Authenticator App
                     </div>
                     <input
                       aria-autocomplete="list"
@@ -447,7 +410,7 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
               class="c6"
               font-size="0"
             >
-              two-factor token
+              Authenticator code
             </label>
             <input
               autocomplete="off"
@@ -478,23 +441,29 @@ exports[`shared/components/Invite.story story.Otp 1`] = `
         <div
           class="c16"
         >
-          Scan the bar code with Google Authenticator to generate a two-factor token.
+          Scan the QR Code with any authenticator app and enter the generated code.
         </div>
         <img
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAcgAAAHIEAAAAAC/Wvl1AAAJV0lEQVR4nOzdsW4jORZA0fbC///LXowVTFIWmqAefUtzTrDJeEtltS+YPDx+fn39ASL+99svAPzr85//+fj47df4ycr5ff1bXD9h/2f3vcenTf0LrTzh2tnvd9/jfZ2QECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgI+fz5P50dOz870rT/u3VH0VZ+dv+32B9mW1H41vc9e18nJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp6Mzl0rjCkV9stNjYytvG9hkOzs+F5nxO3vrL+vExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSHLo3M8nB1bOztItv9pU8N3+59W54SEEEFCiCAhRJAQIkgIESSECBJCBAkhgoQQQULIG43OvcdOs7NDZ9cKQ3L7o4n3HKhzQkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIWR5dO5uA0lT42Vnnzu1427/Hfaf0B2H+42/dSckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCnozOTQ1mTdnfLzd1UenZcbjumF3hZ691/tadkBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPkenbvbJrlrZwez9t9h39khubPvcPY763BCQoggIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5OPrq3FJ6LWpS0L3nzD1PUxdatp936l3uNZ9swcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQkYvbN3f8FW4SPPs1aErule+Fi6u7Xr2PTghIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQ8jF5geV/b1Tq7Ja8qecW9vedvVi1s4vOCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJDl0bnCoNOUs/vaCjv5pv7d9jfUrTy3MGb3qt/CCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJAnF7ZeK1zFWbgA9ezPrji7HW7F1PfQHai7Zusc3IQgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5Hvr3NTw0oqzI3nda1GvFS65feffbZ+tc/CGBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSFPRudWnL189OwQ177uOxQGFqeeULhEeP3NnJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5vrC1cLXlylDU2R13+084O1h47exut8K1viumBgvXn+CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyMfqWFdhO9yUV126+Xc/u/8OK+52Ke/KE/adHXm0dQ5uQpAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZHTu7KjU3a58LexKu3Z2QO09LnedYusc3JogIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhZHnr3A+PGdppdvYJ+wq76M5+k1MDliu6G/XWOSEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDy+eclQ1z7g0P7G+qmRqWmhu9WfuPCpr53VtiPaOsc5AgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn/+T91NZ/tP2B9buzY1QrjvbtfOrpgafPuNPXtOSAgRJIQIEkIECSGChBBBQoggIUSQECJICBEkhHyPznV2bv3dz147O+g0NV5WGFub+nvY36jX/Xu4tv4bOyEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZOvcvpUxpf2RpsJY1bWpa2f3P23f2VG/qUtup76z9Sc4ISFEkBAiSAgRJIQIEkIECSGChBBBQoggIUSQELI8Ojc1KlXYZjd1mefUtbN3GzecGt87+/3uf9o1W+cgR5AQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyPTp3dlyrMII19Q5TQ1wr9sfA7vZvPLXVb2pI7hknJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp5snfuNnVt/94SzV5IWLnfdf0JhoG7f2b/JFa96ByckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn4e+Tm7I2xFYbdbYYPa1BNWFEbRrp39Hl71Dk5ICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSELF/YOmV/09nUvraz9rfDXetu6iu8w9Snrf9uTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ82Tr3w//hZteBvvM+vLtt1Fv5tMLw3bWpa4gfP+uEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLWucKOsKnhu6kxu8IVqiufdnbccF/3r2SdExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGfr3nM1GWpZwe+zm4v23d2f9/+O+x/v1NPKFwl++CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLoXGEo6m5jdlNb3N5jb92KwuWus+/ghIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjH11fjQtF93QG199gD173q9D2+3wcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQj7udknpn8Ehrv19Yt1Pu3Z2i9vZ8b2zI4+v+h6ckBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPm+sPXs1q4V1wNJ++NlZ6282f4w28oTCpfcFnYe7n8Pr/rWnZAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5/Pk/nd1Hd3a8rKCw7+/sHrizQ3LXpj7tVc91QkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIeTJ6Ny1qctSu87+xvvby1Z20Z21/y/f/Y1fNRbohIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FzX1IjbynOnriQtvMOK7vewb2rn4eMJTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIS80ejc1IWtZy+CvdtOvmtTg3pTY3b772DrHLwhQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FxhtGvlHaY2yV1beW7hCtV93d1uUz879WkPTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ8GZ3rjnbtD76d3X92ber60v0xsClnB9/OsnUO3pAgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5KMwdgQ8OCEhRJAQ8v8AAAD//1QuL6EmJFBiAAAAAElFTkSuQmCC"
           style="border: 8px solid;"
           width="152px"
         />
-        <a
-          class="c17 c18"
-          href="https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DiOS&hl=en&oco=0"
-          kind="secondary"
-          rel="noreferrer"
-          target="_blank"
-          width="100%"
+        <div
+          class="c17"
+          color="text.secondary"
         >
-          Download Google Authenticator
-        </a>
+          We recommend
+           
+          <a
+            class="c18"
+            href="https://authy.com/download/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Authy
+          </a>
+          .
+        </div>
       </div>
     </div>
   </div>
@@ -610,61 +579,6 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c19 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #222C59;
-  color: rgba(255,255,255,0.87);
-  font-size: 10px;
-  min-height: 24px;
-  padding: 0px 16px;
-  width: 100%;
-}
-
-.c19:active {
-  opacity: 0.56;
-}
-
-.c19:hover,
-.c19:focus {
-  background: #2C3A73;
-}
-
-.c19:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c18 {
-  color: #03a9f4;
-  font-weight: normal;
-  background: none;
-  text-decoration: underline;
-  text-transform: none;
-  padding: 0 8px;
-}
-
-.c18:hover,
-.c18:focus {
-  background: #222C59;
-}
-
 .c0 {
   box-sizing: border-box;
   margin-left: auto;
@@ -715,6 +629,14 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
   margin-bottom: 4px;
 }
 
+.c19 {
+  color: #03a9f4;
+  font-weight: normal;
+  background: none;
+  text-decoration: underline;
+  text-transform: none;
+}
+
 .c3 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -746,6 +668,16 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
   line-height: 24px;
   margin: 0px;
   margin-bottom: 16px;
+}
+
+.c18 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 12px;
+  line-height: 24px;
+  margin: 0px;
+  color: rgba(255,255,255,0.56);
 }
 
 .c1 {
@@ -909,7 +841,7 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
               class="c7"
               font-size="0"
             >
-              Second factor
+              Two-factor type
             </label>
             <div
               class="c12"
@@ -926,7 +858,7 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
                     <div
                       class="react-select__single-value css-1uccc91-singleValue"
                     >
-                      TOTP
+                      Authenticator App
                     </div>
                     <input
                       aria-autocomplete="list"
@@ -977,7 +909,7 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
               class="c7"
               font-size="0"
             >
-              two-factor token
+              Authenticator code
             </label>
             <input
               autocomplete="off"
@@ -1008,23 +940,29 @@ exports[`shared/components/Invite.story story.OtpError 1`] = `
         <div
           class="c17"
         >
-          Scan the bar code with Google Authenticator to generate a two-factor token.
+          Scan the QR Code with any authenticator app and enter the generated code.
         </div>
         <img
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAcgAAAHIEAAAAAC/Wvl1AAAJV0lEQVR4nOzdsW4jORZA0fbC///LXowVTFIWmqAefUtzTrDJeEtltS+YPDx+fn39ASL+99svAPzr85//+fj47df4ycr5ff1bXD9h/2f3vcenTf0LrTzh2tnvd9/jfZ2QECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgI+fz5P50dOz870rT/u3VH0VZ+dv+32B9mW1H41vc9e18nJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp6Mzl0rjCkV9stNjYytvG9hkOzs+F5nxO3vrL+vExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSHLo3M8nB1bOztItv9pU8N3+59W54SEEEFCiCAhRJAQIkgIESSECBJCBAkhgoQQQULIG43OvcdOs7NDZ9cKQ3L7o4n3HKhzQkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIWR5dO5uA0lT42Vnnzu1427/Hfaf0B2H+42/dSckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCnozOTQ1mTdnfLzd1UenZcbjumF3hZ691/tadkBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPkenbvbJrlrZwez9t9h39khubPvcPY763BCQoggIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5OPrq3FJ6LWpS0L3nzD1PUxdatp936l3uNZ9swcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQkYvbN3f8FW4SPPs1aErule+Fi6u7Xr2PTghIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQ8jF5geV/b1Tq7Ja8qecW9vedvVi1s4vOCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJDl0bnCoNOUs/vaCjv5pv7d9jfUrTy3MGb3qt/CCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJAnF7ZeK1zFWbgA9ezPrji7HW7F1PfQHai7Zusc3IQgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5Hvr3NTw0oqzI3nda1GvFS65feffbZ+tc/CGBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSFPRudWnL189OwQ177uOxQGFqeeULhEeP3NnJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5vrC1cLXlylDU2R13+084O1h47exut8K1viumBgvXn+CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyMfqWFdhO9yUV126+Xc/u/8OK+52Ke/KE/adHXm0dQ5uQpAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZHTu7KjU3a58LexKu3Z2QO09LnedYusc3JogIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhZHnr3A+PGdppdvYJ+wq76M5+k1MDliu6G/XWOSEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDy+eclQ1z7g0P7G+qmRqWmhu9WfuPCpr53VtiPaOsc5AgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn/+T91NZ/tP2B9buzY1QrjvbtfOrpgafPuNPXtOSAgRJIQIEkIECSGChBBBQoggIUSQECJICBEkhHyPznV2bv3dz147O+g0NV5WGFub+nvY36jX/Xu4tv4bOyEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZOvcvpUxpf2RpsJY1bWpa2f3P23f2VG/qUtup76z9Sc4ISFEkBAiSAgRJIQIEkIECSGChBBBQoggIUSQELI8Ojc1KlXYZjd1mefUtbN3GzecGt87+/3uf9o1W+cgR5AQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyPTp3dlyrMII19Q5TQ1wr9sfA7vZvPLXVb2pI7hknJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp5snfuNnVt/94SzV5IWLnfdf0JhoG7f2b/JFa96ByckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn4e+Tm7I2xFYbdbYYPa1BNWFEbRrp39Hl71Dk5ICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSELF/YOmV/09nUvraz9rfDXetu6iu8w9Snrf9uTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ82Tr3w//hZteBvvM+vLtt1Fv5tMLw3bWpa4gfP+uEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLWucKOsKnhu6kxu8IVqiufdnbccF/3r2SdExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGfr3nM1GWpZwe+zm4v23d2f9/+O+x/v1NPKFwl++CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLoXGEo6m5jdlNb3N5jb92KwuWus+/ghIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjH11fjQtF93QG199gD173q9D2+3wcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQj7udknpn8Ehrv19Yt1Pu3Z2i9vZ8b2zI4+v+h6ckBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPm+sPXs1q4V1wNJ++NlZ6282f4w28oTCpfcFnYe7n8Pr/rWnZAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5/Pk/nd1Hd3a8rKCw7+/sHrizQ3LXpj7tVc91QkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIeTJ6Ny1qctSu87+xvvby1Z20Z21/y/f/Y1fNRbohIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FzX1IjbynOnriQtvMOK7vewb2rn4eMJTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIS80ejc1IWtZy+CvdtOvmtTg3pTY3b772DrHLwhQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FxhtGvlHaY2yV1beW7hCtV93d1uUz879WkPTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ8GZ3rjnbtD76d3X92ber60v0xsClnB9/OsnUO3pAgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5KMwdgQ8OCEhRJAQ8v8AAAD//1QuL6EmJFBiAAAAAElFTkSuQmCC"
           style="border: 8px solid;"
           width="152px"
         />
-        <a
-          class="c18 c19"
-          href="https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DiOS&hl=en&oco=0"
-          kind="secondary"
-          rel="noreferrer"
-          target="_blank"
-          width="100%"
+        <div
+          class="c18"
+          color="text.secondary"
         >
-          Download Google Authenticator
-        </a>
+          We recommend
+           
+          <a
+            class="c19"
+            href="https://authy.com/download/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Authy
+          </a>
+          .
+        </div>
       </div>
     </div>
   </div>
@@ -1066,11 +1004,6 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
 .c15 {
   box-sizing: border-box;
   width: 168px;
-}
-
-.c17 {
-  box-sizing: border-box;
-  color: rgba(255,255,255,0.87);
 }
 
 .c13 {
@@ -1169,15 +1102,6 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   margin-bottom: 4px;
 }
 
-.c20 {
-  color: #03a9f4;
-  font-weight: normal;
-  background: none;
-  text-decoration: underline;
-  text-transform: none;
-  color: #FFFFFF;
-}
-
 .c3 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1221,7 +1145,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   margin-bottom: 8px;
 }
 
-.c18 {
+.c17 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -1231,7 +1155,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
   margin-bottom: 16px;
 }
 
-.c19 {
+.c18 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
@@ -1391,7 +1315,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
               class="c6"
               font-size="0"
             >
-              Second factor
+              Two-factor type
             </label>
             <div
               class="c11"
@@ -1408,7 +1332,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
                     <div
                       class="react-select__single-value react-select__single-value--is-disabled css-107lb6w-singleValue"
                     >
-                      U2F
+                      Hardware Key
                     </div>
                     <input
                       aria-autocomplete="list"
@@ -1456,7 +1380,7 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
           <div
             class="c12"
           >
-            Insert your U2F key and press the button on the key.
+            Insert your hardware key and press the button on the key.
           </div>
         </div>
       </div>
@@ -1479,41 +1403,21 @@ exports[`shared/components/Invite.story story.U2f 1`] = `
         <div
           class="c16"
         >
-          Insert your U2F key
+          Insert your hardware key
         </div>
         <div
           class="c17"
-          color="text.primary"
         >
-          <div
+          Press the button on the hardware key after you press the
+           
+          <span
             class="c18"
+            style="text-transform: uppercase;"
           >
-            Press the button on the U2F key after you press the
-             
-            <span
-              class="c19"
-              style="text-transform: uppercase;"
-            >
-              Submit
-            </span>
-             
-            button.
-          </div>
-          <div
-            class="c18"
-          >
-            <a
-              class="c20"
-              color="light"
-              href="https://support.google.com/accounts/answer/6103523?hl=en"
-              rel="noreferrer"
-              target="_blank"
-            >
-              Learn more
-            </a>
-             
-            about U2F 2-Step Verification.
-          </div>
+            Submit
+          </span>
+           
+          button.
         </div>
       </div>
     </div>

--- a/packages/shared/components/FormLogin/FormLogin.story.test.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.story.test.tsx
@@ -17,6 +17,8 @@
 import React from 'react';
 import {
   Basic,
+  Multi,
+  Cloud,
   ServerError,
   SSOProviders,
   Universal2ndFactor,
@@ -27,6 +29,16 @@ import { render } from 'design/utils/testing';
 
 test('auth2faType: otp rendering', () => {
   const { container } = render(<Basic />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('auth2faType: optional rendering', () => {
+  const { container } = render(<Multi />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('cloud auth2faType: on rendering', () => {
+  const { container } = render(<Cloud />);
   expect(container.firstChild).toMatchSnapshot();
 });
 

--- a/packages/shared/components/FormLogin/FormLogin.story.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.story.tsx
@@ -40,6 +40,16 @@ export const Basic = () => <FormLogin {...props} auth2faType="otp" />;
 
 export const Multi = () => <FormLogin {...props} auth2faType="optional" />;
 
+export const Cloud = () => (
+  <FormLogin
+    {...props}
+    title="Teleport Cloud"
+    auth2faType="on"
+    isRecoveryEnabled={true}
+    onRecover={() => null}
+  />
+);
+
 export const ServerError = () => {
   const attempt = {
     ...props.attempt,

--- a/packages/shared/components/FormLogin/FormLogin.test.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.test.tsx
@@ -115,7 +115,7 @@ test('login with auth2faType: U2F', () => {
   );
 
   const expEl = getByText(
-    /insert your U2F key and press the button on the key/i
+    /insert your hardware key and press the button on the key/i
   );
 
   expect(expEl).toBeInTheDocument();

--- a/packages/shared/components/FormLogin/FormLogin.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.tsx
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import styled from 'styled-components';
 import { Card, Text, Flex, ButtonLink, ButtonPrimary, Box } from 'design';
 import * as Alerts from 'design/Alert';
 import { AuthProvider, Auth2faType } from 'shared/services';
-import { Option } from 'shared/components/Select';
 import { useAttempt } from 'shared/hooks';
+import { getMfaOptions, MfaOption } from 'teleport/services/mfa/utils';
 import Validation, { Validator } from '../Validation';
 import FieldInput from '../FieldInput';
 import FieldSelect from '../FieldSelect';
@@ -42,33 +42,15 @@ export default function LoginForm(props: Props) {
     clearAttempt,
   } = props;
 
-  const mfaEnabled = auth2faType === 'on' || auth2faType === 'optional';
-  const u2fEnabled = auth2faType === 'u2f';
-  const otpEnabled = auth2faType === 'otp';
   const ssoEnabled = authProviders && authProviders.length > 0;
 
   const [pass, setPass] = useState('');
   const [user, setUser] = useState('');
   const [token, setToken] = useState('');
-  const [mfaOptions] = useState<MFAOption[]>(() => {
-    const mfaOptions: MFAOption[] = [];
 
-    if (auth2faType === 'optional') {
-      mfaOptions.push({ value: 'optional', label: 'None' });
-    }
+  const mfaOptions = useMemo<MfaOption[]>(() => getMfaOptions(auth2faType), []);
 
-    if (mfaEnabled || u2fEnabled) {
-      mfaOptions.push({ value: 'u2f', label: 'Hardware Key' });
-    }
-
-    if (mfaEnabled || otpEnabled) {
-      mfaOptions.push({ value: 'otp', label: 'Authenticator App' });
-    }
-
-    return mfaOptions;
-  });
-
-  const [mfaType, setMfaType] = useState<MFAOption>(mfaOptions[0]);
+  const [mfaType, setMfaType] = useState<MfaOption>(mfaOptions[0]);
   const [isExpanded, toggleExpander] = useState(
     !(isLocalAuthEnabled && ssoEnabled)
   );
@@ -90,7 +72,7 @@ export default function LoginForm(props: Props) {
     }
   }
 
-  function onSetMfaOption(option: MFAOption, validator: Validator) {
+  function onSetMfaOption(option: MfaOption, validator: Validator) {
     setToken('');
     clearAttempt();
     validator.reset();
@@ -180,7 +162,7 @@ export default function LoginForm(props: Props) {
                         value={mfaType}
                         options={mfaOptions}
                         onChange={opt =>
-                          onSetMfaOption(opt as MFAOption, validator)
+                          onSetMfaOption(opt as MfaOption, validator)
                         }
                         mr={3}
                         mb={0}
@@ -294,5 +276,3 @@ type Props = {
   onLoginWithU2f(username: string, password: string): void;
   onLogin(username: string, password: string, token: string): void;
 };
-
-type MFAOption = Option<Auth2faType>;

--- a/packages/shared/components/FormLogin/FormLogin.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.tsx
@@ -164,7 +164,7 @@ export default function LoginForm(props: Props) {
                   <Box textAlign="right">
                     <ButtonLink
                       style={{ padding: '0px', minHeight: 0 }}
-                      onClick={() => onRecover(true)}
+                      onClick={() => onRecover('password')}
                     >
                       Forgot Password?
                     </ButtonLink>
@@ -211,7 +211,7 @@ export default function LoginForm(props: Props) {
                     <Box>
                       <ButtonLink
                         style={{ padding: '0px', minHeight: 0 }}
-                        onClick={() => onRecover(false)}
+                        onClick={() => onRecover('2fa')}
                       >
                         Lost Two-Factor Device?
                       </ButtonLink>
@@ -288,7 +288,7 @@ type Props = {
   auth2faType?: Auth2faType;
   attempt: ReturnType<typeof useAttempt>[0];
   isRecoveryEnabled?: boolean;
-  onRecover?: (isRecoverPassword: boolean) => void;
+  onRecover?: (type: 'password' | '2fa') => void;
   clearAttempt?: () => void;
   onLoginWithSso(provider: AuthProvider): void;
   onLoginWithU2f(username: string, password: string): void;

--- a/packages/shared/components/FormLogin/FormLogin.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.tsx
@@ -54,7 +54,7 @@ export default function LoginForm(props: Props) {
     const mfaOptions: MFAOption[] = [];
 
     if (auth2faType === 'optional') {
-      mfaOptions.push({ value: 'optional', label: 'NONE' });
+      mfaOptions.push({ value: 'optional', label: 'None' });
     }
 
     if (mfaEnabled || u2fEnabled) {

--- a/packages/shared/components/FormLogin/FormLogin.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.tsx
@@ -91,7 +91,7 @@ export default function LoginForm(props: Props) {
       {({ validator }) => (
         <CardLogin title={title}>
           {isFailed && (
-            <Alerts.Danger mx={5} mb={0} mt={5}>
+            <Alerts.Danger m={5} mb={0}>
               {message}
             </Alerts.Danger>
           )}
@@ -105,7 +105,6 @@ export default function LoginForm(props: Props) {
           )}
           {ssoEnabled && isLocalAuthEnabled && (
             <Flex
-              height="1px"
               alignItems="center"
               justifyContent="center"
               style={{ position: 'relative' }}
@@ -146,7 +145,7 @@ export default function LoginForm(props: Props) {
                   <Box textAlign="right">
                     <ButtonLink
                       style={{ padding: '0px', minHeight: 0 }}
-                      onClick={() => onRecover('password')}
+                      onClick={() => onRecover(true)}
                     >
                       Forgot Password?
                     </ButtonLink>
@@ -156,48 +155,46 @@ export default function LoginForm(props: Props) {
               {auth2faType !== 'off' && (
                 <Box mb={isRecoveryEnabled ? 3 : 4}>
                   <Flex alignItems="flex-end">
-                    <Box width="50%" data-testid="mfa-select">
-                      <FieldSelect
-                        label="Two-factor type"
-                        value={mfaType}
-                        options={mfaOptions}
-                        onChange={opt =>
-                          onSetMfaOption(opt as MfaOption, validator)
-                        }
-                        mr={3}
+                    <FieldSelect
+                      maxWidth="50%"
+                      width="100%"
+                      data-testid="mfa-select"
+                      label="Two-factor type"
+                      value={mfaType}
+                      options={mfaOptions}
+                      onChange={opt =>
+                        onSetMfaOption(opt as MfaOption, validator)
+                      }
+                      mr={3}
+                      mb={0}
+                      isDisabled={isProcessing}
+                    />
+                    {mfaType.value === 'otp' && (
+                      <FieldInput
+                        width="50%"
+                        label="Authenticator code"
+                        rule={requiredToken}
+                        autoComplete="off"
+                        value={token}
+                        onChange={e => setToken(e.target.value)}
+                        placeholder="123 456"
                         mb={0}
-                        isDisabled={isProcessing}
                       />
-                    </Box>
-                    <Box width="50%">
-                      {mfaType.value === 'otp' && (
-                        <FieldInput
-                          label="Authenticator code"
-                          rule={requiredToken}
-                          autoComplete="off"
-                          value={token}
-                          onChange={e => setToken(e.target.value)}
-                          placeholder="123 456"
-                          mb={0}
-                        />
-                      )}
-                      {mfaType.value === 'u2f' && isProcessing && (
-                        <Text typography="body2" mb={1}>
-                          Insert your hardware key and press the button on the
-                          key.
-                        </Text>
-                      )}
-                    </Box>
+                    )}
+                    {mfaType.value === 'u2f' && isProcessing && (
+                      <Text typography="body2" mb={1}>
+                        Insert your hardware key and press the button on the
+                        key.
+                      </Text>
+                    )}
                   </Flex>
                   {isRecoveryEnabled && (
-                    <Box>
-                      <ButtonLink
-                        style={{ padding: '0px', minHeight: 0 }}
-                        onClick={() => onRecover('2fa')}
-                      >
-                        Lost Two-Factor Device?
-                      </ButtonLink>
-                    </Box>
+                    <ButtonLink
+                      style={{ padding: '0px', minHeight: 0 }}
+                      onClick={() => onRecover(false)}
+                    >
+                      Lost Two-Factor Device?
+                    </ButtonLink>
                   )}
                 </Box>
               )}
@@ -270,7 +267,7 @@ type Props = {
   auth2faType?: Auth2faType;
   attempt: ReturnType<typeof useAttempt>[0];
   isRecoveryEnabled?: boolean;
-  onRecover?: (type: 'password' | '2fa') => void;
+  onRecover?: (isRecoverPassword: boolean) => void;
   clearAttempt?: () => void;
   onLoginWithSso(provider: AuthProvider): void;
   onLoginWithU2f(username: string, password: string): void;

--- a/packages/shared/components/FormLogin/FormLogin.tsx
+++ b/packages/shared/components/FormLogin/FormLogin.tsx
@@ -58,11 +58,11 @@ export default function LoginForm(props: Props) {
     }
 
     if (mfaEnabled || u2fEnabled) {
-      mfaOptions.push({ value: 'u2f', label: 'U2F' });
+      mfaOptions.push({ value: 'u2f', label: 'Hardware Key' });
     }
 
     if (mfaEnabled || otpEnabled) {
-      mfaOptions.push({ value: 'otp', label: 'TOTP' });
+      mfaOptions.push({ value: 'otp', label: 'Authenticator App' });
     }
 
     return mfaOptions;
@@ -164,7 +164,7 @@ export default function LoginForm(props: Props) {
                   <Box textAlign="right">
                     <ButtonLink
                       style={{ padding: '0px', minHeight: 0 }}
-                      onClick={() => onRecover('password')}
+                      onClick={() => onRecover(true)}
                     >
                       Forgot Password?
                     </ButtonLink>
@@ -176,7 +176,7 @@ export default function LoginForm(props: Props) {
                   <Flex alignItems="flex-end">
                     <Box width="50%" data-testid="mfa-select">
                       <FieldSelect
-                        label="Second factor"
+                        label="Two-factor type"
                         value={mfaType}
                         options={mfaOptions}
                         onChange={opt =>
@@ -190,7 +190,7 @@ export default function LoginForm(props: Props) {
                     <Box width="50%">
                       {mfaType.value === 'otp' && (
                         <FieldInput
-                          label="two-factor token"
+                          label="Authenticator code"
                           rule={requiredToken}
                           autoComplete="off"
                           value={token}
@@ -201,31 +201,19 @@ export default function LoginForm(props: Props) {
                       )}
                       {mfaType.value === 'u2f' && isProcessing && (
                         <Text typography="body2" mb={1}>
-                          Insert your U2F key and press the button on the key.
+                          Insert your hardware key and press the button on the
+                          key.
                         </Text>
                       )}
                     </Box>
                   </Flex>
-                  {isRecoveryEnabled && mfaType.value === 'u2f' && (
+                  {isRecoveryEnabled && (
                     <Box>
                       <ButtonLink
                         style={{ padding: '0px', minHeight: 0 }}
-                        onClick={() => onRecover('u2f')}
+                        onClick={() => onRecover(false)}
                       >
-                        Lost U2F Key?
-                      </ButtonLink>
-                    </Box>
-                  )}
-                  {isRecoveryEnabled && mfaType.value === 'otp' && (
-                    <Box>
-                      <ButtonLink
-                        style={{
-                          padding: '0px',
-                          minHeight: 0,
-                        }}
-                        onClick={() => onRecover('totp')}
-                      >
-                        Lost Two-Factor Token?
+                        Lost Two-Factor Device?
                       </ButtonLink>
                     </Box>
                   )}
@@ -300,7 +288,7 @@ type Props = {
   auth2faType?: Auth2faType;
   attempt: ReturnType<typeof useAttempt>[0];
   isRecoveryEnabled?: boolean;
-  onRecover?: (type: 'totp' | 'u2f' | 'password') => void;
+  onRecover?: (isRecoverPassword: boolean) => void;
   clearAttempt?: () => void;
   onLoginWithSso(provider: AuthProvider): void;
   onLoginWithU2f(username: string, password: string): void;

--- a/packages/shared/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/packages/shared/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -1,5 +1,371 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`auth2faType: optional rendering 1`] = `
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c8 {
+  box-sizing: border-box;
+  width: 50%;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-bottom: 0px;
+  margin-right: 16px;
+}
+
+.c11 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c11:active {
+  opacity: 0.56;
+}
+
+.c11:hover,
+.c11:focus {
+  background: #651FFF;
+}
+
+.c11:active {
+  background: #354AA4;
+}
+
+.c11:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c0 {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 32px;
+  margin-bottom: 32px;
+  width: 464px;
+  background-color: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-radius: 8px;
+}
+
+.c5 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  color: #324148;
+  background-color: #FFFFFF;
+}
+
+.c5::-ms-clear {
+  display: none;
+}
+
+.c5::placeholder {
+  opacity: 0.4;
+}
+
+.c5:read-only {
+  cursor: not-allowed;
+}
+
+.c4 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  padding-top: 32px;
+  color: #FFFFFF;
+  text-align: center;
+}
+
+.c2 {
+  box-sizing: border-box;
+  padding: 32px;
+  background-color: #222C59;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.c7 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-end;
+}
+
+.c10 .react-select-container {
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
+  box-sizing: border-box;
+  border: none;
+  display: block;
+  font-size: 14px;
+  outline: none;
+  width: 100%;
+  color: rgba(0,0,0,0.87);
+  background-color: #ffffff;
+  margin-bottom: 0px;
+  border-radius: 4px;
+}
+
+.c10 .react-select__control,
+.c10 .react-select__control--is-focused {
+  min-height: 40px;
+  height: 40px;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+}
+
+.c10 .react-select__control:hover,
+.c10 .react-select__control--is-focused:hover {
+  border-color: transparent;
+  cursor: pointer;
+}
+
+.c10 .react-select__option:hover {
+  cursor: pointer;
+  background-color: #eceff1;
+}
+
+.c10 .react-select__option--is-focused {
+  background-color: #eceff1;
+}
+
+.c10 .react-select__option--is-selected {
+  background-color: #cfd8dc;
+  color: inherit;
+}
+
+.c10 .react-select__option--is-selected:hover {
+  background-color: #cfd8dc;
+}
+
+.c10 .react-select__menu {
+  margin-top: 0px;
+}
+
+.c10 .react-select__indicator-separator {
+  display: none;
+}
+
+.c10 .react-select__loading-indicator {
+  display: none;
+}
+
+.c10 .react-select--is-disabled .react-select__single-value,
+.c10 .react-select--is-disabled .react-select__placeholder {
+  color: rgba(0,0,0,0.24);
+}
+
+.c10 .react-select--is-disabled .react-select__indicator {
+  color: rgba(0,0,0,0.14);
+}
+
+<div
+  class="c0"
+  width="464px"
+>
+  <div
+    class="c1"
+    color="light"
+  >
+    Custom Title
+  </div>
+  <form
+    class="c2"
+  >
+    <div
+      class="c3"
+    >
+      <label
+        class="c4"
+        font-size="0"
+      >
+        Username
+      </label>
+      <input
+        autocomplete="off"
+        class="c5"
+        color="text.onLight"
+        placeholder="Username"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c6"
+        width="100%"
+      >
+        <label
+          class="c4"
+          font-size="0"
+        >
+          Password
+        </label>
+        <input
+          autocomplete="off"
+          class="c5"
+          color="text.onLight"
+          placeholder="Password"
+          type="password"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c7"
+      >
+        <div
+          class="c8"
+          data-testid="mfa-select"
+          width="50%"
+        >
+          <div
+            class="c9"
+          >
+            <label
+              class="c4"
+              font-size="0"
+            >
+              Two-factor type
+            </label>
+            <div
+              class="c10"
+            >
+              <div
+                class="react-select-container css-2b097c-container"
+              >
+                <div
+                  class="react-select__control css-yk16xz-control"
+                >
+                  <div
+                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                  >
+                    <div
+                      class="react-select__single-value css-1uccc91-singleValue"
+                    >
+                      None
+                    </div>
+                    <input
+                      aria-autocomplete="list"
+                      class="css-62g3xt-dummyInput"
+                      id="react-select-3-input"
+                      readonly=""
+                      tabindex="0"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                  >
+                    <span
+                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="css-6q0nyr-Svg"
+                        focusable="false"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                      >
+                        <path
+                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c8"
+          width="50%"
+        />
+      </div>
+    </div>
+    <button
+      class="c11"
+      kind="primary"
+      type="submit"
+      width="100%"
+    >
+      LOGIN
+    </button>
+  </form>
+</div>
+`;
+
 exports[`auth2faType: otp rendering 1`] = `
 .c3 {
   box-sizing: border-box;
@@ -714,7 +1080,7 @@ exports[`auth2faType: u2f rendering 1`] = `
                       aria-autocomplete="list"
                       class="css-62g3xt-dummyInput"
                       disabled=""
-                      id="react-select-3-input"
+                      id="react-select-5-input"
                       readonly=""
                       tabindex="0"
                       value=""
@@ -764,6 +1130,471 @@ exports[`auth2faType: u2f rendering 1`] = `
     <button
       class="c12"
       disabled=""
+      kind="primary"
+      type="submit"
+      width="100%"
+    >
+      LOGIN
+    </button>
+  </form>
+</div>
+`;
+
+exports[`cloud auth2faType: on rendering 1`] = `
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  margin-bottom: 8px;
+}
+
+.c7 {
+  box-sizing: border-box;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c8 {
+  box-sizing: border-box;
+  text-align: right;
+}
+
+.c11 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
+.c13 {
+  box-sizing: border-box;
+  width: 50%;
+}
+
+.c14 {
+  box-sizing: border-box;
+  margin-bottom: 0px;
+  margin-right: 16px;
+}
+
+.c16 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+}
+
+.c10:active {
+  opacity: 0.56;
+}
+
+.c10:hover,
+.c10:focus {
+  background: #651FFF;
+}
+
+.c10:active {
+  background: #354AA4;
+}
+
+.c10:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c17 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c17:active {
+  opacity: 0.56;
+}
+
+.c17:hover,
+.c17:focus {
+  background: #651FFF;
+}
+
+.c17:active {
+  background: #354AA4;
+}
+
+.c17:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c9 {
+  color: #03a9f4;
+  font-weight: normal;
+  background: none;
+  text-decoration: underline;
+  text-transform: none;
+  padding: 0 8px;
+}
+
+.c9:hover,
+.c9:focus {
+  background: #222C59;
+}
+
+.c0 {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 32px;
+  margin-bottom: 32px;
+  width: 464px;
+  background-color: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-radius: 8px;
+}
+
+.c5 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  color: #324148;
+  background-color: #FFFFFF;
+}
+
+.c5::-ms-clear {
+  display: none;
+}
+
+.c5::placeholder {
+  opacity: 0.4;
+}
+
+.c5:read-only {
+  cursor: not-allowed;
+}
+
+.c4 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  padding-top: 32px;
+  color: #FFFFFF;
+  text-align: center;
+}
+
+.c2 {
+  box-sizing: border-box;
+  padding: 32px;
+  background-color: #222C59;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.c12 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-end;
+}
+
+.c15 .react-select-container {
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
+  box-sizing: border-box;
+  border: none;
+  display: block;
+  font-size: 14px;
+  outline: none;
+  width: 100%;
+  color: rgba(0,0,0,0.87);
+  background-color: #ffffff;
+  margin-bottom: 0px;
+  border-radius: 4px;
+}
+
+.c15 .react-select__control,
+.c15 .react-select__control--is-focused {
+  min-height: 40px;
+  height: 40px;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+}
+
+.c15 .react-select__control:hover,
+.c15 .react-select__control--is-focused:hover {
+  border-color: transparent;
+  cursor: pointer;
+}
+
+.c15 .react-select__option:hover {
+  cursor: pointer;
+  background-color: #eceff1;
+}
+
+.c15 .react-select__option--is-focused {
+  background-color: #eceff1;
+}
+
+.c15 .react-select__option--is-selected {
+  background-color: #cfd8dc;
+  color: inherit;
+}
+
+.c15 .react-select__option--is-selected:hover {
+  background-color: #cfd8dc;
+}
+
+.c15 .react-select__menu {
+  margin-top: 0px;
+}
+
+.c15 .react-select__indicator-separator {
+  display: none;
+}
+
+.c15 .react-select__loading-indicator {
+  display: none;
+}
+
+.c15 .react-select--is-disabled .react-select__single-value,
+.c15 .react-select--is-disabled .react-select__placeholder {
+  color: rgba(0,0,0,0.24);
+}
+
+.c15 .react-select--is-disabled .react-select__indicator {
+  color: rgba(0,0,0,0.14);
+}
+
+<div
+  class="c0"
+  width="464px"
+>
+  <div
+    class="c1"
+    color="light"
+  >
+    Teleport Cloud
+  </div>
+  <form
+    class="c2"
+  >
+    <div
+      class="c3"
+    >
+      <label
+        class="c4"
+        font-size="0"
+      >
+        Username
+      </label>
+      <input
+        autocomplete="off"
+        class="c5"
+        color="text.onLight"
+        placeholder="Username"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+        width="100%"
+      >
+        <label
+          class="c4"
+          font-size="0"
+        >
+          Password
+        </label>
+        <input
+          autocomplete="off"
+          class="c5"
+          color="text.onLight"
+          placeholder="Password"
+          type="password"
+          value=""
+        />
+      </div>
+      <div
+        class="c8"
+      >
+        <a
+          class="c9 c10"
+          kind="primary"
+          style="padding: 0px; min-height: 0;"
+        >
+          Forgot Password?
+        </a>
+      </div>
+    </div>
+    <div
+      class="c11"
+    >
+      <div
+        class="c12"
+      >
+        <div
+          class="c13"
+          data-testid="mfa-select"
+          width="50%"
+        >
+          <div
+            class="c14"
+          >
+            <label
+              class="c4"
+              font-size="0"
+            >
+              Two-factor type
+            </label>
+            <div
+              class="c15"
+            >
+              <div
+                class="react-select-container css-2b097c-container"
+              >
+                <div
+                  class="react-select__control css-yk16xz-control"
+                >
+                  <div
+                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                  >
+                    <div
+                      class="react-select__single-value css-1uccc91-singleValue"
+                    >
+                      Hardware Key
+                    </div>
+                    <input
+                      aria-autocomplete="list"
+                      class="css-62g3xt-dummyInput"
+                      id="react-select-4-input"
+                      readonly=""
+                      tabindex="0"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                  >
+                    <span
+                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="css-6q0nyr-Svg"
+                        focusable="false"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                      >
+                        <path
+                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c13"
+          width="50%"
+        />
+      </div>
+      <div
+        class="c16"
+      >
+        <a
+          class="c9 c10"
+          kind="primary"
+          style="padding: 0px; min-height: 0;"
+        >
+          Lost Two-Factor Device?
+        </a>
+      </div>
+    </div>
+    <button
+      class="c17"
       kind="primary"
       type="submit"
       width="100%"

--- a/packages/shared/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/packages/shared/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -296,7 +296,7 @@ exports[`auth2faType: otp rendering 1`] = `
               class="c4"
               font-size="0"
             >
-              Second factor
+              Two-factor type
             </label>
             <div
               class="c10"
@@ -313,7 +313,7 @@ exports[`auth2faType: otp rendering 1`] = `
                     <div
                       class="react-select__single-value css-1uccc91-singleValue"
                     >
-                      TOTP
+                      Authenticator App
                     </div>
                     <input
                       aria-autocomplete="list"
@@ -364,7 +364,7 @@ exports[`auth2faType: otp rendering 1`] = `
               class="c4"
               font-size="0"
             >
-              two-factor token
+              Authenticator code
             </label>
             <input
               autocomplete="off"
@@ -691,7 +691,7 @@ exports[`auth2faType: u2f rendering 1`] = `
               class="c4"
               font-size="0"
             >
-              Second factor
+              Two-factor type
             </label>
             <div
               class="c10"
@@ -708,7 +708,7 @@ exports[`auth2faType: u2f rendering 1`] = `
                     <div
                       class="react-select__single-value react-select__single-value--is-disabled css-107lb6w-singleValue"
                     >
-                      U2F
+                      Hardware Key
                     </div>
                     <input
                       aria-autocomplete="list"
@@ -756,7 +756,7 @@ exports[`auth2faType: u2f rendering 1`] = `
           <div
             class="c11"
           >
-            Insert your U2F key and press the button on the key.
+            Insert your hardware key and press the button on the key.
           </div>
         </div>
       </div>

--- a/packages/shared/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/packages/shared/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -14,13 +14,371 @@ exports[`auth2faType: optional rendering 1`] = `
 
 .c8 {
   box-sizing: border-box;
-  width: 50%;
-}
-
-.c9 {
-  box-sizing: border-box;
+  max-width: 50%;
   margin-bottom: 0px;
   margin-right: 16px;
+  width: 100%;
+}
+
+.c10 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c10:active {
+  opacity: 0.56;
+}
+
+.c10:hover,
+.c10:focus {
+  background: #651FFF;
+}
+
+.c10:active {
+  background: #354AA4;
+}
+
+.c10:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c0 {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 32px;
+  margin-bottom: 32px;
+  width: 464px;
+  background-color: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-radius: 8px;
+}
+
+.c5 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  color: #324148;
+  background-color: #FFFFFF;
+}
+
+.c5::-ms-clear {
+  display: none;
+}
+
+.c5::placeholder {
+  opacity: 0.4;
+}
+
+.c5:read-only {
+  cursor: not-allowed;
+}
+
+.c4 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  padding-top: 32px;
+  color: #FFFFFF;
+  text-align: center;
+}
+
+.c2 {
+  box-sizing: border-box;
+  padding: 32px;
+  background-color: #222C59;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.c7 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-end;
+}
+
+.c9 .react-select-container {
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
+  box-sizing: border-box;
+  border: none;
+  display: block;
+  font-size: 14px;
+  outline: none;
+  width: 100%;
+  color: rgba(0,0,0,0.87);
+  background-color: #ffffff;
+  margin-bottom: 0px;
+  border-radius: 4px;
+}
+
+.c9 .react-select__control,
+.c9 .react-select__control--is-focused {
+  min-height: 40px;
+  height: 40px;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+}
+
+.c9 .react-select__control:hover,
+.c9 .react-select__control--is-focused:hover {
+  border-color: transparent;
+  cursor: pointer;
+}
+
+.c9 .react-select__option:hover {
+  cursor: pointer;
+  background-color: #eceff1;
+}
+
+.c9 .react-select__option--is-focused {
+  background-color: #eceff1;
+}
+
+.c9 .react-select__option--is-selected {
+  background-color: #cfd8dc;
+  color: inherit;
+}
+
+.c9 .react-select__option--is-selected:hover {
+  background-color: #cfd8dc;
+}
+
+.c9 .react-select__menu {
+  margin-top: 0px;
+}
+
+.c9 .react-select__indicator-separator {
+  display: none;
+}
+
+.c9 .react-select__loading-indicator {
+  display: none;
+}
+
+.c9 .react-select--is-disabled .react-select__single-value,
+.c9 .react-select--is-disabled .react-select__placeholder {
+  color: rgba(0,0,0,0.24);
+}
+
+.c9 .react-select--is-disabled .react-select__indicator {
+  color: rgba(0,0,0,0.14);
+}
+
+<div
+  class="c0"
+  width="464px"
+>
+  <div
+    class="c1"
+    color="light"
+  >
+    Custom Title
+  </div>
+  <form
+    class="c2"
+  >
+    <div
+      class="c3"
+    >
+      <label
+        class="c4"
+        font-size="0"
+      >
+        Username
+      </label>
+      <input
+        autocomplete="off"
+        class="c5"
+        color="text.onLight"
+        placeholder="Username"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c6"
+        width="100%"
+      >
+        <label
+          class="c4"
+          font-size="0"
+        >
+          Password
+        </label>
+        <input
+          autocomplete="off"
+          class="c5"
+          color="text.onLight"
+          placeholder="Password"
+          type="password"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c7"
+      >
+        <div
+          class="c8"
+          data-testid="mfa-select"
+          width="100%"
+        >
+          <label
+            class="c4"
+            font-size="0"
+          >
+            Two-factor type
+          </label>
+          <div
+            class="c9"
+          >
+            <div
+              class="react-select-container css-2b097c-container"
+            >
+              <div
+                class="react-select__control css-yk16xz-control"
+              >
+                <div
+                  class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                >
+                  <div
+                    class="react-select__single-value css-1uccc91-singleValue"
+                  >
+                    None
+                  </div>
+                  <input
+                    aria-autocomplete="list"
+                    class="css-62g3xt-dummyInput"
+                    id="react-select-3-input"
+                    readonly=""
+                    tabindex="0"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
+                    >
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="c10"
+      kind="primary"
+      type="submit"
+      width="100%"
+    >
+      LOGIN
+    </button>
+  </form>
+</div>
+`;
+
+exports[`auth2faType: otp rendering 1`] = `
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c8 {
+  box-sizing: border-box;
+  max-width: 50%;
+  margin-bottom: 0px;
+  margin-right: 16px;
+  width: 100%;
+}
+
+.c10 {
+  box-sizing: border-box;
+  margin-bottom: 0px;
+  width: 50%;
 }
 
 .c11 {
@@ -148,7 +506,7 @@ exports[`auth2faType: optional rendering 1`] = `
   align-items: flex-end;
 }
 
-.c10 .react-select-container {
+.c9 .react-select-container {
   box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
   box-sizing: border-box;
   border: none;
@@ -162,8 +520,8 @@ exports[`auth2faType: optional rendering 1`] = `
   border-radius: 4px;
 }
 
-.c10 .react-select__control,
-.c10 .react-select__control--is-focused {
+.c9 .react-select__control,
+.c9 .react-select__control--is-focused {
   min-height: 40px;
   height: 40px;
   background-color: transparent;
@@ -174,48 +532,48 @@ exports[`auth2faType: optional rendering 1`] = `
   box-shadow: none;
 }
 
-.c10 .react-select__control:hover,
-.c10 .react-select__control--is-focused:hover {
+.c9 .react-select__control:hover,
+.c9 .react-select__control--is-focused:hover {
   border-color: transparent;
   cursor: pointer;
 }
 
-.c10 .react-select__option:hover {
+.c9 .react-select__option:hover {
   cursor: pointer;
   background-color: #eceff1;
 }
 
-.c10 .react-select__option--is-focused {
+.c9 .react-select__option--is-focused {
   background-color: #eceff1;
 }
 
-.c10 .react-select__option--is-selected {
+.c9 .react-select__option--is-selected {
   background-color: #cfd8dc;
   color: inherit;
 }
 
-.c10 .react-select__option--is-selected:hover {
+.c9 .react-select__option--is-selected:hover {
   background-color: #cfd8dc;
 }
 
-.c10 .react-select__menu {
+.c9 .react-select__menu {
   margin-top: 0px;
 }
 
-.c10 .react-select__indicator-separator {
+.c9 .react-select__indicator-separator {
   display: none;
 }
 
-.c10 .react-select__loading-indicator {
+.c9 .react-select__loading-indicator {
   display: none;
 }
 
-.c10 .react-select--is-disabled .react-select__single-value,
-.c10 .react-select--is-disabled .react-select__placeholder {
+.c9 .react-select--is-disabled .react-select__single-value,
+.c9 .react-select--is-disabled .react-select__placeholder {
   color: rgba(0,0,0,0.24);
 }
 
-.c10 .react-select--is-disabled .react-select__indicator {
+.c9 .react-select--is-disabled .react-select__indicator {
   color: rgba(0,0,0,0.14);
 }
 
@@ -282,66 +640,62 @@ exports[`auth2faType: optional rendering 1`] = `
         <div
           class="c8"
           data-testid="mfa-select"
-          width="50%"
+          width="100%"
         >
+          <label
+            class="c4"
+            font-size="0"
+          >
+            Two-factor type
+          </label>
           <div
             class="c9"
           >
-            <label
-              class="c4"
-              font-size="0"
-            >
-              Two-factor type
-            </label>
             <div
-              class="c10"
+              class="react-select-container css-2b097c-container"
             >
               <div
-                class="react-select-container css-2b097c-container"
+                class="react-select__control css-yk16xz-control"
               >
                 <div
-                  class="react-select__control css-yk16xz-control"
+                  class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
                 >
                   <div
-                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                    class="react-select__single-value css-1uccc91-singleValue"
                   >
-                    <div
-                      class="react-select__single-value css-1uccc91-singleValue"
-                    >
-                      None
-                    </div>
-                    <input
-                      aria-autocomplete="list"
-                      class="css-62g3xt-dummyInput"
-                      id="react-select-3-input"
-                      readonly=""
-                      tabindex="0"
-                      value=""
-                    />
+                    Authenticator App
                   </div>
+                  <input
+                    aria-autocomplete="list"
+                    class="css-62g3xt-dummyInput"
+                    id="react-select-2-input"
+                    readonly=""
+                    tabindex="0"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                  />
                   <div
-                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                    aria-hidden="true"
+                    class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
                   >
-                    <span
-                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
-                    />
-                    <div
+                    <svg
                       aria-hidden="true"
-                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="css-6q0nyr-Svg"
-                        focusable="false"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        width="20"
-                      >
-                        <path
-                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                        />
-                      </svg>
-                    </div>
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
@@ -349,403 +703,28 @@ exports[`auth2faType: optional rendering 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
           width="50%"
-        />
+        >
+          <label
+            class="c4"
+            font-size="0"
+          >
+            Authenticator code
+          </label>
+          <input
+            autocomplete="off"
+            class="c5"
+            color="text.onLight"
+            placeholder="123 456"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
     <button
       class="c11"
-      kind="primary"
-      type="submit"
-      width="100%"
-    >
-      LOGIN
-    </button>
-  </form>
-</div>
-`;
-
-exports[`auth2faType: otp rendering 1`] = `
-.c3 {
-  box-sizing: border-box;
-  margin-bottom: 24px;
-}
-
-.c6 {
-  box-sizing: border-box;
-  margin-bottom: 0px;
-  width: 100%;
-}
-
-.c8 {
-  box-sizing: border-box;
-  width: 50%;
-}
-
-.c9 {
-  box-sizing: border-box;
-  margin-bottom: 0px;
-  margin-right: 16px;
-}
-
-.c11 {
-  box-sizing: border-box;
-  margin-bottom: 0px;
-}
-
-.c12 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 40px;
-  font-size: 12px;
-  padding: 0px 40px;
-  margin-top: 16px;
-  width: 100%;
-}
-
-.c12:active {
-  opacity: 0.56;
-}
-
-.c12:hover,
-.c12:focus {
-  background: #651FFF;
-}
-
-.c12:active {
-  background: #354AA4;
-}
-
-.c12:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c0 {
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 32px;
-  margin-bottom: 32px;
-  width: 464px;
-  background-color: #222C59;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
-  border-radius: 8px;
-}
-
-.c5 {
-  appearance: none;
-  border: none;
-  border-radius: 4px;
-  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
-  box-sizing: border-box;
-  display: block;
-  height: 40px;
-  font-size: 16px;
-  padding: 0 16px;
-  outline: none;
-  width: 100%;
-  color: #324148;
-  background-color: #FFFFFF;
-}
-
-.c5::-ms-clear {
-  display: none;
-}
-
-.c5::placeholder {
-  opacity: 0.4;
-}
-
-.c5:read-only {
-  cursor: not-allowed;
-}
-
-.c4 {
-  color: #FFFFFF;
-  display: block;
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  width: 100%;
-  margin-bottom: 4px;
-}
-
-.c1 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 300;
-  font-size: 22px;
-  line-height: 32px;
-  margin: 0px;
-  padding-top: 32px;
-  color: #FFFFFF;
-  text-align: center;
-}
-
-.c2 {
-  box-sizing: border-box;
-  padding: 32px;
-  background-color: #222C59;
-  border-bottom-right-radius: 8px;
-  border-bottom-left-radius: 8px;
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-}
-
-.c7 {
-  box-sizing: border-box;
-  display: flex;
-  align-items: flex-end;
-}
-
-.c10 .react-select-container {
-  box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
-  box-sizing: border-box;
-  border: none;
-  display: block;
-  font-size: 14px;
-  outline: none;
-  width: 100%;
-  color: rgba(0,0,0,0.87);
-  background-color: #ffffff;
-  margin-bottom: 0px;
-  border-radius: 4px;
-}
-
-.c10 .react-select__control,
-.c10 .react-select__control--is-focused {
-  min-height: 40px;
-  height: 40px;
-  background-color: transparent;
-  border-color: transparent;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: none;
-}
-
-.c10 .react-select__control:hover,
-.c10 .react-select__control--is-focused:hover {
-  border-color: transparent;
-  cursor: pointer;
-}
-
-.c10 .react-select__option:hover {
-  cursor: pointer;
-  background-color: #eceff1;
-}
-
-.c10 .react-select__option--is-focused {
-  background-color: #eceff1;
-}
-
-.c10 .react-select__option--is-selected {
-  background-color: #cfd8dc;
-  color: inherit;
-}
-
-.c10 .react-select__option--is-selected:hover {
-  background-color: #cfd8dc;
-}
-
-.c10 .react-select__menu {
-  margin-top: 0px;
-}
-
-.c10 .react-select__indicator-separator {
-  display: none;
-}
-
-.c10 .react-select__loading-indicator {
-  display: none;
-}
-
-.c10 .react-select--is-disabled .react-select__single-value,
-.c10 .react-select--is-disabled .react-select__placeholder {
-  color: rgba(0,0,0,0.24);
-}
-
-.c10 .react-select--is-disabled .react-select__indicator {
-  color: rgba(0,0,0,0.14);
-}
-
-<div
-  class="c0"
-  width="464px"
->
-  <div
-    class="c1"
-    color="light"
-  >
-    Custom Title
-  </div>
-  <form
-    class="c2"
-  >
-    <div
-      class="c3"
-    >
-      <label
-        class="c4"
-        font-size="0"
-      >
-        Username
-      </label>
-      <input
-        autocomplete="off"
-        class="c5"
-        color="text.onLight"
-        placeholder="Username"
-        type="text"
-        value=""
-      />
-    </div>
-    <div
-      class="c3"
-    >
-      <div
-        class="c6"
-        width="100%"
-      >
-        <label
-          class="c4"
-          font-size="0"
-        >
-          Password
-        </label>
-        <input
-          autocomplete="off"
-          class="c5"
-          color="text.onLight"
-          placeholder="Password"
-          type="password"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      class="c3"
-    >
-      <div
-        class="c7"
-      >
-        <div
-          class="c8"
-          data-testid="mfa-select"
-          width="50%"
-        >
-          <div
-            class="c9"
-          >
-            <label
-              class="c4"
-              font-size="0"
-            >
-              Two-factor type
-            </label>
-            <div
-              class="c10"
-            >
-              <div
-                class="react-select-container css-2b097c-container"
-              >
-                <div
-                  class="react-select__control css-yk16xz-control"
-                >
-                  <div
-                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
-                  >
-                    <div
-                      class="react-select__single-value css-1uccc91-singleValue"
-                    >
-                      Authenticator App
-                    </div>
-                    <input
-                      aria-autocomplete="list"
-                      class="css-62g3xt-dummyInput"
-                      id="react-select-2-input"
-                      readonly=""
-                      tabindex="0"
-                      value=""
-                    />
-                  </div>
-                  <div
-                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
-                  >
-                    <span
-                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
-                    />
-                    <div
-                      aria-hidden="true"
-                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-6q0nyr-Svg"
-                        focusable="false"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        width="20"
-                      >
-                        <path
-                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="c8"
-          width="50%"
-        >
-          <div
-            class="c11"
-          >
-            <label
-              class="c4"
-              font-size="0"
-            >
-              Authenticator code
-            </label>
-            <input
-              autocomplete="off"
-              class="c5"
-              color="text.onLight"
-              placeholder="123 456"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <button
-      class="c12"
       kind="primary"
       type="submit"
       width="100%"
@@ -770,16 +749,13 @@ exports[`auth2faType: u2f rendering 1`] = `
 
 .c8 {
   box-sizing: border-box;
-  width: 50%;
-}
-
-.c9 {
-  box-sizing: border-box;
+  max-width: 50%;
   margin-bottom: 0px;
   margin-right: 16px;
+  width: 100%;
 }
 
-.c12 {
+.c11 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -807,20 +783,20 @@ exports[`auth2faType: u2f rendering 1`] = `
   width: 100%;
 }
 
-.c12:active {
+.c11:active {
   opacity: 0.56;
 }
 
-.c12:hover,
-.c12:focus {
+.c11:hover,
+.c11:focus {
   background: #651FFF;
 }
 
-.c12:active {
+.c11:active {
   background: #354AA4;
 }
 
-.c12:disabled {
+.c11:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -887,7 +863,7 @@ exports[`auth2faType: u2f rendering 1`] = `
   text-align: center;
 }
 
-.c11 {
+.c10 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -914,7 +890,7 @@ exports[`auth2faType: u2f rendering 1`] = `
   align-items: flex-end;
 }
 
-.c10 .react-select-container {
+.c9 .react-select-container {
   box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
   box-sizing: border-box;
   border: none;
@@ -928,8 +904,8 @@ exports[`auth2faType: u2f rendering 1`] = `
   border-radius: 4px;
 }
 
-.c10 .react-select__control,
-.c10 .react-select__control--is-focused {
+.c9 .react-select__control,
+.c9 .react-select__control--is-focused {
   min-height: 40px;
   height: 40px;
   background-color: transparent;
@@ -940,48 +916,48 @@ exports[`auth2faType: u2f rendering 1`] = `
   box-shadow: none;
 }
 
-.c10 .react-select__control:hover,
-.c10 .react-select__control--is-focused:hover {
+.c9 .react-select__control:hover,
+.c9 .react-select__control--is-focused:hover {
   border-color: transparent;
   cursor: pointer;
 }
 
-.c10 .react-select__option:hover {
+.c9 .react-select__option:hover {
   cursor: pointer;
   background-color: #eceff1;
 }
 
-.c10 .react-select__option--is-focused {
+.c9 .react-select__option--is-focused {
   background-color: #eceff1;
 }
 
-.c10 .react-select__option--is-selected {
+.c9 .react-select__option--is-selected {
   background-color: #cfd8dc;
   color: inherit;
 }
 
-.c10 .react-select__option--is-selected:hover {
+.c9 .react-select__option--is-selected:hover {
   background-color: #cfd8dc;
 }
 
-.c10 .react-select__menu {
+.c9 .react-select__menu {
   margin-top: 0px;
 }
 
-.c10 .react-select__indicator-separator {
+.c9 .react-select__indicator-separator {
   display: none;
 }
 
-.c10 .react-select__loading-indicator {
+.c9 .react-select__loading-indicator {
   display: none;
 }
 
-.c10 .react-select--is-disabled .react-select__single-value,
-.c10 .react-select--is-disabled .react-select__placeholder {
+.c9 .react-select--is-disabled .react-select__single-value,
+.c9 .react-select--is-disabled .react-select__placeholder {
   color: rgba(0,0,0,0.24);
 }
 
-.c10 .react-select--is-disabled .react-select__indicator {
+.c9 .react-select--is-disabled .react-select__indicator {
   color: rgba(0,0,0,0.14);
 }
 
@@ -1048,67 +1024,63 @@ exports[`auth2faType: u2f rendering 1`] = `
         <div
           class="c8"
           data-testid="mfa-select"
-          width="50%"
+          width="100%"
         >
+          <label
+            class="c4"
+            font-size="0"
+          >
+            Two-factor type
+          </label>
           <div
             class="c9"
           >
-            <label
-              class="c4"
-              font-size="0"
-            >
-              Two-factor type
-            </label>
             <div
-              class="c10"
+              class="react-select-container react-select--is-disabled css-14jk2my-container"
             >
               <div
-                class="react-select-container react-select--is-disabled css-14jk2my-container"
+                class="react-select__control react-select__control--is-disabled css-1fhf3k1-control"
               >
                 <div
-                  class="react-select__control react-select__control--is-disabled css-1fhf3k1-control"
+                  class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
                 >
                   <div
-                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                    class="react-select__single-value react-select__single-value--is-disabled css-107lb6w-singleValue"
                   >
-                    <div
-                      class="react-select__single-value react-select__single-value--is-disabled css-107lb6w-singleValue"
-                    >
-                      Hardware Key
-                    </div>
-                    <input
-                      aria-autocomplete="list"
-                      class="css-62g3xt-dummyInput"
-                      disabled=""
-                      id="react-select-5-input"
-                      readonly=""
-                      tabindex="0"
-                      value=""
-                    />
+                    Hardware Key
                   </div>
+                  <input
+                    aria-autocomplete="list"
+                    class="css-62g3xt-dummyInput"
+                    disabled=""
+                    id="react-select-5-input"
+                    readonly=""
+                    tabindex="0"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="react-select__indicator-separator css-109onse-indicatorSeparator"
+                  />
                   <div
-                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                    aria-hidden="true"
+                    class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
                   >
-                    <span
-                      class="react-select__indicator-separator css-109onse-indicatorSeparator"
-                    />
-                    <div
+                    <svg
                       aria-hidden="true"
-                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="css-6q0nyr-Svg"
-                        focusable="false"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        width="20"
-                      >
-                        <path
-                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                        />
-                      </svg>
-                    </div>
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
@@ -1116,19 +1088,14 @@ exports[`auth2faType: u2f rendering 1`] = `
           </div>
         </div>
         <div
-          class="c8"
-          width="50%"
+          class="c10"
         >
-          <div
-            class="c11"
-          >
-            Insert your hardware key and press the button on the key.
-          </div>
+          Insert your hardware key and press the button on the key.
         </div>
       </div>
     </div>
     <button
-      class="c12"
+      class="c11"
       disabled=""
       kind="primary"
       type="submit"
@@ -1169,17 +1136,10 @@ exports[`cloud auth2faType: on rendering 1`] = `
 
 .c13 {
   box-sizing: border-box;
-  width: 50%;
-}
-
-.c14 {
-  box-sizing: border-box;
+  max-width: 50%;
   margin-bottom: 0px;
   margin-right: 16px;
-}
-
-.c16 {
-  box-sizing: border-box;
+  width: 100%;
 }
 
 .c10 {
@@ -1226,7 +1186,7 @@ exports[`cloud auth2faType: on rendering 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c17 {
+.c15 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -1254,20 +1214,20 @@ exports[`cloud auth2faType: on rendering 1`] = `
   width: 100%;
 }
 
-.c17:active {
+.c15:active {
   opacity: 0.56;
 }
 
-.c17:hover,
-.c17:focus {
+.c15:hover,
+.c15:focus {
   background: #651FFF;
 }
 
-.c17:active {
+.c15:active {
   background: #354AA4;
 }
 
-.c17:disabled {
+.c15:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -1365,7 +1325,7 @@ exports[`cloud auth2faType: on rendering 1`] = `
   align-items: flex-end;
 }
 
-.c15 .react-select-container {
+.c14 .react-select-container {
   box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
   box-sizing: border-box;
   border: none;
@@ -1379,8 +1339,8 @@ exports[`cloud auth2faType: on rendering 1`] = `
   border-radius: 4px;
 }
 
-.c15 .react-select__control,
-.c15 .react-select__control--is-focused {
+.c14 .react-select__control,
+.c14 .react-select__control--is-focused {
   min-height: 40px;
   height: 40px;
   background-color: transparent;
@@ -1391,48 +1351,48 @@ exports[`cloud auth2faType: on rendering 1`] = `
   box-shadow: none;
 }
 
-.c15 .react-select__control:hover,
-.c15 .react-select__control--is-focused:hover {
+.c14 .react-select__control:hover,
+.c14 .react-select__control--is-focused:hover {
   border-color: transparent;
   cursor: pointer;
 }
 
-.c15 .react-select__option:hover {
+.c14 .react-select__option:hover {
   cursor: pointer;
   background-color: #eceff1;
 }
 
-.c15 .react-select__option--is-focused {
+.c14 .react-select__option--is-focused {
   background-color: #eceff1;
 }
 
-.c15 .react-select__option--is-selected {
+.c14 .react-select__option--is-selected {
   background-color: #cfd8dc;
   color: inherit;
 }
 
-.c15 .react-select__option--is-selected:hover {
+.c14 .react-select__option--is-selected:hover {
   background-color: #cfd8dc;
 }
 
-.c15 .react-select__menu {
+.c14 .react-select__menu {
   margin-top: 0px;
 }
 
-.c15 .react-select__indicator-separator {
+.c14 .react-select__indicator-separator {
   display: none;
 }
 
-.c15 .react-select__loading-indicator {
+.c14 .react-select__loading-indicator {
   display: none;
 }
 
-.c15 .react-select--is-disabled .react-select__single-value,
-.c15 .react-select--is-disabled .react-select__placeholder {
+.c14 .react-select--is-disabled .react-select__single-value,
+.c14 .react-select--is-disabled .react-select__placeholder {
   color: rgba(0,0,0,0.24);
 }
 
-.c15 .react-select--is-disabled .react-select__indicator {
+.c14 .react-select--is-disabled .react-select__indicator {
   color: rgba(0,0,0,0.14);
 }
 
@@ -1510,91 +1470,79 @@ exports[`cloud auth2faType: on rendering 1`] = `
         <div
           class="c13"
           data-testid="mfa-select"
-          width="50%"
+          width="100%"
         >
+          <label
+            class="c4"
+            font-size="0"
+          >
+            Two-factor type
+          </label>
           <div
             class="c14"
           >
-            <label
-              class="c4"
-              font-size="0"
-            >
-              Two-factor type
-            </label>
             <div
-              class="c15"
+              class="react-select-container css-2b097c-container"
             >
               <div
-                class="react-select-container css-2b097c-container"
+                class="react-select__control css-yk16xz-control"
               >
                 <div
-                  class="react-select__control css-yk16xz-control"
+                  class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
                 >
                   <div
-                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                    class="react-select__single-value css-1uccc91-singleValue"
                   >
-                    <div
-                      class="react-select__single-value css-1uccc91-singleValue"
-                    >
-                      Hardware Key
-                    </div>
-                    <input
-                      aria-autocomplete="list"
-                      class="css-62g3xt-dummyInput"
-                      id="react-select-4-input"
-                      readonly=""
-                      tabindex="0"
-                      value=""
-                    />
+                    Hardware Key
                   </div>
+                  <input
+                    aria-autocomplete="list"
+                    class="css-62g3xt-dummyInput"
+                    id="react-select-4-input"
+                    readonly=""
+                    tabindex="0"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                  />
                   <div
-                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                    aria-hidden="true"
+                    class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
                   >
-                    <span
-                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
-                    />
-                    <div
+                    <svg
                       aria-hidden="true"
-                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="css-6q0nyr-Svg"
-                        focusable="false"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        width="20"
-                      >
-                        <path
-                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                        />
-                      </svg>
-                    </div>
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          class="c13"
-          width="50%"
-        />
       </div>
-      <div
-        class="c16"
+      <a
+        class="c9 c10"
+        kind="primary"
+        style="padding: 0px; min-height: 0;"
       >
-        <a
-          class="c9 c10"
-          kind="primary"
-          style="padding: 0px; min-height: 0;"
-        >
-          Lost Two-Factor Device?
-        </a>
-      </div>
+        Lost Two-Factor Device?
+      </a>
     </div>
     <button
-      class="c17"
+      class="c15"
       kind="primary"
       type="submit"
       width="100%"
@@ -1891,10 +1839,8 @@ exports[`server error rendering 1`] = `
   overflow: auto;
   word-break: break-all;
   line-height: 1.5;
+  margin: 32px;
   margin-bottom: 0px;
-  margin-top: 32px;
-  margin-left: 32px;
-  margin-right: 32px;
   background: #f50057;
   color: #FFFFFF;
 }
@@ -2250,7 +2196,6 @@ exports[`sso providers rendering 1`] = `
 
 .c12 {
   box-sizing: border-box;
-  height: 1px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2487,7 +2432,6 @@ exports[`sso providers rendering 1`] = `
   </div>
   <div
     class="c12"
-    height="1px"
     style="position: relative;"
   >
     <div

--- a/packages/teleport/src/Invite/__snapshots__/Invite.test.tsx.snap
+++ b/packages/teleport/src/Invite/__snapshots__/Invite.test.tsx.snap
@@ -190,6 +190,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
 .c18 {
   overflow: hidden;
   text-overflow: ellipsis;
+  text-transform: uppercase;
   font-weight: 600;
   margin: 0px;
 }
@@ -443,7 +444,6 @@ exports[`teleport/components/Invite should render form with token requirement wh
              
             <span
               class="c18"
-              style="text-transform: uppercase;"
             >
               Create Account
             </span>

--- a/packages/teleport/src/Invite/__snapshots__/Invite.test.tsx.snap
+++ b/packages/teleport/src/Invite/__snapshots__/Invite.test.tsx.snap
@@ -14,16 +14,13 @@ exports[`teleport/components/Invite should render form with token requirement wh
 
 .c10 {
   box-sizing: border-box;
-  width: 50%;
-}
-
-.c11 {
-  box-sizing: border-box;
-  margin-bottom: 0px;
+  max-width: 50%;
+  margin-bottom: 24px;
   margin-right: 16px;
+  width: 100%;
 }
 
-.c14 {
+.c13 {
   box-sizing: border-box;
   padding: 40px;
   background-color: #1C254D;
@@ -32,12 +29,12 @@ exports[`teleport/components/Invite should render form with token requirement wh
   border-bottom-right-radius: 8px;
 }
 
-.c15 {
+.c14 {
   box-sizing: border-box;
   width: 168px;
 }
 
-.c13 {
+.c12 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -65,20 +62,20 @@ exports[`teleport/components/Invite should render form with token requirement wh
   width: 100%;
 }
 
-.c13:active {
+.c12:active {
   opacity: 0.56;
 }
 
-.c13:hover,
-.c13:focus {
+.c12:hover,
+.c12:focus {
   background: #651FFF;
 }
 
-.c13:active {
+.c12:active {
   background: #354AA4;
 }
 
-.c13:disabled {
+.c12:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -167,7 +164,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
   margin-bottom: 16px;
 }
 
-.c16 {
+.c15 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -177,7 +174,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
   margin-bottom: 8px;
 }
 
-.c17 {
+.c16 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -187,7 +184,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
   margin-bottom: 16px;
 }
 
-.c18 {
+.c17 {
   overflow: hidden;
   text-overflow: ellipsis;
   text-transform: uppercase;
@@ -202,12 +199,11 @@ exports[`teleport/components/Invite should render form with token requirement wh
 
 .c9 {
   box-sizing: border-box;
-  margin-bottom: 24px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
 }
 
-.c12 .react-select-container {
+.c11 .react-select-container {
   box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
   box-sizing: border-box;
   border: none;
@@ -221,8 +217,8 @@ exports[`teleport/components/Invite should render form with token requirement wh
   border-radius: 4px;
 }
 
-.c12 .react-select__control,
-.c12 .react-select__control--is-focused {
+.c11 .react-select__control,
+.c11 .react-select__control--is-focused {
   min-height: 40px;
   height: 40px;
   background-color: transparent;
@@ -233,48 +229,48 @@ exports[`teleport/components/Invite should render form with token requirement wh
   box-shadow: none;
 }
 
-.c12 .react-select__control:hover,
-.c12 .react-select__control--is-focused:hover {
+.c11 .react-select__control:hover,
+.c11 .react-select__control--is-focused:hover {
   border-color: transparent;
   cursor: pointer;
 }
 
-.c12 .react-select__option:hover {
+.c11 .react-select__option:hover {
   cursor: pointer;
   background-color: #eceff1;
 }
 
-.c12 .react-select__option--is-focused {
+.c11 .react-select__option--is-focused {
   background-color: #eceff1;
 }
 
-.c12 .react-select__option--is-selected {
+.c11 .react-select__option--is-selected {
   background-color: #cfd8dc;
   color: inherit;
 }
 
-.c12 .react-select__option--is-selected:hover {
+.c11 .react-select__option--is-selected:hover {
   background-color: #cfd8dc;
 }
 
-.c12 .react-select__menu {
+.c11 .react-select__menu {
   margin-top: 0px;
 }
 
-.c12 .react-select__indicator-separator {
+.c11 .react-select__indicator-separator {
   display: none;
 }
 
-.c12 .react-select__loading-indicator {
+.c11 .react-select__loading-indicator {
   display: none;
 }
 
-.c12 .react-select--is-disabled .react-select__single-value,
-.c12 .react-select--is-disabled .react-select__placeholder {
+.c11 .react-select--is-disabled .react-select__single-value,
+.c11 .react-select--is-disabled .react-select__placeholder {
   color: rgba(0,0,0,0.24);
 }
 
-.c12 .react-select--is-disabled .react-select__indicator {
+.c11 .react-select--is-disabled .react-select__indicator {
   color: rgba(0,0,0,0.14);
 }
 
@@ -346,79 +342,71 @@ exports[`teleport/components/Invite should render form with token requirement wh
           <div
             class="c10"
             data-testid="mfa-select"
-            width="50%"
+            width="100%"
           >
+            <label
+              class="c7"
+              font-size="0"
+            >
+              Two-factor type
+            </label>
             <div
               class="c11"
             >
-              <label
-                class="c7"
-                font-size="0"
-              >
-                Two-factor type
-              </label>
               <div
-                class="c12"
+                class="react-select-container css-2b097c-container"
               >
                 <div
-                  class="react-select-container css-2b097c-container"
+                  class="react-select__control css-yk16xz-control"
                 >
                   <div
-                    class="react-select__control css-yk16xz-control"
+                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
                   >
                     <div
-                      class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                      class="react-select__single-value css-1uccc91-singleValue"
                     >
-                      <div
-                        class="react-select__single-value css-1uccc91-singleValue"
-                      >
-                        Hardware Key
-                      </div>
-                      <input
-                        aria-autocomplete="list"
-                        class="css-62g3xt-dummyInput"
-                        id="react-select-4-input"
-                        readonly=""
-                        tabindex="0"
-                        value=""
-                      />
+                      Hardware Key
                     </div>
+                    <input
+                      aria-autocomplete="list"
+                      class="css-62g3xt-dummyInput"
+                      id="react-select-4-input"
+                      readonly=""
+                      tabindex="0"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                  >
+                    <span
+                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                    />
                     <div
-                      class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                      aria-hidden="true"
+                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
                     >
-                      <span
-                        class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
-                      />
-                      <div
+                      <svg
                         aria-hidden="true"
-                        class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        class="css-6q0nyr-Svg"
+                        focusable="false"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="css-6q0nyr-Svg"
-                          focusable="false"
-                          height="20"
-                          viewBox="0 0 20 20"
-                          width="20"
-                        >
-                          <path
-                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                          />
-                        </svg>
-                      </div>
+                        <path
+                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                        />
+                      </svg>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-          <div
-            class="c10"
-            width="50%"
-          />
         </div>
         <button
-          class="c13"
+          class="c12"
           kind="primary"
           width="100%"
         >
@@ -426,24 +414,24 @@ exports[`teleport/components/Invite should render form with token requirement wh
         </button>
       </div>
       <div
-        class="c14"
+        class="c13"
       >
         <div
-          class="c15"
+          class="c14"
           width="168px"
         >
           <div
-            class="c16"
+            class="c15"
           >
             Insert your hardware key
           </div>
           <div
-            class="c17"
+            class="c16"
           >
             Press the button on the hardware key after you press the
              
             <span
-              class="c18"
+              class="c17"
             >
               Create Account
             </span>
@@ -471,16 +459,13 @@ exports[`teleport/components/Invite should render form with token requirement wh
 
 .c10 {
   box-sizing: border-box;
-  width: 50%;
-}
-
-.c11 {
-  box-sizing: border-box;
-  margin-bottom: 0px;
+  max-width: 50%;
+  margin-bottom: 24px;
   margin-right: 16px;
+  width: 100%;
 }
 
-.c13 {
+.c12 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -508,20 +493,20 @@ exports[`teleport/components/Invite should render form with token requirement wh
   width: 100%;
 }
 
-.c13:active {
+.c12:active {
   opacity: 0.56;
 }
 
-.c13:hover,
-.c13:focus {
+.c12:hover,
+.c12:focus {
   background: #651FFF;
 }
 
-.c13:active {
+.c12:active {
   background: #354AA4;
 }
 
-.c13:disabled {
+.c12:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -617,12 +602,11 @@ exports[`teleport/components/Invite should render form with token requirement wh
 
 .c9 {
   box-sizing: border-box;
-  margin-bottom: 24px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
 }
 
-.c12 .react-select-container {
+.c11 .react-select-container {
   box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
   box-sizing: border-box;
   border: none;
@@ -636,8 +620,8 @@ exports[`teleport/components/Invite should render form with token requirement wh
   border-radius: 4px;
 }
 
-.c12 .react-select__control,
-.c12 .react-select__control--is-focused {
+.c11 .react-select__control,
+.c11 .react-select__control--is-focused {
   min-height: 40px;
   height: 40px;
   background-color: transparent;
@@ -648,48 +632,48 @@ exports[`teleport/components/Invite should render form with token requirement wh
   box-shadow: none;
 }
 
-.c12 .react-select__control:hover,
-.c12 .react-select__control--is-focused:hover {
+.c11 .react-select__control:hover,
+.c11 .react-select__control--is-focused:hover {
   border-color: transparent;
   cursor: pointer;
 }
 
-.c12 .react-select__option:hover {
+.c11 .react-select__option:hover {
   cursor: pointer;
   background-color: #eceff1;
 }
 
-.c12 .react-select__option--is-focused {
+.c11 .react-select__option--is-focused {
   background-color: #eceff1;
 }
 
-.c12 .react-select__option--is-selected {
+.c11 .react-select__option--is-selected {
   background-color: #cfd8dc;
   color: inherit;
 }
 
-.c12 .react-select__option--is-selected:hover {
+.c11 .react-select__option--is-selected:hover {
   background-color: #cfd8dc;
 }
 
-.c12 .react-select__menu {
+.c11 .react-select__menu {
   margin-top: 0px;
 }
 
-.c12 .react-select__indicator-separator {
+.c11 .react-select__indicator-separator {
   display: none;
 }
 
-.c12 .react-select__loading-indicator {
+.c11 .react-select__loading-indicator {
   display: none;
 }
 
-.c12 .react-select--is-disabled .react-select__single-value,
-.c12 .react-select--is-disabled .react-select__placeholder {
+.c11 .react-select--is-disabled .react-select__single-value,
+.c11 .react-select--is-disabled .react-select__placeholder {
   color: rgba(0,0,0,0.24);
 }
 
-.c12 .react-select--is-disabled .react-select__indicator {
+.c11 .react-select--is-disabled .react-select__indicator {
   color: rgba(0,0,0,0.14);
 }
 
@@ -761,79 +745,71 @@ exports[`teleport/components/Invite should render form with token requirement wh
           <div
             class="c10"
             data-testid="mfa-select"
-            width="50%"
+            width="100%"
           >
+            <label
+              class="c7"
+              font-size="0"
+            >
+              Two-factor type
+            </label>
             <div
               class="c11"
             >
-              <label
-                class="c7"
-                font-size="0"
-              >
-                Two-factor type
-              </label>
               <div
-                class="c12"
+                class="react-select-container css-2b097c-container"
               >
                 <div
-                  class="react-select-container css-2b097c-container"
+                  class="react-select__control css-yk16xz-control"
                 >
                   <div
-                    class="react-select__control css-yk16xz-control"
+                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
                   >
                     <div
-                      class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                      class="react-select__single-value css-1uccc91-singleValue"
                     >
-                      <div
-                        class="react-select__single-value css-1uccc91-singleValue"
-                      >
-                        None
-                      </div>
-                      <input
-                        aria-autocomplete="list"
-                        class="css-62g3xt-dummyInput"
-                        id="react-select-5-input"
-                        readonly=""
-                        tabindex="0"
-                        value=""
-                      />
+                      None
                     </div>
+                    <input
+                      aria-autocomplete="list"
+                      class="css-62g3xt-dummyInput"
+                      id="react-select-5-input"
+                      readonly=""
+                      tabindex="0"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                  >
+                    <span
+                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                    />
                     <div
-                      class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                      aria-hidden="true"
+                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
                     >
-                      <span
-                        class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
-                      />
-                      <div
+                      <svg
                         aria-hidden="true"
-                        class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        class="css-6q0nyr-Svg"
+                        focusable="false"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="css-6q0nyr-Svg"
-                          focusable="false"
-                          height="20"
-                          viewBox="0 0 20 20"
-                          width="20"
-                        >
-                          <path
-                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                          />
-                        </svg>
-                      </div>
+                        <path
+                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                        />
+                      </svg>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-          <div
-            class="c10"
-            width="50%"
-          />
         </div>
         <button
-          class="c13"
+          class="c12"
           kind="primary"
           width="100%"
         >

--- a/packages/teleport/src/Invite/__snapshots__/Invite.test.tsx.snap
+++ b/packages/teleport/src/Invite/__snapshots__/Invite.test.tsx.snap
@@ -37,11 +37,6 @@ exports[`teleport/components/Invite should render form with token requirement wh
   width: 168px;
 }
 
-.c17 {
-  box-sizing: border-box;
-  color: rgba(255,255,255,0.87);
-}
-
 .c13 {
   line-height: 1.5;
   margin: 0;
@@ -138,15 +133,6 @@ exports[`teleport/components/Invite should render form with token requirement wh
   margin-bottom: 4px;
 }
 
-.c20 {
-  color: #03a9f4;
-  font-weight: normal;
-  background: none;
-  text-decoration: underline;
-  text-transform: none;
-  color: #FFFFFF;
-}
-
 .c0 {
   display: block;
   outline: none;
@@ -191,7 +177,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
   margin-bottom: 8px;
 }
 
-.c18 {
+.c17 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -201,7 +187,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
   margin-bottom: 16px;
 }
 
-.c19 {
+.c18 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
@@ -368,7 +354,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
                 class="c7"
                 font-size="0"
               >
-                Second factor
+                Two-factor type
               </label>
               <div
                 class="c12"
@@ -385,7 +371,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        U2F
+                        Hardware Key
                       </div>
                       <input
                         aria-autocomplete="list"
@@ -448,41 +434,21 @@ exports[`teleport/components/Invite should render form with token requirement wh
           <div
             class="c16"
           >
-            Insert your U2F key
+            Insert your hardware key
           </div>
           <div
             class="c17"
-            color="text.primary"
           >
-            <div
+            Press the button on the hardware key after you press the
+             
+            <span
               class="c18"
+              style="text-transform: uppercase;"
             >
-              Press the button on the U2F key after you press the
-               
-              <span
-                class="c19"
-                style="text-transform: uppercase;"
-              >
-                Create Account
-              </span>
-               
-              button.
-            </div>
-            <div
-              class="c18"
-            >
-              <a
-                class="c20"
-                color="light"
-                href="https://support.google.com/accounts/answer/6103523?hl=en"
-                rel="noreferrer"
-                target="_blank"
-              >
-                Learn more
-              </a>
-               
-              about U2F 2-Step Verification.
-            </div>
+              Create Account
+            </span>
+             
+            button.
           </div>
         </div>
       </div>
@@ -804,7 +770,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
                 class="c7"
                 font-size="0"
               >
-                Second factor
+                Two-factor type
               </label>
               <div
                 class="c12"

--- a/packages/teleport/src/Invite/__snapshots__/Invite.test.tsx.snap
+++ b/packages/teleport/src/Invite/__snapshots__/Invite.test.tsx.snap
@@ -787,7 +787,7 @@ exports[`teleport/components/Invite should render form with token requirement wh
                       <div
                         class="react-select__single-value css-1uccc91-singleValue"
                       >
-                        NONE
+                        None
                       </div>
                       <input
                         aria-autocomplete="list"

--- a/packages/teleport/src/Login/Login.test.tsx
+++ b/packages/teleport/src/Login/Login.test.tsx
@@ -120,9 +120,8 @@ test('login with 2fa set to "optional", select option: u2f', async () => {
   const selectEl = screen.getByTestId('mfa-select').querySelector('input');
   fireEvent.focus(selectEl);
   fireEvent.keyDown(selectEl, { key: 'ArrowDown', keyCode: 40 });
-  fireEvent.click(screen.getByText(/u2f/i));
-  screen.getByText(/u2f/i);
-  expect(screen.queryAllByLabelText(/two factor token/i)).toHaveLength(0);
+  fireEvent.click(screen.getByText(/hardware key/i));
+  expect(screen.queryAllByLabelText(/authenticator code/i)).toHaveLength(0);
 
   // fill form
   const username = screen.getByPlaceholderText(/username/i);
@@ -132,7 +131,7 @@ test('login with 2fa set to "optional", select option: u2f', async () => {
 
   // test login pathway
   await wait(() => fireEvent.click(screen.getByText(/login/i)));
-  screen.getByText(/Insert your U2F key/i);
+  screen.getByText(/Insert your hardware key/i);
   expect(auth.loginWithU2f).toHaveBeenCalledWith('username', '123');
 });
 
@@ -146,8 +145,7 @@ test('login with 2fa set to "optional", select option: totp', async () => {
   const selectEl = screen.getByTestId('mfa-select').querySelector('input');
   fireEvent.focus(selectEl);
   fireEvent.keyDown(selectEl, { key: 'ArrowDown', keyCode: 40 });
-  fireEvent.click(screen.getByText(/totp/i));
-  screen.getByText(/totp/i);
+  fireEvent.click(screen.getByText(/authenticator app/i));
 
   // fill form
   const username = screen.getByPlaceholderText(/username/i);
@@ -174,14 +172,13 @@ test('login with 2fa set to "on" have correct select options', async () => {
   render(<Login />);
 
   // default mfa dropdown is set to u2f
-  expect(screen.getByTestId('mfa-select').textContent).toMatch(/u2f/i);
+  expect(screen.getByTestId('mfa-select').textContent).toMatch(/hardware key/i);
 
   // select totp from mfa dropdown
   const selectEl = screen.getByTestId('mfa-select').querySelector('input');
   fireEvent.focus(selectEl);
   fireEvent.keyDown(selectEl, { key: 'ArrowDown', keyCode: 40 });
-  fireEvent.click(screen.getByText(/totp/i));
-  screen.getByText(/totp/i);
+  fireEvent.click(screen.getByText(/authenticator app/i));
 
   // none type is not part of mfa dropdown
   fireEvent.focus(selectEl);

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { sortBy } from 'lodash';
+import { ButtonBorder, Text } from 'design';
+import {
+  Column,
+  SortHeaderCell,
+  Cell,
+  TextCell,
+  SortTypes,
+  Table,
+} from 'design/DataTable';
+import { MfaDevice } from 'teleport/services/mfa/types';
+
+export default function MfaDeviceList({
+  devices = [],
+  onDelete,
+  isRecoveryFlow,
+}: Props) {
+  const [sortDir, setSortDir] = useState<Record<string, string>>({
+    registeredDate: SortTypes.ASC,
+  });
+
+  function sort(data, sortDirParam = sortDir) {
+    const columnKey = Object.getOwnPropertyNames(sortDirParam)[0];
+    const sorted = sortBy(data, columnKey);
+    if (sortDirParam[columnKey] === SortTypes.ASC) {
+      return sorted.reverse();
+    }
+
+    return sorted;
+  }
+
+  function onSortChange(columnKey: string, sortDir: string) {
+    setSortDir({ [columnKey]: sortDir });
+  }
+
+  const mostRecentDevice = sort(devices, { registeredDate: SortTypes.ASC })[0];
+
+  const data = sort(devices);
+
+  return (
+    <StyledTable data={data}>
+      <Column columnKey="type" cell={<TextCell />} header={<Cell>Type</Cell>} />
+      <Column
+        columnKey="name"
+        cell={<NameCell />}
+        header={<Cell>Device Name</Cell>}
+      />
+      <Column
+        columnKey="registeredDate"
+        header={
+          <SortHeaderCell
+            sortDir={sortDir.registeredDate}
+            onSortChange={onSortChange}
+            title="Registered"
+          />
+        }
+        cell={<DateCell />}
+      />
+      <Column
+        columnKey="lastUsedDate"
+        header={
+          <SortHeaderCell
+            sortDir={sortDir.lastUsedDate}
+            onSortChange={onSortChange}
+            title="Last Used"
+          />
+        }
+        cell={<DateCell />}
+      />
+      <Column
+        header={<Cell />}
+        cell={
+          <DeleteDeviceBtn
+            onDelete={onDelete}
+            mostRecentDevice={mostRecentDevice}
+            isRecoveryFlow={isRecoveryFlow}
+          />
+        }
+      />
+    </StyledTable>
+  );
+}
+
+const NameCell = props => {
+  const { data, rowIndex } = props;
+  const { name } = data[rowIndex];
+
+  return (
+    <Cell>
+      <Text style={{ maxWidth: '12ch' }}>{name}</Text>
+    </Cell>
+  );
+};
+
+const DateCell = props => {
+  const { data, rowIndex, columnKey } = props;
+  const dateText = data[rowIndex][`${columnKey}Text`];
+
+  return <Cell>{dateText}</Cell>;
+};
+
+const DeleteDeviceBtn = props => {
+  const { data, rowIndex, onDelete, mostRecentDevice, isRecoveryFlow } = props;
+  const { id, name } = data[rowIndex];
+
+  if (id === mostRecentDevice.id && isRecoveryFlow) {
+    return null;
+  }
+
+  return (
+    <Cell align="right">
+      <ButtonBorder size="small" onClick={() => onDelete({ id, name })}>
+        Remove
+      </ButtonBorder>
+    </Cell>
+  );
+};
+
+type Props = {
+  devices: MfaDevice[];
+  onDelete({ id, name }: { id: string; name: string }): void;
+  isRecoveryFlow: boolean; // Whether this list is being shown in the recovery flow as opposed to in the account dashboard
+};
+
+const StyledTable = styled(Table)`
+  & > tbody > tr {
+    td {
+      vertical-align: middle;
+    }
+  }
+`;

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -15,7 +15,7 @@ import { MfaDevice } from 'teleport/services/mfa/types';
 
 export default function MfaDeviceList({
   devices = [],
-  onDelete,
+  remove,
   mostRecentDevice,
   ...styles
 }: Props) {
@@ -76,7 +76,7 @@ export default function MfaDeviceList({
       <Column
         header={<Cell />}
         cell={
-          <DeleteCell onDelete={onDelete} mostRecentDevice={mostRecentDevice} />
+          <RemoveCell remove={remove} mostRecentDevice={mostRecentDevice} />
         }
       />
     </StyledTable>
@@ -108,8 +108,8 @@ const DateCell = props => {
   return <Cell>{dateText}</Cell>;
 };
 
-const DeleteCell = props => {
-  const { data, rowIndex, onDelete, mostRecentDevice } = props;
+const RemoveCell = props => {
+  const { data, rowIndex, remove, mostRecentDevice } = props;
   const { id, name } = data[rowIndex];
 
   if (id === mostRecentDevice?.id) {
@@ -118,7 +118,7 @@ const DeleteCell = props => {
 
   return (
     <Cell align="right">
-      <ButtonBorder size="small" onClick={() => onDelete({ id, name })}>
+      <ButtonBorder size="small" onClick={() => remove({ id, name })}>
         Remove
       </ButtonBorder>
     </Cell>
@@ -127,7 +127,7 @@ const DeleteCell = props => {
 
 type Props = {
   devices: MfaDevice[];
-  onDelete({ id, name }: { id: string; name: string }): void;
+  remove({ id, name }: { id: string; name: string }): void;
   mostRecentDevice?: MfaDevice;
   [key: string]: any;
 };

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { sortBy } from 'lodash';
 import { ButtonBorder, Text } from 'design';
@@ -16,13 +16,12 @@ import { MfaDevice } from 'teleport/services/mfa/types';
 export default function MfaDeviceList({
   devices = [],
   onDelete,
-  isRecoveryFlow,
+  mostRecentDevice,
+  ...styles
 }: Props) {
   const [sortDir, setSortDir] = useState<Record<string, string>>({
     registeredDate: SortTypes.ASC,
   });
-
-  const mostRecentDevice = useMemo(() => sort(devices)[0], []);
 
   function sort(data) {
     const columnKey = Object.getOwnPropertyNames(sortDir)[0];
@@ -41,10 +40,7 @@ export default function MfaDeviceList({
   const data = sort(devices);
 
   return (
-    <StyledTable
-      data={data}
-      style={isRecoveryFlow ? { overflow: 'hidden', borderRadius: '8px' } : {}}
-    >
+    <StyledTable data={data} {...styles}>
       <Column
         columnKey="description"
         cell={<TextCell />}
@@ -80,11 +76,7 @@ export default function MfaDeviceList({
       <Column
         header={<Cell />}
         cell={
-          <DeleteCell
-            onDelete={onDelete}
-            mostRecentDevice={mostRecentDevice}
-            isRecoveryFlow={isRecoveryFlow}
-          />
+          <DeleteCell onDelete={onDelete} mostRecentDevice={mostRecentDevice} />
         }
       />
     </StyledTable>
@@ -117,10 +109,10 @@ const DateCell = props => {
 };
 
 const DeleteCell = props => {
-  const { data, rowIndex, onDelete, mostRecentDevice, isRecoveryFlow } = props;
+  const { data, rowIndex, onDelete, mostRecentDevice } = props;
   const { id, name } = data[rowIndex];
 
-  if (id === mostRecentDevice.id && isRecoveryFlow) {
+  if (id === mostRecentDevice?.id) {
     return null;
   }
 
@@ -136,8 +128,8 @@ const DeleteCell = props => {
 type Props = {
   devices: MfaDevice[];
   onDelete({ id, name }: { id: string; name: string }): void;
-  // Whether this list is being shown in the recovery flow as opposed to in the account dashboard
-  isRecoveryFlow: boolean;
+  mostRecentDevice?: MfaDevice;
+  [key: string]: any;
 };
 
 const StyledTable = styled(Table)`

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -46,7 +46,7 @@ export default function MfaDeviceList({
       style={isRecoveryFlow ? { overflow: 'hidden', borderRadius: '8px' } : {}}
     >
       <Column
-        columnKey="typeText"
+        columnKey="description"
         cell={<TextCell />}
         header={<Cell>Type</Cell>}
       />

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -40,7 +40,10 @@ export default function MfaDeviceList({
   const data = sort(devices);
 
   return (
-    <StyledTable data={data}>
+    <StyledTable
+      data={data}
+      style={{ overflow: 'hidden', borderRadius: '8px' }}
+    >
       <Column columnKey="type" cell={<TextCell />} header={<Cell>Type</Cell>} />
       <Column
         columnKey="name"

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -10,6 +10,7 @@ import {
   SortTypes,
   Table,
 } from 'design/DataTable';
+import { displayDate } from 'shared/services/loc';
 import { MfaDevice } from 'teleport/services/mfa/types';
 
 export default function MfaDeviceList({
@@ -44,7 +45,11 @@ export default function MfaDeviceList({
       data={data}
       style={isRecoveryFlow ? { overflow: 'hidden', borderRadius: '8px' } : {}}
     >
-      <Column columnKey="type" cell={<TextCell />} header={<Cell>Type</Cell>} />
+      <Column
+        columnKey="typeText"
+        cell={<TextCell />}
+        header={<Cell>Type</Cell>}
+      />
       <Column
         columnKey="name"
         cell={<NameCell />}
@@ -75,7 +80,7 @@ export default function MfaDeviceList({
       <Column
         header={<Cell />}
         cell={
-          <DeleteDeviceBtn
+          <DeleteCell
             onDelete={onDelete}
             mostRecentDevice={mostRecentDevice}
             isRecoveryFlow={isRecoveryFlow}
@@ -91,8 +96,13 @@ const NameCell = props => {
   const { name } = data[rowIndex];
 
   return (
-    <Cell>
-      <Text style={{ maxWidth: '12ch' }} title={name}>
+    <Cell title={name}>
+      <Text
+        style={{
+          maxWidth: '96px',
+          whiteSpace: 'nowrap',
+        }}
+      >
         {name}
       </Text>
     </Cell>
@@ -101,12 +111,12 @@ const NameCell = props => {
 
 const DateCell = props => {
   const { data, rowIndex, columnKey } = props;
-  const dateText = data[rowIndex][`${columnKey}Text`];
+  const dateText = displayDate(data[rowIndex][columnKey]);
 
   return <Cell>{dateText}</Cell>;
 };
 
-const DeleteDeviceBtn = props => {
+const DeleteCell = props => {
   const { data, rowIndex, onDelete, mostRecentDevice, isRecoveryFlow } = props;
   const { id, name } = data[rowIndex];
 

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import styled from 'styled-components';
 import { sortBy } from 'lodash';
 import { ButtonBorder, Text } from 'design';
@@ -21,10 +21,12 @@ export default function MfaDeviceList({
     registeredDate: SortTypes.ASC,
   });
 
-  function sort(data, sortDirParam = sortDir) {
-    const columnKey = Object.getOwnPropertyNames(sortDirParam)[0];
+  const mostRecentDevice = useMemo(() => sort(devices)[0], []);
+
+  function sort(data) {
+    const columnKey = Object.getOwnPropertyNames(sortDir)[0];
     const sorted = sortBy(data, columnKey);
-    if (sortDirParam[columnKey] === SortTypes.ASC) {
+    if (sortDir[columnKey] === SortTypes.ASC) {
       return sorted.reverse();
     }
 
@@ -35,14 +37,12 @@ export default function MfaDeviceList({
     setSortDir({ [columnKey]: sortDir });
   }
 
-  const mostRecentDevice = sort(devices, { registeredDate: SortTypes.ASC })[0];
-
   const data = sort(devices);
 
   return (
     <StyledTable
       data={data}
-      style={{ overflow: 'hidden', borderRadius: '8px' }}
+      style={isRecoveryFlow ? { overflow: 'hidden', borderRadius: '8px' } : {}}
     >
       <Column columnKey="type" cell={<TextCell />} header={<Cell>Type</Cell>} />
       <Column
@@ -92,7 +92,9 @@ const NameCell = props => {
 
   return (
     <Cell>
-      <Text style={{ maxWidth: '12ch' }}>{name}</Text>
+      <Text style={{ maxWidth: '12ch' }} title={name}>
+        {name}
+      </Text>
     </Cell>
   );
 };
@@ -124,13 +126,15 @@ const DeleteDeviceBtn = props => {
 type Props = {
   devices: MfaDevice[];
   onDelete({ id, name }: { id: string; name: string }): void;
-  isRecoveryFlow: boolean; // Whether this list is being shown in the recovery flow as opposed to in the account dashboard
+  // Whether this list is being shown in the recovery flow as opposed to in the account dashboard
+  isRecoveryFlow: boolean;
 };
 
 const StyledTable = styled(Table)`
   & > tbody > tr {
     td {
       vertical-align: middle;
+      height: 32px;
     }
   }
 `;

--- a/packages/teleport/src/components/MfaDeviceList/RemoveDialog/RemoveDialog.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/RemoveDialog/RemoveDialog.tsx
@@ -5,12 +5,12 @@ import Dialog, { DialogContent, DialogFooter } from 'design/DialogConfirmation';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 export default function RemoveDialog(props: Props) {
-  const { name, onCancel, onDelete } = props;
+  const { name, onCancel, onRemove } = props;
   const { attempt, handleError, setAttempt } = useAttempt('');
 
   function onConfirm() {
     setAttempt({ status: 'processing' });
-    onDelete().catch(handleError);
+    onRemove().catch(handleError);
   }
 
   return (
@@ -49,6 +49,6 @@ export default function RemoveDialog(props: Props) {
 
 type Props = {
   onCancel: () => void;
-  onDelete: () => Promise<any>;
+  onRemove: () => Promise<any>;
   name: string;
 };

--- a/packages/teleport/src/components/MfaDeviceList/RemoveDialog/RemoveDialog.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/RemoveDialog/RemoveDialog.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { ButtonSecondary, ButtonWarning, Text } from 'design';
+import * as Alerts from 'design/Alert';
+import Dialog, { DialogContent, DialogFooter } from 'design/DialogConfirmation';
+import useAttempt from 'shared/hooks/useAttemptNext';
+
+export default function RemoveDialog(props: Props) {
+  const { name, onCancel, onDelete } = props;
+  const { attempt, handleError, setAttempt } = useAttempt('');
+
+  function onConfirm() {
+    setAttempt({ status: 'processing' });
+    onDelete().catch(handleError);
+  }
+
+  return (
+    <Dialog disableEscapeKeyDown={false} onClose={onCancel} open={true}>
+      {attempt.status == 'failed' && (
+        <Alerts.Danger>{attempt.statusText}</Alerts.Danger>
+      )}
+      <DialogContent width="400px">
+        <Text typography="h2">Remove Device</Text>
+        <Text typography="paragraph" mt="2" mb="6">
+          Are you sure you want to remove device{' '}
+          <Text as="span" bold color="primary.contrastText">
+            {name}
+          </Text>{' '}
+          ?
+        </Text>
+      </DialogContent>
+      <DialogFooter>
+        <ButtonWarning
+          mr="3"
+          disabled={attempt.status === 'processing'}
+          onClick={onConfirm}
+        >
+          Remove
+        </ButtonWarning>
+        <ButtonSecondary
+          disabled={attempt.status === 'processing'}
+          onClick={onCancel}
+        >
+          Cancel
+        </ButtonSecondary>
+      </DialogFooter>
+    </Dialog>
+  );
+}
+
+type Props = {
+  onCancel: () => void;
+  onDelete: () => Promise<any>;
+  name: string;
+};

--- a/packages/teleport/src/components/MfaDeviceList/RemoveDialog/index.ts
+++ b/packages/teleport/src/components/MfaDeviceList/RemoveDialog/index.ts
@@ -1,0 +1,2 @@
+import RemoveDialog from './RemoveDialog';
+export default RemoveDialog;

--- a/packages/teleport/src/components/MfaDeviceList/index.ts
+++ b/packages/teleport/src/components/MfaDeviceList/index.ts
@@ -1,0 +1,5 @@
+import MfaDeviceList from './MfaDeviceList';
+import RemoveDialog from './RemoveDialog';
+
+export { RemoveDialog };
+export default MfaDeviceList;

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -116,8 +116,8 @@ const cfg = {
     appNodeScriptPath: '/scripts/:token/install-app.sh?name=:name&uri=:uri',
 
     mfaSignRequestWithTokenPath: '/v1/webapi/u2f/signrequest/token',
-    mfaFetchDevicesPath: '/v1/webapi/mfadevice/:token',
-    mfaDeleteDevicePath: '/v1/webapi/mfadevice',
+    mfaDeviceListPath: '/v1/webapi/mfa/:token',
+    mfaDevicePath: '/v1/webapi/mfa',
   },
 
   getAppFqdnUrl(params: UrlAppParams) {
@@ -310,7 +310,7 @@ const cfg = {
   },
 
   getMfaDeviceListUrl(token: string) {
-    return generatePath(cfg.api.mfaFetchDevicesPath, { token });
+    return generatePath(cfg.api.mfaDeviceListPath, { token });
   },
 
   init(backendConfig = {}) {

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -114,6 +114,10 @@ const cfg = {
     nodeTokenPath: '/v1/enterprise/nodes/token',
     nodeScriptPath: '/scripts/:token/install-node.sh',
     appNodeScriptPath: '/scripts/:token/install-app.sh?name=:name&uri=:uri',
+
+    mfaSignRequestWithTokenPath: '/v1/webapi/u2f/signrequest/token',
+    mfaFetchDevicesPath: '/v1/webapi/mfadevice/:token',
+    mfaDeleteDevicePath: '/v1/webapi/mfadevice',
   },
 
   getAppFqdnUrl(params: UrlAppParams) {
@@ -303,6 +307,10 @@ const cfg = {
 
   getKubernetesUrl(clusterId: string) {
     return generatePath(cfg.api.kubernetesPath, { clusterId });
+  },
+
+  getMfaDeviceListUrl(token: string) {
+    return generatePath(cfg.api.mfaFetchDevicesPath, { token });
   },
 
   init(backendConfig = {}) {

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -115,9 +115,10 @@ const cfg = {
     nodeScriptPath: '/scripts/:token/install-node.sh',
     appNodeScriptPath: '/scripts/:token/install-app.sh?name=:name&uri=:uri',
 
-    mfaSignRequestWithTokenPath: '/v1/webapi/u2f/signrequest/token',
-    mfaDeviceListPath: '/v1/webapi/mfa/:token',
-    mfaDevicePath: '/v1/webapi/mfa',
+    mfaAuthnChallengeWithTokenPath:
+      '/v1/webapi/mfa/token/:tokenId/authenticatechallenge',
+    mfaDeviceListPath: '/v1/webapi/mfa/token/:tokenId/devices',
+    mfaDevicePath: '/v1/webapi/mfa/token/:tokenId/devices/:deviceName',
   },
 
   getAppFqdnUrl(params: UrlAppParams) {
@@ -309,8 +310,18 @@ const cfg = {
     return generatePath(cfg.api.kubernetesPath, { clusterId });
   },
 
-  getMfaDeviceListUrl(token: string) {
-    return generatePath(cfg.api.mfaDeviceListPath, { token });
+  getAuthnChallengeWithTokenUrl(tokenId: string) {
+    return generatePath(cfg.api.mfaAuthnChallengeWithTokenPath, {
+      tokenId,
+    });
+  },
+
+  getMfaDeviceListUrl(tokenId: string) {
+    return generatePath(cfg.api.mfaDeviceListPath, { tokenId });
+  },
+
+  getMfaDeviceUrl(tokenId: string, deviceName: string) {
+    return generatePath(cfg.api.mfaDevicePath, { tokenId, deviceName });
   },
 
   init(backendConfig = {}) {

--- a/packages/teleport/src/services/mfa/index.ts
+++ b/packages/teleport/src/services/mfa/index.ts
@@ -1,0 +1,4 @@
+import MfaService from './mfa';
+
+export default MfaService;
+export * from './types';

--- a/packages/teleport/src/services/mfa/makeMfaDevice.ts
+++ b/packages/teleport/src/services/mfa/makeMfaDevice.ts
@@ -3,22 +3,20 @@ import { MfaDevice } from './types';
 export default function makeMfaDevice(json): MfaDevice {
   const { id, name, lastUsed, addedAt } = json;
 
-  let typeText: MfaDevice['typeText'];
+  let description = '';
   if (json.type === 'TOTP') {
-    typeText = 'Authenticator App';
+    description = 'Authenticator App';
+  } else if (json.type === 'U2F') {
+    description = 'Hardware Key';
+  } else {
+    description = 'unknown device';
   }
-  if (json.type === 'U2F') {
-    typeText = 'Hardware Key';
-  }
-
-  const registeredDate = new Date(addedAt);
-  const lastUsedDate = new Date(lastUsed);
 
   return {
     id,
     name,
-    typeText,
-    registeredDate,
-    lastUsedDate,
+    description,
+    registeredDate: new Date(addedAt),
+    lastUsedDate: new Date(lastUsed),
   };
 }

--- a/packages/teleport/src/services/mfa/makeMfaDevice.ts
+++ b/packages/teleport/src/services/mfa/makeMfaDevice.ts
@@ -1,0 +1,25 @@
+import moment from 'moment';
+import { displayDate } from 'shared/services/loc';
+import { MfaDevice } from './types';
+
+export default function makeMfaDevice(json): MfaDevice {
+  const { id, name, lastUsed, addedAt } = json;
+
+  let type: MfaDevice['type'];
+  if (json.type === 'TOTP') {
+    type = 'Authenticator App';
+  }
+  if (json.type === 'U2F') {
+    type = 'Hardware Key';
+  }
+
+  return {
+    id,
+    name,
+    type,
+    registeredDate: moment(addedAt).unix(),
+    lastUsedDate: moment(lastUsed).unix(),
+    registeredDateText: displayDate(addedAt),
+    lastUsedDateText: displayDate(lastUsed),
+  };
+}

--- a/packages/teleport/src/services/mfa/makeMfaDevice.ts
+++ b/packages/teleport/src/services/mfa/makeMfaDevice.ts
@@ -1,25 +1,24 @@
-import moment from 'moment';
-import { displayDate } from 'shared/services/loc';
 import { MfaDevice } from './types';
 
 export default function makeMfaDevice(json): MfaDevice {
   const { id, name, lastUsed, addedAt } = json;
 
-  let type: MfaDevice['type'];
+  let typeText: MfaDevice['typeText'];
   if (json.type === 'TOTP') {
-    type = 'Authenticator App';
+    typeText = 'Authenticator App';
   }
   if (json.type === 'U2F') {
-    type = 'Hardware Key';
+    typeText = 'Hardware Key';
   }
+
+  const registeredDate = new Date(addedAt);
+  const lastUsedDate = new Date(lastUsed);
 
   return {
     id,
     name,
-    type,
-    registeredDate: moment(addedAt).unix(),
-    lastUsedDate: moment(lastUsed).unix(),
-    registeredDateText: displayDate(addedAt),
-    lastUsedDateText: displayDate(lastUsed),
+    typeText,
+    registeredDate,
+    lastUsedDate,
   };
 }

--- a/packages/teleport/src/services/mfa/mfa.ts
+++ b/packages/teleport/src/services/mfa/mfa.ts
@@ -12,7 +12,7 @@ class MfaService {
   }
 
   deleteMfaDevice(data: DeleteMfaDeviceRequest) {
-    return api.delete(cfg.api.mfaDeleteDevicePath, { ...data });
+    return api.delete(cfg.api.mfaDevicePath, { ...data });
   }
 }
 

--- a/packages/teleport/src/services/mfa/mfa.ts
+++ b/packages/teleport/src/services/mfa/mfa.ts
@@ -1,7 +1,7 @@
 import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 import makeMfaDevice from './makeMfaDevice';
-import { MfaDevice, RemoveDeviceRequest } from './types';
+import { MfaDevice } from './types';
 
 class MfaService {
   fetchDevicesWithToken(tokenId: string): Promise<MfaDevice[]> {
@@ -10,8 +10,8 @@ class MfaService {
       .then(devices => devices.map(makeMfaDevice));
   }
 
-  removeDevice(req: RemoveDeviceRequest) {
-    return api.delete(cfg.api.mfaDevicePath, req);
+  removeDevice(tokenId: string, deviceName: string) {
+    return api.delete(cfg.getMfaDeviceUrl(tokenId, deviceName));
   }
 }
 

--- a/packages/teleport/src/services/mfa/mfa.ts
+++ b/packages/teleport/src/services/mfa/mfa.ts
@@ -10,8 +10,8 @@ class MfaService {
       .then(devices => devices.map(makeMfaDevice));
   }
 
-  removeDevice(data: RemoveDeviceRequest) {
-    return api.delete(cfg.api.mfaDevicePath, { ...data });
+  removeDevice(req: RemoveDeviceRequest) {
+    return api.delete(cfg.api.mfaDevicePath, req);
   }
 }
 

--- a/packages/teleport/src/services/mfa/mfa.ts
+++ b/packages/teleport/src/services/mfa/mfa.ts
@@ -1,0 +1,19 @@
+import 'u2f-api-polyfill';
+import cfg from 'teleport/config';
+import api from 'teleport/services/api';
+import makeMfaDevice from './makeMfaDevice';
+import { DeleteMfaDeviceRequest } from './types';
+
+class MfaService {
+  fetchMfaDevices(tokenId: string) {
+    return api
+      .get(cfg.getMfaDeviceListUrl(tokenId))
+      .then(devices => devices.map(makeMfaDevice));
+  }
+
+  deleteMfaDevice(data: DeleteMfaDeviceRequest) {
+    return api.delete(cfg.api.mfaDeleteDevicePath, { ...data });
+  }
+}
+
+export default MfaService;

--- a/packages/teleport/src/services/mfa/mfa.ts
+++ b/packages/teleport/src/services/mfa/mfa.ts
@@ -1,17 +1,16 @@
-import 'u2f-api-polyfill';
 import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 import makeMfaDevice from './makeMfaDevice';
-import { DeleteMfaDeviceRequest } from './types';
+import { RemoveDeviceRequest } from './types';
 
 class MfaService {
-  fetchMfaDevices(tokenId: string) {
+  fetchDevices(tokenId: string) {
     return api
       .get(cfg.getMfaDeviceListUrl(tokenId))
       .then(devices => devices.map(makeMfaDevice));
   }
 
-  deleteMfaDevice(data: DeleteMfaDeviceRequest) {
+  removeDevice(data: RemoveDeviceRequest) {
     return api.delete(cfg.api.mfaDevicePath, { ...data });
   }
 }

--- a/packages/teleport/src/services/mfa/mfa.ts
+++ b/packages/teleport/src/services/mfa/mfa.ts
@@ -1,10 +1,10 @@
 import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 import makeMfaDevice from './makeMfaDevice';
-import { RemoveDeviceRequest } from './types';
+import { MfaDevice, RemoveDeviceRequest } from './types';
 
 class MfaService {
-  fetchDevices(tokenId: string) {
+  fetchDevicesWithToken(tokenId: string): Promise<MfaDevice[]> {
     return api
       .get(cfg.getMfaDeviceListUrl(tokenId))
       .then(devices => devices.map(makeMfaDevice));

--- a/packages/teleport/src/services/mfa/types.ts
+++ b/packages/teleport/src/services/mfa/types.ts
@@ -5,9 +5,3 @@ export type MfaDevice = {
   registeredDate: Date;
   lastUsedDate: Date;
 };
-
-export type RemoveDeviceRequest = {
-  tokenId: string;
-  deviceId: string;
-  deviceName: string;
-};

--- a/packages/teleport/src/services/mfa/types.ts
+++ b/packages/teleport/src/services/mfa/types.ts
@@ -1,0 +1,15 @@
+export type MfaDevice = {
+  id: string;
+  type: 'Hardware Key' | 'Authenticator App';
+  name: string;
+  registeredDate: number;
+  lastUsedDate: number;
+  registeredDateText: string;
+  lastUsedDateText: string;
+};
+
+export type DeleteMfaDeviceRequest = {
+  tokenId: string;
+  deviceId: string;
+  deviceName: string;
+};

--- a/packages/teleport/src/services/mfa/types.ts
+++ b/packages/teleport/src/services/mfa/types.ts
@@ -1,14 +1,12 @@
 export type MfaDevice = {
   id: string;
-  type: 'Hardware Key' | 'Authenticator App';
   name: string;
-  registeredDate: number;
-  lastUsedDate: number;
-  registeredDateText: string;
-  lastUsedDateText: string;
+  typeText: 'Hardware Key' | 'Authenticator App';
+  registeredDate: Date;
+  lastUsedDate: Date;
 };
 
-export type DeleteMfaDeviceRequest = {
+export type RemoveDeviceRequest = {
   tokenId: string;
   deviceId: string;
   deviceName: string;

--- a/packages/teleport/src/services/mfa/types.ts
+++ b/packages/teleport/src/services/mfa/types.ts
@@ -1,7 +1,7 @@
 export type MfaDevice = {
   id: string;
   name: string;
-  typeText: 'Hardware Key' | 'Authenticator App';
+  description: string;
   registeredDate: Date;
   lastUsedDate: Date;
 };

--- a/packages/teleport/src/services/mfa/utils.ts
+++ b/packages/teleport/src/services/mfa/utils.ts
@@ -1,0 +1,23 @@
+import { Auth2faType } from 'shared/services';
+import { Option } from 'shared/components/Select';
+
+export type MfaOption = Option<Auth2faType>;
+
+export function getMfaOptions(auth2faType: Auth2faType) {
+  const mfaOptions: MfaOption[] = [];
+  const mfaEnabled = auth2faType === 'on' || auth2faType === 'optional';
+
+  if (auth2faType === 'optional' || auth2faType === 'off') {
+    mfaOptions.push({ value: 'optional', label: 'None' });
+  }
+
+  if (auth2faType === 'u2f' || mfaEnabled) {
+    mfaOptions.push({ value: 'u2f', label: 'Hardware Key' });
+  }
+
+  if (auth2faType === 'otp' || mfaEnabled) {
+    mfaOptions.push({ value: 'otp', label: 'Authenticator App' });
+  }
+
+  return mfaOptions;
+}


### PR DESCRIPTION
## Purpose

Changed the way we call MFA devices after discussing with @klizhentas and @kimlisa .

Moved MFA logic to OSS for the upcoming MFA device management feature and also to reduce the scope of the PR in `webapps.e`.

## Implementation

The back-end MFA-related endpoints have been moved to the OSS cfg, and I created a new `MfaService` for MFA-related logic, this service will also be used by the account dashboard device management.

We previously had inconsistent and sometimes confusing naming when it came to MFA devices. We now call them "Two-Factor Devices".

- "TOTP" is now "Authenticator App".
- "U2F" is now "Hardware Key".

The flows for resetting `totp` and `u2f` have been combined into one, there is no longer a "Lost U2F Key?"/"Lost Two-Factor Token?", but a single "Lost Two-Factor Device?".

## Demo

### Login

![login](https://user-images.githubusercontent.com/56373201/129799621-5b07516f-e62f-44f2-a013-9ab4ac52e2ef.gif)

### Invite

#### U2F

![image](https://user-images.githubusercontent.com/56373201/129799812-00213ba2-b2fb-42ba-82ec-eaaafbab60eb.png)

#### TOTP

![image](https://user-images.githubusercontent.com/56373201/129799842-20547852-8cbd-48e1-a8d8-cb04531bcdbd.png)

