### PR TITLE
Fix broken paged table layout

### DIFF
--- a/packages/design/src/DataTable/Paged/Paged.jsx
+++ b/packages/design/src/DataTable/Paged/Paged.jsx
@@ -44,10 +44,13 @@ export default function TablePaged(props) {
   if (showBottomPager) {
     tableProps.borderBottomRightRadius = '0';
     tableProps.borderBottomLeftRadius = '0';
+  } else {
+    tableProps.borderTopRightRadius = '0';
+    tableProps.borderTopLeftRadius = '0';
   }
 
   return (
-    <div>
+    <div style={{ minWidth: 'min-content' }}>
       {showTopPager && (
         <StyledPanel borderTopRightRadius="3" borderTopLeftRadius="3">
           <Pager {...pagerProps} />

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -777,6 +777,8 @@ exports[`loaded state 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c12 > thead > tr > th,
@@ -927,7 +929,9 @@ exports[`loaded state 1`] = `
         placeholder="SEARCH..."
         value=""
       />
-      <div>
+      <div
+        style="min-width: min-content;"
+      >
         <nav
           class="c6"
         >

--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -146,6 +146,8 @@ exports[`loaded 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c13 > thead > tr > th,
@@ -659,7 +661,9 @@ exports[`loaded 1`] = `
       value=""
     />
   </div>
-  <div>
+  <div
+    style="min-width: min-content;"
+  >
     <nav
       class="c7"
     >

--- a/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -159,6 +159,8 @@ exports[`render DocumentNodes 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c19 > thead > tr > th,
@@ -768,7 +770,9 @@ exports[`render DocumentNodes 1`] = `
         </div>
       </div>
       <div>
-        <div>
+        <div
+          style="min-width: min-content;"
+        >
           <nav
             class="c13"
           >

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -711,6 +711,8 @@ exports[`open source loaded 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c12 > thead > tr > th,
@@ -861,7 +863,9 @@ exports[`open source loaded 1`] = `
       value=""
     />
   </div>
-  <div>
+  <div
+    style="min-width: min-content;"
+  >
     <nav
       class="c6"
     >

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -640,6 +640,8 @@ exports[`loaded 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c12 > thead > tr > th,
@@ -865,7 +867,9 @@ exports[`loaded 1`] = `
       value=""
     />
   </div>
-  <div>
+  <div
+    style="min-width: min-content;"
+  >
     <nav
       class="c6"
     >

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -760,6 +760,8 @@ exports[`loaded 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c15 > thead > tr > th,
@@ -926,7 +928,9 @@ exports[`loaded 1`] = `
     </div>
   </div>
   <div>
-    <div>
+    <div
+      style="min-width: min-content;"
+    >
       <nav
         class="c9"
       >

--- a/packages/teleport/src/Recordings/__snapshots__/Recordings.story.test.tsx.snap
+++ b/packages/teleport/src/Recordings/__snapshots__/Recordings.story.test.tsx.snap
@@ -133,6 +133,8 @@ exports[`rendering of Session Recordings 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c13 > thead > tr > th,
@@ -610,7 +612,9 @@ exports[`rendering of Session Recordings 1`] = `
         value=""
       />
     </div>
-    <div>
+    <div
+      style="min-width: min-content;"
+    >
       <nav
         class="c7"
       >

--- a/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -144,6 +144,8 @@ exports[`loaded 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c10 > thead > tr > th,
@@ -281,7 +283,9 @@ exports[`loaded 1`] = `
   <div
     class="c3"
   >
-    <div>
+    <div
+      style="min-width: min-content;"
+    >
       <nav
         class="c4"
       >

--- a/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -206,6 +206,8 @@ exports[`success state 1`] = `
   border-radius: 8px;
   font-size: 12px;
   width: 100%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .c12 > thead > tr > th,
@@ -387,7 +389,9 @@ exports[`success state 1`] = `
         value=""
       />
     </div>
-    <div>
+    <div
+      style="min-width: min-content;"
+    >
       <nav
         class="c6"
       >


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/webapps/issues/388

In some cases the table could exceed the width of its parent and cause it to be misaligned with the pager section above it. this caused it to look clipped and broken.

## Implementation

The issue was that the pager section was respecting the parent div's width, while the table section was overflowing. Adding a `min-width: min-content` to the parent div ensures that it will always be at least as wide as its widest child, and the pager section's width can match and be aligned with the table regardless of how wide it is.

Also fixed the rounded corners so that the table doesn't have rounded corners if the pager section is above it.

## Demo

### Before

![broken](https://user-images.githubusercontent.com/56373201/132697172-9620f050-8ce7-41cd-9f89-8d4a9d7a2e40.gif)

### After

![fixed](https://user-images.githubusercontent.com/56373201/132698878-7e5b5a9c-bf65-45d9-bf38-fa1d4cb05424.gif)


