### PR TITLE
Fix base64 encoding for passwords on signup

### DIFF
--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -109,8 +109,8 @@ const auth = {
 
   changePassword(oldPass, newPass, token) {
     const data = {
-      old_password: window.btoa(oldPass),
-      new_password: window.btoa(newPass),
+      old_password: base64EncodeUnicode(oldPass),
+      new_password: base64EncodeUnicode(newPass),
       second_factor_token: token,
     };
 
@@ -143,7 +143,7 @@ const auth = {
           }
 
           const data = {
-            new_password: window.btoa(newPass),
+            new_password: base64EncodeUnicode(newPass),
             u2f_sign_response: res,
           };
 
@@ -162,7 +162,7 @@ const auth = {
 
   _resetPassword(tokenId, psw, hotpToken, u2fResponse) {
     const request = {
-      password: window.btoa(psw),
+      password: base64EncodeUnicode(psw),
       second_factor_token: hotpToken,
       token: tokenId,
       u2f_register_response: u2fResponse,
@@ -200,5 +200,13 @@ const auth = {
     return new Error(message);
   },
 };
+
+function base64EncodeUnicode(str) {
+  return window.btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+      return String.fromCharCode('0x' + p1);
+    })
+  );
+}
 
 export default auth;


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/7985

Fix the browser-breaking error that is caused when the user tries to sign up with some characters (such as cyrillic alphabet characters)

## Implementation

We use `window.btoa()` to encode the password string in base64 before it is sent to the backend. However, the `window.btoa()` function only accepts strings with characters within the [Latin-1 character set](https://kb.iu.edu/d/aepu), trying to pass in a string containing characters beyond this range will trigger a `The string to be encoded contains characters outside of the Latin1 range` exception.

This solution from the [MDN Docs](https://developer.mozilla.org/en-US/docs/Glossary/Base64) works by first using `encodeURIComponent()` to percent-encode the special characters in UTF-8, then those percent-encoded bits of the string are converted to raw bytes and replaced, the resulting string is compatible with `window.btoa()` and is encoded in base64. This way, any unicode string can be encoded in base64.

## Demo 

### Signing up using `Беларусь123` as the password
![signup with cyrillic](https://user-images.githubusercontent.com/56373201/132694949-126e70a4-d591-41ea-b416-c9b65ff22301.gif)
