### PR TITLE
performance test setup

### DIFF
--- a/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import React from 'react';
+import blobArray from './fixtures/onmessageBlobs';
+import { DesktopSession } from './DesktopSession';
+import TdpClient from 'teleport/lib/tdp/client';
+
+export default {
+  title: 'Teleport/DesktopSession',
+};
+
+export const PerformanceTest = () => {
+  const client = new TdpClient('wss://address', 'Administrator');
+  client.connect = () => {
+    // Allows us test out the rendering pipeline with different simulated delays between
+    // onmessage calls.
+    var optionallyDelayedOnmessage = (i: number, delay?: number) => {
+      if (!delay || delay == 0) {
+        blobArray.forEach(blob => {
+          client.processMessage(blob);
+        });
+        return;
+      }
+
+      if (i < blobArray.length - 1) {
+        client.processMessage(blobArray[i++]);
+        //create a pause of 2 seconds.
+        setTimeout(function() {
+          optionallyDelayedOnmessage(i, delay);
+        }, delay);
+      }
+    };
+
+    client.disconnect = () => {
+      client.removeAllListeners();
+    };
+
+    const delayMs = 1;
+    optionallyDelayedOnmessage(0, delayMs);
+  };
+  return (
+    <DesktopSession
+      tdpClient={client}
+      attempt={{ status: 'success' }}
+      setAttempt={() => {}}
+    />
+  );
+};

--- a/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
@@ -24,7 +24,10 @@ export default {
 
 export const PerformanceTest = () => {
   const client = new TdpClient('wss://address', 'Administrator');
+
   client.connect = () => {
+    // emit open to simulate the opening of a websocket, alerts DesktopSession to resize its canvas to screen size
+    client.emit('open');
     // Allows us test out the rendering pipeline with different simulated delays between
     // onmessage calls.
     var optionallyDelayedOnmessage = (i: number, delay?: number) => {
@@ -37,7 +40,6 @@ export const PerformanceTest = () => {
 
       if (i < blobArray.length - 1) {
         client.processMessage(blobArray[i++]);
-        //create a pause of 2 seconds.
         setTimeout(function() {
           optionallyDelayedOnmessage(i, delay);
         }, delay);
@@ -51,6 +53,10 @@ export const PerformanceTest = () => {
     const delayMs = 1;
     optionallyDelayedOnmessage(0, delayMs);
   };
+
+  client.sendUsername = () => {};
+  client.resize = (w: number, h: number) => {};
+
   return (
     <DesktopSession
       tdpClient={client}

--- a/packages/teleport/src/DesktopSession/fixtures/onmessageBlobs.ts
+++ b/packages/teleport/src/DesktopSession/fixtures/onmessageBlobs.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// onMessageUint8Arrays is an array of objects (each representing a Uint8Array) that were saved by converting
+// all the websocket messages to Uint8Array's and saving them as a big json list, when first connecting to a remote machine.
+// Therefore when displayed sequentially via the DesktopSession client, they show what one would expect when a user connects
+// and logs in over TDP.
+import onMessageUint8Arrays from './windows.onmessage.ev.data.json';
+
+// Convert the array of Uint8Arrays into an array of Blobs for use in simulating the websocket onmessage events.
+// The blobs from onmessage(ev => ev.data) were saved as an array of objects, with each object representing a Uint8Array.
+// E.g.
+// [
+//   { '0': 2, '1': 45 , ...},
+//   { '0': 78, '1': 0 , ...},
+//   ...
+// ]
+// needs to be converted into
+// [
+//   Uint8Array([2, 45, ...]),
+//   Uint8Array([78, 0, ...]),
+//   ...
+// ]
+const data = onMessageUint8Arrays as Array<{ index: string; value: number }>;
+const blobArray: Blob[] = [];
+data.forEach(obj => {
+  let uint8array = new Uint8Array(Object.keys(obj).map(key => obj[key]));
+  blobArray.push(new Blob([uint8array]));
+});
+
+export default blobArray;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,9 @@
     // Require format
     "module": "commonjs",
     // Import non-ES modules as default imports.
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    // Allow for import of json files as modules.
+    "resolveJsonModule": true,
   },
   "exclude": ["node_modules", "dist", "**/node_modules/*", "**/dist/*"]
 }


### PR DESCRIPTION
Adds the necessary framework for loading `Websocket.onmessage` calls from json and running them in a storybook.

One issue I haven't solved is that the "recording" I'm loading from json is fit to a particular (large) screen size. We will eventually need to solve this problem for playback, but that's a relatively low priority issue. 

Regardless, we can use this to test the time from when an `onmessage` is received to actually rendering one the screen. That said, I don't see why we can't do the same when talking over a real websocket. Open for discussion.