### PR TITLE
moves openNewTab into a utils file and uses it for Desktop

### DIFF
--- a/packages/teleport/src/Desktops/useDesktops.ts
+++ b/packages/teleport/src/Desktops/useDesktops.ts
@@ -20,6 +20,7 @@ import Ctx from 'teleport/teleportContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import { Desktop } from 'teleport/services/desktops';
 import cfg from 'teleport/config';
+import { openNewTab } from 'teleport/lib/util';
 
 export default function useDesktops(ctx: Ctx) {
   const { attempt, run } = useAttempt('processing');
@@ -41,24 +42,7 @@ export default function useDesktops(ctx: Ctx) {
       username,
     });
 
-    openNewWindow(url);
-  };
-
-  // It turns out opening a new window is not as simple as one would hope with modern browsers.
-  // The following solution works on recent versions of Chrome/Firefox/Safari, but it may be unstable
-  // since it is not explicitly defined behavior. For now it should be tested manually before releases.
-  const openNewWindow = (url: string) => {
-    const element = document.createElement('a');
-    // see https://forums.asp.net/post/4841258.aspx
-    element.setAttribute('href', `${url}`);
-    element.setAttribute(
-      'onclick',
-      `window.open(this.href, '_blank', 'scrollbars=no,status=no,toolbar=no,menubar=no,location=no'); return false;`
-    );
-    element.style.display = 'none';
-    document.body.appendChild(element);
-    element.click();
-    document.body.removeChild(element);
+    openNewTab(url);
   };
 
   return {

--- a/packages/teleport/src/Nodes/useNodes.ts
+++ b/packages/teleport/src/Nodes/useNodes.ts
@@ -20,6 +20,7 @@ import Ctx from 'teleport/teleportContext';
 import { StickyCluster } from 'teleport/types';
 import cfg from 'teleport/config';
 import { Node } from 'teleport/services/nodes';
+import { openNewTab } from 'teleport/lib/util';
 
 export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
   const { isLeafCluster, clusterId } = stickyCluster;
@@ -38,17 +39,6 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
     (serverId: string) => makeOptions(clusterId, serverId, logins),
     [logins]
   );
-
-  const openNewTab = (url: string) => {
-    const element = document.createElement('a');
-    element.setAttribute('href', `${url}`);
-    // works in ie11
-    element.setAttribute('target', `_blank`);
-    element.style.display = 'none';
-    document.body.appendChild(element);
-    element.click();
-    document.body.removeChild(element);
-  };
 
   const startSshSession = (login: string, serverId: string) => {
     const url = cfg.getSshConnectRoute({

--- a/packages/teleport/src/lib/util.ts
+++ b/packages/teleport/src/lib/util.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export const openNewTab = (url: string) => {
+  const element = document.createElement('a');
+  element.setAttribute('href', `${url}`);
+  // works in ie11
+  element.setAttribute('target', `_blank`);
+  element.style.display = 'none';
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+};


### PR DESCRIPTION
After reviewing with Sasha yesterday we agreed that desktops should open in a new tab, not a new window.

This pulls the `openNewTab` function out into a new file `teleport/lib/utils.ts`, since I am unaware of another appropriate util file (let me know if you know of a better place).