### PR TITLE
Add created date to recovery codes respones

### DIFF
--- a/packages/teleport/src/services/auth/index.ts
+++ b/packages/teleport/src/services/auth/index.ts
@@ -17,5 +17,6 @@ limitations under the License.
 import service from './auth';
 
 export * from './makeMfa';
+export * from './makeRecoveryCodes';
 export * from './types';
 export default service;

--- a/packages/teleport/src/services/auth/makeMfa.ts
+++ b/packages/teleport/src/services/auth/makeMfa.ts
@@ -68,7 +68,11 @@ export function makeMfaAuthenticateChallenge(json): MfaAuthenticateChallenge {
   }
 
   return {
-    u2fSignRequests: json.u2f_challenges || [],
+    u2f: {
+      appId: json.appId,
+      challenge: json.challenge,
+      registeredKeys: json.u2f_challenges || [],
+    },
     webauthnPublicKey: webauthnPublicKey,
   };
 }

--- a/packages/teleport/src/services/auth/makeRecoveryCodes.ts
+++ b/packages/teleport/src/services/auth/makeRecoveryCodes.ts
@@ -16,6 +16,9 @@
 
 import { RecoveryCodes } from './types';
 
+// makeRecoveryCodes makes the response from a successful user reset or invite.
+// Only teleport cloud and users with valid emails as username will receive
+// recovery codes.
 export function makeRecoveryCodes(json): RecoveryCodes {
   json = json || {};
 

--- a/packages/teleport/src/services/auth/makeRecoveryCodes.ts
+++ b/packages/teleport/src/services/auth/makeRecoveryCodes.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2021 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RecoveryCodes } from './types';
+
+export function makeRecoveryCodes(json): RecoveryCodes {
+  json = json || {};
+
+  return {
+    codes: json.codes || [],
+    createdDate: json.created ? new Date(json.created) : null,
+  };
+}

--- a/packages/teleport/src/services/auth/types.ts
+++ b/packages/teleport/src/services/auth/types.ts
@@ -34,6 +34,12 @@ export type U2fRegisterRequest = {
   appId: string;
 };
 
+export type U2fChallenge = {
+  appId: string;
+  challenge: string;
+  registeredKeys: U2fSignRequest[];
+};
+
 export type U2fSignRequest = {
   version: string;
   challenge: string;
@@ -42,7 +48,7 @@ export type U2fSignRequest = {
 };
 
 export type MfaAuthenticateChallenge = {
-  u2fSignRequests: U2fSignRequest[];
+  u2f: U2fChallenge;
   webauthnPublicKey: PublicKeyCredentialRequestOptions;
 };
 
@@ -50,4 +56,9 @@ export type MfaRegistrationChallenge = {
   qrCode: Base64urlString;
   u2fRegisterRequest: U2fRegisterRequest;
   webauthnPublicKey: PublicKeyCredentialCreationOptions;
+};
+
+export type RecoveryCodes = {
+  codes?: string[];
+  createdDate: Date;
 };


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/323

#### Description
- Moved recovery code typing and make response to open source
- Fixes a regression bug I introduced where firefox still requires global setting of appId and challenges whereas chrome looks for it among the registered keys

#### Enterprise changes
https://github.com/gravitational/webapps.e/pull/84