### PR TITLE
Clear localStorage on Login

### DIFF
--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -17,9 +17,9 @@ limitations under the License.
 // This puts it in window.u2f
 import 'u2f-api-polyfill';
 import api from 'teleport/services/api';
+import session from 'teleport/services/session';
 import cfg from 'teleport/config';
 import makePasswordToken from './makePasswordToken';
-import session from 'teleport/services/session';
 
 const auth = {
   u2fBrowserSupported() {

--- a/packages/teleport/src/services/auth/auth.js
+++ b/packages/teleport/src/services/auth/auth.js
@@ -19,6 +19,7 @@ import 'u2f-api-polyfill';
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import makePasswordToken from './makePasswordToken';
+import session from 'teleport/services/session';
 
 const auth = {
   u2fBrowserSupported() {
@@ -38,6 +39,7 @@ const auth = {
       second_factor_token: token,
     };
 
+    session.clear();
     return api.post(cfg.api.sessionPath, data, false);
   },
 
@@ -52,6 +54,7 @@ const auth = {
       pass: password,
     };
 
+    session.clear();
     return api.post(cfg.api.u2fSessionChallengePath, data, false).then(data => {
       const promise = new Promise((resolve, reject) => {
         var devices = [data];


### PR DESCRIPTION
## Purpose

The browser `localStorage` gets cleared when the user clicks the “Sign Out” button, however, it is possible to navigate to the `/web/login` page directly and log into a new user without clicking “Sign Out". When logging into a new user in this manner, the `localStorage` can still contain remnants of the previous user and cause unintended UI behavior, for example, the "role assumed" banner from the previous user can persist. This PR clears the remnants of the previous user on login.


