### PR TITLE
emit connect event when the connection is actually confirmed

### DIFF
--- a/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
@@ -176,6 +176,7 @@ export const Performance = () => {
           startTime = performance.now();
         } else if (i === arrayBuf2260x1130.length - 1) {
           endTime = performance.now();
+          // eslint-disable-next-line no-console
           console.log(`Total time (ms): ${endTime - startTime}`);
         }
         i++;


### PR DESCRIPTION
Previously I was emitting `'connect'` if the
```typescript
this.sendUsername(this.username);
this.resize(initialWidth, initialHeight);
```
didn't cause anything to fail, but after playing around with trying to connect to desktops that do not even exist, its clear that our backend isn't written in a way that this is reliable.

This change instead emits the `'connect'` event after we receive the first frame, at which point we know that the connection was successful. In the future, we might add a tdp event for connection confirmed, but this should do for the preview.

I also checked if this extra `if` clause affected performance -- before the change, I clocked the average of 10 runs of the `Performance` story at 11.82ms, after the change was 8.68ms. So it appears it's well-optimized.