### PR TITLE
`preventDefault`

### DIFF
--- a/packages/teleport/src/DesktopSession/TdpClientCanvas/TdpClientCanvas.tsx
+++ b/packages/teleport/src/DesktopSession/TdpClientCanvas/TdpClientCanvas.tsx
@@ -81,10 +81,12 @@ export default function TdpClientCanvas(props: Props) {
 
     // Key controls.
     const onkeydown = (e: KeyboardEvent) => {
+      e.preventDefault();
       onKeyDown(tdpClient, e);
     };
     canvas.onkeydown = onkeydown;
     const onkeyup = (e: KeyboardEvent) => {
+      e.preventDefault();
       onKeyUp(tdpClient, e);
     };
     canvas.onkeyup = onkeyup;


### PR DESCRIPTION
Add preventDefault to prevent default browser shortcuts from interfering with desktop sessions (like how pressing `'` (apostrophe) in Firefox can open the "quick find" bar.