### PR TITLE
Improve error message when TOTP token is not valid

### DIFF
--- a/packages/teleport/src/Invite/useInvite.ts
+++ b/packages/teleport/src/Invite/useInvite.ts
@@ -39,7 +39,17 @@ export default function useInvite(tokenId: string) {
     auth
       .resetPassword(tokenId, password, otpToken)
       .then(redirect)
-      .catch(submitAttempt.handleError);
+      .catch(err => {
+        if (err.response.status === 403) {
+          submitAttempt.handleError(
+            new Error(
+              'Invalid one time token. Please check if the token has expired and try again.'
+            )
+          );
+          return;
+        }
+        submitAttempt.handleError(err);
+      });
   }
 
   function onSubmitWithU2f(password: string) {

--- a/packages/teleport/src/Invite/useInvite.ts
+++ b/packages/teleport/src/Invite/useInvite.ts
@@ -40,7 +40,7 @@ export default function useInvite(tokenId: string) {
       .resetPassword(tokenId, password, otpToken)
       .then(redirect)
       .catch(err => {
-        if (err.response.status === 403) {
+        if (err.response?.status === 403) {
           submitAttempt.handleError(
             new Error(
               'Invalid one time token. Please check if the token has expired and try again.'

--- a/packages/teleport/src/services/auth/auth.ts
+++ b/packages/teleport/src/services/auth/auth.ts
@@ -323,22 +323,7 @@ const auth = {
       u2f_register_response: u2fResponse,
     };
 
-    return api
-      .put(cfg.getPasswordTokenUrl(), request)
-      .then(makeRecoveryCodes)
-      .catch(auth._handleResetPasswordErr);
-  },
-
-  _handleResetPasswordErr(err) {
-    if (err.response.status === 403) {
-      return Promise.reject(
-        new Error(
-          'Invalid one time token. Please check if the token has expired and try again.'
-        )
-      );
-    }
-
-    return Promise.reject(err);
+    return api.put(cfg.getPasswordTokenUrl(), request).then(makeRecoveryCodes);
   },
 
   _getU2FRegisterRes(tokenId: string) {

--- a/packages/teleport/src/services/auth/auth.ts
+++ b/packages/teleport/src/services/auth/auth.ts
@@ -323,7 +323,22 @@ const auth = {
       u2f_register_response: u2fResponse,
     };
 
-    return api.put(cfg.getPasswordTokenUrl(), request).then(makeRecoveryCodes);
+    return api
+      .put(cfg.getPasswordTokenUrl(), request)
+      .then(makeRecoveryCodes)
+      .catch(auth._handleResetPasswordErr);
+  },
+
+  _handleResetPasswordErr(err) {
+    if (err.response.status === 403) {
+      return Promise.reject(
+        new Error(
+          'Invalid one time token. Please check if the token has expired and try again.'
+        )
+      );
+    }
+
+    return Promise.reject(err);
   },
 
   _getU2FRegisterRes(tokenId: string) {


### PR DESCRIPTION
Closes gravitational/cloud#243

As mentioned in the issue, the error message when the TOTP token isn't valid is not actionable.
I've fixed it in the front end, should we change it in [Teleport's api](https://github.com/gravitational/teleport/blob/master/lib/auth/password.go#L301) instead?

