### PR TITLE
State timezone for consistent dates in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 const config = require('@gravitational/build/jest/config');
+
+process.env.TZ = 'PST';
+
 module.exports = {
   ...config,
   collectCoverageFrom: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const config = require('@gravitational/build/jest/config');
 
-process.env.TZ = 'PST';
+process.env.TZ = 'UTC';
 
 module.exports = {
   ...config,


### PR DESCRIPTION
Ran into drone test errors in snapshots:

```
    -           Created: Fri Aug 30 2019 04:00:00 GMT-0700 (Pacific Daylight Time)
    +           Created: Fri Aug 30 2019 11:00:00 GMT+0000 (Coordinated Universal Time)
```