### PR TITLE
performance upgrade

### DIFF
--- a/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
+++ b/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import TdpClient, { RenderData } from 'teleport/lib/tdp/client';
 import { useParams } from 'react-router';
 import { TopBarHeight } from './TopBar';
@@ -67,7 +67,11 @@ export default function useTdpClientCanvas() {
 
   const onRender = (canvas: HTMLCanvasElement, data: RenderData) => {
     const ctx = canvas.getContext('2d');
-    ctx.drawImage(data.bitmap, data.left, data.top);
+    if (data.image.complete) {
+      ctx.drawImage(data.image, data.left, data.top);
+      return;
+    }
+    queueMicrotask(() => onRender(canvas, data));
   };
 
   const onDisconnect = () => {

--- a/packages/teleport/src/lib/tdp/client.ts
+++ b/packages/teleport/src/lib/tdp/client.ts
@@ -93,15 +93,8 @@ export default class Client extends EventEmitter {
   // bounds and png bitmap and emit a render event.
   processFrame(buffer: ArrayBuffer) {
     const { left, top } = this.codec.decodeRegion(buffer);
-    console.log(`left: ${left} top: ${top}`);
-    this.codec
-      .decodePng(buffer)
-      .then(bitmap => {
-        this.emit('render', { bitmap, left, top });
-      })
-      .catch(err => {
-        this.handleError(err);
-      });
+    const image = this.codec.decodePng(buffer);
+    this.emit('render', { image, left, top });
   }
 
   sendUsername(username: string) {
@@ -148,7 +141,7 @@ export default class Client extends EventEmitter {
 }
 
 export type RenderData = {
-  bitmap: ImageBitmap;
+  image: HTMLImageElement;
   left: number;
   top: number;
 };

--- a/packages/teleport/src/lib/tdp/codec.ts
+++ b/packages/teleport/src/lib/tdp/codec.ts
@@ -296,12 +296,21 @@ export default class Codec {
       left: dv.getUint32(1),
       top: dv.getUint32(5),
       right: dv.getUint32(9),
-      bottom: dv.getUint32(15),
+      bottom: dv.getUint32(13),
     };
   }
 
+  // Taken as the winning algorithm of https://jsbench.me/vjk9nczxst/1
+  // jsbench link was discovered in https://gist.github.com/jonleighton/958841
+  toBase64(buffer: ArrayBuffer) {
+    const binary = String.fromCharCode.apply(null, new Uint8Array(buffer, 17));
+    return btoa(binary);
+  }
+
   // decodePng decodes the image bitmap from the png data part of a PNG_FRAME tdp message.
-  decodePng(buffer: ArrayBuffer): Promise<ImageBitmap> {
-    return createImageBitmap(new Blob([buffer.slice(17)]));
+  decodePng(buffer: ArrayBuffer): HTMLImageElement {
+    const image = new Image();
+    image.src = `data:image/png;base64,${this.toBase64(buffer)}`;
+    return image;
   }
 }


### PR DESCRIPTION
Managed to get big performance improvements by taking the image array buffer and converting it to a base64 encoded png url and strapping that as the source of an html image element which is then drawn to the canvas. Thanks to @alex-kovoy for the hypothesis that it was the buildup of promises that was causing major latency and the suggestion to look to [prior art](https://github.com/cedrozor/myrtille) for inspiration.

Many iterations were tried and timed, the data sheet with average time calculations is found [here](https://docs.google.com/spreadsheets/d/1ylMGXjSLqY9iP5bVR3Mqn5cKd3qkXjx8F2VMVWgDWr8/edit?usp=sharing). This PR takes us from an average time of 2.8 seconds to go from the start of `processFrame` to completing the canvas draw call all the way down to an average of _140 µs_, a roughly 20,000x improvement.

The line by line drawing of the screen is still noticeable upon startup, particularly for bigger screens, so there is still more work to do, but massive UX improvement compared to what we had before.