### PR TITLE
adds mouse wheel support to tdp / client

### DIFF
--- a/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
@@ -66,6 +66,7 @@ const props: State = {
   onMouseMove: (cli: TdpClient, canvas: HTMLCanvasElement, e: MouseEvent) => {},
   onMouseDown: (cli: TdpClient, e: MouseEvent) => {},
   onMouseUp: (cli: TdpClient, e: MouseEvent) => {},
+  onMouseWheelScroll: (cli: TdpClient, e: WheelEvent) => {},
 };
 
 export const Processing = () => (

--- a/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -47,6 +47,7 @@ export function DesktopSession(props: State) {
     onMouseMove,
     onMouseDown,
     onMouseUp,
+    onMouseWheelScroll,
   } = props;
 
   const { attempt, setAttempt } = useAttempt('processing'); // attempt.status === '' means disconnected
@@ -126,6 +127,7 @@ export function DesktopSession(props: State) {
         onMouseMove={onMouseMove}
         onMouseDown={onMouseDown}
         onMouseUp={onMouseUp}
+        onMouseWheelScroll={onMouseWheelScroll}
       />
     </Flex>
   );

--- a/packages/teleport/src/DesktopSession/TdpClientCanvas/TdpClientCanvas.tsx
+++ b/packages/teleport/src/DesktopSession/TdpClientCanvas/TdpClientCanvas.tsx
@@ -30,6 +30,7 @@ export default function TdpClientCanvas(props: Props) {
     onMouseMove,
     onMouseDown,
     onMouseUp,
+    onMouseWheelScroll,
     style,
   } = props;
 
@@ -78,6 +79,11 @@ export default function TdpClientCanvas(props: Props) {
       onMouseUp(tdpClient, e);
     };
     canvas.onmouseup = onmouseup;
+    const onwheel = (e: WheelEvent) => {
+      e.preventDefault();
+      onMouseWheelScroll(tdpClient, e);
+    };
+    canvas.onwheel = onwheel;
 
     // Key controls.
     const onkeydown = (e: KeyboardEvent) => {
@@ -122,6 +128,7 @@ export default function TdpClientCanvas(props: Props) {
       canvas.removeEventListener('mouseup', onmouseup);
       canvas.removeEventListener('keydown', onkeydown);
       canvas.removeEventListener('keyup', onkeyup);
+      canvas.removeEventListener('wheel', onwheel);
     };
   }, [tdpClient]);
 

--- a/packages/teleport/src/DesktopSession/TdpClientCanvas/useTdpClientCanvas.tsx
+++ b/packages/teleport/src/DesktopSession/TdpClientCanvas/useTdpClientCanvas.tsx
@@ -20,7 +20,7 @@ import { useParams } from 'react-router';
 import { TopBarHeight } from './TopBar';
 import cfg, { UrlDesktopParams } from 'teleport/config';
 import { getAccessToken, getHostName } from 'teleport/services/api';
-import { ButtonState } from 'teleport/lib/tdp/codec';
+import { ButtonState, ScrollAxis } from 'teleport/lib/tdp/codec';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 export default function useTdpClientCanvas() {
@@ -111,6 +111,19 @@ export default function useTdpClientCanvas() {
     }
   };
 
+  const onMouseWheelScroll = (cli: TdpClient, e: WheelEvent) => {
+    // We only support pixel scroll events, not line or page events.
+    // https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaMode
+    if (e.deltaMode === WheelEvent.DOM_DELTA_PIXEL) {
+      if (e.deltaX) {
+        cli.sendMouseWheelScroll(ScrollAxis.HORIZONTAL, -e.deltaX);
+      }
+      if (e.deltaY) {
+        cli.sendMouseWheelScroll(ScrollAxis.VERTICAL, -e.deltaY);
+      }
+    }
+  };
+
   return {
     tdpClient,
     connectionAttempt,
@@ -125,5 +138,6 @@ export default function useTdpClientCanvas() {
     onMouseMove,
     onMouseDown,
     onMouseUp,
+    onMouseWheelScroll,
   };
 }

--- a/packages/teleport/src/lib/tdp/client.ts
+++ b/packages/teleport/src/lib/tdp/client.ts
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { EventEmitter } from 'events';
-import Codec, { MessageType, MouseButton, ButtonState } from './codec';
+import Codec, {
+  MessageType,
+  MouseButton,
+  ButtonState,
+  ScrollAxis,
+} from './codec';
 import Logger from 'shared/libs/logger';
 
 // Client is the TDP client. It is responsible for connecting to a websocket serving the tdp server,
@@ -113,6 +118,10 @@ export default class Client extends EventEmitter {
 
   sendMouseButton(button: MouseButton, state: ButtonState) {
     this.socket.send(this.codec.encodeMouseButton(button, state));
+  }
+
+  sendMouseWheelScroll(axis: ScrollAxis, delta: number) {
+    this.socket.send(this.codec.encodeMouseWheelScroll(axis, delta));
   }
 
   sendKeyboardInput(code: string, state: ButtonState) {

--- a/packages/teleport/src/lib/tdp/codec.test.ts
+++ b/packages/teleport/src/lib/tdp/codec.test.ts
@@ -1,5 +1,10 @@
 const { TextEncoder } = require('util');
-import Codec, { MessageType, ButtonState, MouseButton } from './codec';
+import Codec, {
+  MessageType,
+  ButtonState,
+  MouseButton,
+  ScrollAxis,
+} from './codec';
 
 // Use nodejs TextEncoder until jsdom adds support for TextEncoder (https://github.com/jsdom/jsdom/issues/2524)
 window.TextEncoder = window.TextEncoder || TextEncoder;
@@ -99,6 +104,16 @@ test('encodes utf8 characters correctly up to 3 bytes for username and password'
   first3RangesUTF8.forEach(byte => {
     expect(view.getUint8(offset++)).toEqual(byte);
   });
+});
+
+test('encodes mouse wheel scroll event', () => {
+  const axis = ScrollAxis.VERTICAL;
+  const delta = 860;
+  const message = codec.encodeMouseWheelScroll(axis, delta);
+  const view = new DataView(message);
+  expect(view.getUint8(0)).toEqual(MessageType.MOUSE_WHEEL_SCROLL);
+  expect(view.getUint8(1)).toEqual(axis);
+  expect(view.getUint16(2)).toEqual(delta);
 });
 
 function makeBufView(type: MessageType, size = 100) {

--- a/packages/teleport/src/lib/tdp/codec.ts
+++ b/packages/teleport/src/lib/tdp/codec.ts
@@ -8,6 +8,7 @@ export enum MessageType {
   KEYBOARD_BUTTON = 5,
   CLIPBOARD_DATA = 6,
   CLIENT_USERNAME = 7,
+  MOUSE_WHEEL_SCROLL = 8,
 }
 
 // 0 is left button, 1 is middle button, 2 is right button
@@ -16,6 +17,11 @@ export type MouseButton = 0 | 1 | 2;
 export enum ButtonState {
   UP = 0,
   DOWN = 1,
+}
+
+export enum ScrollAxis {
+  VERTICAL = 0,
+  HORIZONTAL = 1,
 }
 
 // Region represents a rectangular region of a screen in pixel coordinates via
@@ -261,6 +267,19 @@ export default class Codec {
       view.setUint8(offset++, byte);
     });
 
+    return buffer;
+  }
+
+  // encodeMouseWheelScroll encodes a mouse wheel scroll event.
+  // on vertical axis, positive delta is up, negative delta is down
+  // on horizontal axis, positive delta is left, negative delta is right
+  // | message type (8) | axis byte | delta int16
+  encodeMouseWheelScroll(axis: ScrollAxis, delta: number): Message {
+    const buffer = new ArrayBuffer(4);
+    const view = new DataView(buffer);
+    view.setUint8(0, MessageType.MOUSE_WHEEL_SCROLL);
+    view.setUint8(1, axis);
+    view.setUint16(2, delta);
     return buffer;
   }
 


### PR DESCRIPTION
Requires [this fix](https://github.com/gravitational/teleport/pull/8753) to work.

Horizontal scroll does not appear to work. I was unable to figure out why this might be the case -- I can generate the events via the browser, and I added logging in `teleport` to confirm they were being received in a proper state by the backend, but horizontal scroll events were not working on the remote machine. I tried horizontal scrolling in Microsoft's MacOS RDP client and that does work.

Added debugging this as a todo under "Client UI" in https://github.com/gravitational/teleport/issues/8742