### PR TITLE
desktop access: remove OS column

### DIFF
--- a/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
+++ b/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
@@ -87,17 +87,6 @@ function DesktopList(props: Props) {
         }
         cell={<DesktopDomainCell />}
       />
-      <Column
-        columnKey="os"
-        header={
-          <SortHeaderCell
-            sortDir={sortDir.desc}
-            onSortChange={onSortChange}
-            title="Operating System"
-          />
-        }
-        cell={<OSCell />}
-      />
       <Column header={<Cell>Labels</Cell>} cell={<LabelCell />} />
       <Column
         header={<Cell />}
@@ -172,13 +161,6 @@ function LabelCell(props) {
   const { tags = [] } = data[rowIndex];
   return renderLabelCell(tags);
 }
-
-const OSCell = props => {
-  const { rowIndex, data, columnKey, ...rest } = props;
-  var osText =
-    data[rowIndex][columnKey] === 'windows' ? 'Windows' : 'Unknown OS';
-  return <Cell {...rest}>{osText}</Cell>;
-};
 
 const StyledTable = styled(Table)`
   & > tbody > tr > td {


### PR DESCRIPTION
We currently only support Windows, and for hosts discovered via
LDAP we automatically apply a teleport.dev/os label which is more
specific than "Windows", so remove the column to avoid repeating
the same information multiple times.