### PR TITLE
Make language for empty resources list more accurate

### DIFF
--- a/packages/teleport/src/Apps/Apps.tsx
+++ b/packages/teleport/src/Apps/Apps.tsx
@@ -107,6 +107,6 @@ const emptyStateInfo: EmptyStateInfo = {
   buttonText: 'ADD APPLICATION',
   readOnly: {
     title: 'No Applications Found',
-    message: 'There are no applications for the "',
+    resource: 'applications',
   },
 };

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -1252,7 +1252,7 @@ exports[`loaded state 1`] = `
 exports[`readonly empty state 1`] = `
 .c4 {
   box-sizing: border-box;
-  max-width: 600px;
+  max-width: 720px;
   margin-top: 24px;
   margin-left: auto;
   margin-right: auto;
@@ -1412,7 +1412,7 @@ exports[`readonly empty state 1`] = `
         >
           im-a-cluster
         </span>
-        " cluster.
+        " cluster, or you don't have access to any.
       </div>
     </div>
   </div>

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -1252,7 +1252,7 @@ exports[`loaded state 1`] = `
 exports[`readonly empty state 1`] = `
 .c4 {
   box-sizing: border-box;
-  max-width: 720px;
+  max-width: 664px;
   margin-top: 24px;
   margin-left: auto;
   margin-right: auto;
@@ -1406,13 +1406,15 @@ exports[`readonly empty state 1`] = `
       <div
         class="c6"
       >
-        There are no applications for the "
+        Either there are no 
+        applications
+         in the "
         <span
           class="c7"
         >
           im-a-cluster
         </span>
-        " cluster, or you don't have access to any.
+        " cluster, or your roles don't grant you access.
       </div>
     </div>
   </div>

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -131,6 +131,6 @@ const emptyStateInfo: EmptyStateInfo = {
   buttonText: 'ADD DATABASE',
   readOnly: {
     title: 'No Databases Found',
-    message: 'There are no databases for the "',
+    resource: 'databases',
   },
 };

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -1069,7 +1069,7 @@ exports[`open source loaded 1`] = `
 exports[`readonly empty state 1`] = `
 .c4 {
   box-sizing: border-box;
-  max-width: 720px;
+  max-width: 664px;
   margin-top: 24px;
   margin-left: auto;
   margin-right: auto;
@@ -1223,13 +1223,15 @@ exports[`readonly empty state 1`] = `
       <div
         class="c6"
       >
-        There are no databases for the "
+        Either there are no 
+        databases
+         in the "
         <span
           class="c7"
         >
           im-a-cluster
         </span>
-        " cluster, or you don't have access to any.
+        " cluster, or your roles don't grant you access.
       </div>
     </div>
   </div>

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -1069,7 +1069,7 @@ exports[`open source loaded 1`] = `
 exports[`readonly empty state 1`] = `
 .c4 {
   box-sizing: border-box;
-  max-width: 600px;
+  max-width: 720px;
   margin-top: 24px;
   margin-left: auto;
   margin-right: auto;
@@ -1229,7 +1229,7 @@ exports[`readonly empty state 1`] = `
         >
           im-a-cluster
         </span>
-        " cluster.
+        " cluster, or you don't have access to any.
       </div>
     </div>
   </div>

--- a/packages/teleport/src/Kubes/Kubes.tsx
+++ b/packages/teleport/src/Kubes/Kubes.tsx
@@ -112,6 +112,6 @@ const emptyStateInfo: EmptyStateInfo = {
   buttonText: 'VIEW DOCUMENTATION',
   readOnly: {
     title: 'No Kubernetes Clusters Found',
-    message: 'There are no kubernetes clusters for the "',
+    resource: 'kubernetes clusters',
   },
 };

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -1032,7 +1032,7 @@ exports[`loaded 1`] = `
 exports[`readonly empty state 1`] = `
 .c4 {
   box-sizing: border-box;
-  max-width: 720px;
+  max-width: 664px;
   margin-top: 24px;
   margin-left: auto;
   margin-right: auto;
@@ -1187,13 +1187,15 @@ exports[`readonly empty state 1`] = `
       <div
         class="c6"
       >
-        There are no kubernetes clusters for the "
+        Either there are no 
+        kubernetes clusters
+         in the "
         <span
           class="c7"
         >
           im-a-cluster
         </span>
-        " cluster, or you don't have access to any.
+        " cluster, or your roles don't grant you access.
       </div>
     </div>
   </div>

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -1032,7 +1032,7 @@ exports[`loaded 1`] = `
 exports[`readonly empty state 1`] = `
 .c4 {
   box-sizing: border-box;
-  max-width: 600px;
+  max-width: 720px;
   margin-top: 24px;
   margin-left: auto;
   margin-right: auto;
@@ -1193,7 +1193,7 @@ exports[`readonly empty state 1`] = `
         >
           im-a-cluster
         </span>
-        " cluster.
+        " cluster, or you don't have access to any.
       </div>
     </div>
   </div>

--- a/packages/teleport/src/Nodes/Nodes.tsx
+++ b/packages/teleport/src/Nodes/Nodes.tsx
@@ -126,6 +126,6 @@ const emptyStateInfo: EmptyStateInfo = {
   videoLink: 'https://www.youtube.com/watch?v=tUXYtwP-Kvw',
   readOnly: {
     title: 'No Servers Found',
-    message: 'There are no servers for the "',
+    resource: 'servers',
   },
 };

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -1297,7 +1297,7 @@ exports[`loaded 1`] = `
 exports[`readonly empty state 1`] = `
 .c4 {
   box-sizing: border-box;
-  max-width: 600px;
+  max-width: 720px;
   margin-top: 24px;
   margin-left: auto;
   margin-right: auto;
@@ -1457,7 +1457,7 @@ exports[`readonly empty state 1`] = `
         >
           im-a-cluster
         </span>
-        " cluster.
+        " cluster, or you don't have access to any.
       </div>
     </div>
   </div>

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -1297,7 +1297,7 @@ exports[`loaded 1`] = `
 exports[`readonly empty state 1`] = `
 .c4 {
   box-sizing: border-box;
-  max-width: 720px;
+  max-width: 664px;
   margin-top: 24px;
   margin-left: auto;
   margin-right: auto;
@@ -1451,13 +1451,15 @@ exports[`readonly empty state 1`] = `
       <div
         class="c6"
       >
-        There are no servers for the "
+        Either there are no 
+        servers
+         in the "
         <span
           class="c7"
         >
           im-a-cluster
         </span>
-        " cluster, or you don't have access to any.
+        " cluster, or your roles don't grant you access.
       </div>
     </div>
   </div>

--- a/packages/teleport/src/components/Empty/Empty.test.tsx
+++ b/packages/teleport/src/components/Empty/Empty.test.tsx
@@ -12,7 +12,7 @@ test('empty state for enterprise or oss, with create perms', async () => {
 test('empty state for cant create or leaf cluster', async () => {
   const { findByText } = render(<Empty {...props} canCreate={false} />);
 
-  expect(await findByText(/There are no servers for the/i)).toBeVisible();
+  expect(await findByText(/Either there are no servers in the/i)).toBeVisible();
 });
 
 const props: Props = {
@@ -39,7 +39,7 @@ const props: Props = {
     videoLink: 'https://www.youtube.com/watch?v=tUXYtwP-Kvw',
     readOnly: {
       title: 'No Servers Found',
-      message: 'There are no servers for the "',
+      resource: 'servers',
     },
   },
 };

--- a/packages/teleport/src/components/Empty/Empty.tsx
+++ b/packages/teleport/src/components/Empty/Empty.tsx
@@ -40,7 +40,7 @@ export default function Empty(props: Props) {
         p={8}
         mt={4}
         mx="auto"
-        maxWidth="720px"
+        maxWidth="664px"
         textAlign="center"
         color="text.primary"
         bg="primary.light"
@@ -50,11 +50,11 @@ export default function Empty(props: Props) {
           {readOnly.title}
         </Text>
         <Text>
-          {readOnly.message}
+          Either there are no {readOnly.resource} in the "
           <Text as="span" bold>
             {clusterId}
           </Text>
-          " cluster, or you don't have access to any.
+          " cluster, or your roles don't grant you access.
         </Text>
       </Box>
     );
@@ -119,7 +119,7 @@ export type EmptyStateInfo = {
   videoLink: string;
   readOnly: {
     title: string;
-    message: string;
+    resource: string;
   };
 };
 

--- a/packages/teleport/src/components/Empty/Empty.tsx
+++ b/packages/teleport/src/components/Empty/Empty.tsx
@@ -40,7 +40,7 @@ export default function Empty(props: Props) {
         p={8}
         mt={4}
         mx="auto"
-        maxWidth="600px"
+        maxWidth="720px"
         textAlign="center"
         color="text.primary"
         bg="primary.light"
@@ -54,7 +54,7 @@ export default function Empty(props: Props) {
           <Text as="span" bold>
             {clusterId}
           </Text>
-          " cluster.
+          " cluster, or you don't have access to any.
         </Text>
       </Box>
     );


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/8721

Changes the text displayed when there are no resources in a list to be more accurate and take into account the fact that the reason why it is empty may be because the user doesn't have the permissions to view that list.

## Demo

### Nodes

![image](https://user-images.githubusercontent.com/56373201/143301072-e1596fa1-4604-48b9-abcb-28c920e3e8f7.png)

### Applications

![image](https://user-images.githubusercontent.com/56373201/143301108-f236cb69-571e-46ed-a3aa-35bb65c7ea91.png)


### Kubernetes Clusters

![image](https://user-images.githubusercontent.com/56373201/143301135-ac7583aa-1a9e-4cbe-8421-d5a7e5939b8a.png)


### Databases

![image](https://user-images.githubusercontent.com/56373201/143301027-6b3fd9ac-c2df-465b-8533-6d73bb71a547.png)


