### PR TITLE
Account dashboard support for SSO users

### DIFF
--- a/packages/teleport/src/Account/Account.tsx
+++ b/packages/teleport/src/Account/Account.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React from 'react';
 import { Box } from 'design';
 import cfg from 'teleport/config';
+import useTeleport from 'teleport/useTeleport';
 import { Route, Switch, NavLink, Redirect } from 'teleport/components/Router';
 import {
   FeatureBox,
@@ -27,14 +28,21 @@ import {
 import ChangePassword from './ChangePassword';
 import ManageDevices from './ManageDevices';
 
-export default function Account() {
+export default function Container() {
+  const ctx = useTeleport();
+  return <Account isSso={ctx.storeUser.isSso()} />;
+}
+
+export function Account({ isSso }: Props) {
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center">
         <FeatureHeaderTitle>
-          <TabItem as={NavLink} to={cfg.routes.accountPassword}>
-            Password
-          </TabItem>
+          {!isSso && (
+            <TabItem as={NavLink} to={cfg.routes.accountPassword}>
+              Password
+            </TabItem>
+          )}
           <TabItem as={NavLink} to={cfg.routes.accountMfaDevices}>
             Two-Factor Devices
           </TabItem>
@@ -42,14 +50,27 @@ export default function Account() {
       </FeatureHeader>
       <Box mt={3}>
         <Switch>
-          <Route path={cfg.routes.accountPassword} component={ChangePassword} />
+          {!isSso && (
+            <Route
+              path={cfg.routes.accountPassword}
+              component={ChangePassword}
+            />
+          )}
           <Route
             path={cfg.routes.accountMfaDevices}
             component={ManageDevices}
           />
-          <Redirect to={cfg.routes.accountPassword} />
+          <Redirect
+            to={
+              isSso ? cfg.routes.accountMfaDevices : cfg.routes.accountPassword
+            }
+          />
         </Switch>
       </Box>
     </FeatureBox>
   );
 }
+
+type Props = {
+  isSso: boolean;
+};

--- a/packages/teleport/src/features.ts
+++ b/packages/teleport/src/features.ts
@@ -158,10 +158,6 @@ export class FeatureAccount {
   };
 
   register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().account) {
-      return;
-    }
-
     ctx.storeNav.addTopMenuItem({
       title: 'Account Settings',
       Icon: Icons.User,

--- a/packages/teleport/src/teleportContext.tsx
+++ b/packages/teleport/src/teleportContext.tsx
@@ -60,7 +60,6 @@ class TeleportContext implements types.Context {
   getFeatureFlags() {
     const userContext = this.storeUser;
     return {
-      account: userContext.isSso() === false,
       audit: userContext.getEventAccess().list,
       authConnector: userContext.getConnectorAccess().list,
       roles: userContext.getRoleAccess().list,

--- a/packages/teleport/src/types.ts
+++ b/packages/teleport/src/types.ts
@@ -19,7 +19,6 @@ import React from 'react';
 export type NavGroup = 'team' | 'activity' | 'clusters';
 
 type FeatureFlags = {
-  account: boolean;
   audit: boolean;
   authConnector: boolean;
   roles: boolean;


### PR DESCRIPTION
## Purpose

This PR allows SSO users to access the account dashboard so they can manage their MFA devices/recovery codes. The "Change Password" tab will be hidden from them.

## Demo

![image](https://user-images.githubusercontent.com/56373201/140811751-dca0d691-5fad-4c17-9d1d-ae76ccc41981.png)


