### PR TITLE
Add a new "accept" endpoint that directs to signup

### DIFF
--- a/packages/teleport/src/Accept/Accept.story.tsx
+++ b/packages/teleport/src/Accept/Accept.story.tsx
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { State } from './useAccept';
+import { Accept as Component, Props } from './Accept';
+
+export default {
+  title: 'Teleport/Accept',
+  component: Component,
+};
+
+export const Accept = () => <Component {...props} />;
+
+const props: State & Props = {
+  onSubmit: () => null,
+};

--- a/packages/teleport/src/Accept/Accept.test.tsx
+++ b/packages/teleport/src/Accept/Accept.test.tsx
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router';
+import { screen, fireEvent, act, render } from 'design/utils/testing';
+import history from 'teleport/services/history';
+import { Logger } from 'shared/libs/logger';
+import cfg from 'teleport/config';
+import Accept from './Accept';
+
+describe('teleport/components/Accept', () => {
+  beforeEach(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(history, 'push').mockImplementation();
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('accept button redirects', async () => {
+    await act(async () => renderAccept());
+    fireEvent.click(screen.getByRole('button'));
+    expect(history.push).toHaveBeenCalledWith('/web/invite/7992');
+  });
+});
+
+function renderAccept(url = `/web/accept/7992`) {
+  render(
+    <MemoryRouter initialEntries={[url]}>
+      <Route path={cfg.routes.userAccept}>
+        <Accept />
+      </Route>
+    </MemoryRouter>
+  );
+}

--- a/packages/teleport/src/Accept/Accept.tsx
+++ b/packages/teleport/src/Accept/Accept.tsx
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { useParams } from 'react-router';
+import AcceptForm from 'teleport/components/FormAccept';
+import LogoHero from 'teleport/components/LogoHero';
+import useAccept, { State } from './useAccept';
+
+export default function Container() {
+  const { tokenId } = useParams<{ tokenId: string }>();
+  const state = useAccept(tokenId);
+  return <Accept {...state} />;
+}
+
+export function Accept(props: State & Props) {
+  const { onSubmit } = props;
+
+  return (
+    <>
+      <LogoHero />
+      <AcceptForm onSubmit={onSubmit} />
+    </>
+  );
+}
+
+export type Props = {};

--- a/packages/teleport/src/Accept/index.ts
+++ b/packages/teleport/src/Accept/index.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Accept from './Accept';
+export default Accept;

--- a/packages/teleport/src/Accept/useAccept.ts
+++ b/packages/teleport/src/Accept/useAccept.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import cfg from 'teleport/config';
+import history from 'teleport/services/history';
+
+export default function useAccept(tokenId: string) {
+  function onSubmit() {
+    const route = cfg.getUserInviteTokenPath(tokenId);
+    history.push(route);
+  }
+
+  return {
+    onSubmit,
+  };
+}
+
+export type State = ReturnType<typeof useAccept>;

--- a/packages/teleport/src/Teleport.tsx
+++ b/packages/teleport/src/Teleport.tsx
@@ -32,6 +32,7 @@ import Player from './Player';
 import TeleportContextProvider from './teleportContextProvider';
 import TeleportContext from './teleportContext';
 import cfg from './config';
+import Accept from './Accept';
 
 const Teleport: React.FC<Props> = props => {
   const { ctx, history } = props;
@@ -97,6 +98,12 @@ export function renderPublicRoutes(children = []) {
       title="Password Reset"
       path={cfg.routes.userReset}
       component={ResetPassword}
+    />,
+    <Route
+      key={7}
+      title="Accept"
+      path={cfg.routes.userAccept}
+      component={Accept}
     />,
   ];
 }

--- a/packages/teleport/src/components/FormAccept/FormAccept.story.test.tsx
+++ b/packages/teleport/src/components/FormAccept/FormAccept.story.test.tsx
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { render } from 'design/utils/testing';
+import * as story from './FormAccept.story';
+
+describe('teleport/components/Accept.story', () => {
+  test('story.FormAccept', () => {
+    const { container } = render(<story.Default />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/packages/teleport/src/components/FormAccept/FormAccept.story.tsx
+++ b/packages/teleport/src/components/FormAccept/FormAccept.story.tsx
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import FormAccept, { Props } from './FormAccept';
+
+export const Default = () => <FormAccept {...props} />;
+
+export default {
+  title: 'Teleport/FormAccept',
+  component: FormAccept,
+};
+
+const props: Props = {
+  onSubmit() {},
+};

--- a/packages/teleport/src/components/FormAccept/FormAccept.tsx
+++ b/packages/teleport/src/components/FormAccept/FormAccept.tsx
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { Text, Card, ButtonPrimary, Flex, Box } from 'design';
+
+export default function FormAccept(props: Props) {
+  const {
+    title = 'Get Started with Teleport',
+    submitBtnText = 'Create Account',
+    onSubmit,
+  } = props;
+
+  const boxWidth = '600px';
+
+  return (
+    <Card as="form" bg="primary.light" my={6} mx="auto" width={boxWidth}>
+      <Flex>
+        <Box flex="3" p="6">
+          <Text typography="h2" mb={3} textAlign="center" color="light">
+            {title}
+          </Text>
+          <Text typography="h4" breakAll mb={3} textAlign="center">
+            Please click the link below to create an account
+          </Text>
+          <ButtonPrimary width="100%" mt={3} size="large" onClick={onSubmit}>
+            {submitBtnText}
+          </ButtonPrimary>
+        </Box>
+      </Flex>
+    </Card>
+  );
+}
+
+export type Props = {
+  title?: string;
+  submitBtnText?: string;
+  onSubmit(): void;
+};

--- a/packages/teleport/src/components/FormAccept/__snapshots__/FormAccept.story.test.tsx.snap
+++ b/packages/teleport/src/components/FormAccept/__snapshots__/FormAccept.story.test.tsx.snap
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`teleport/components/Accept.story story.FormAccept 1`] = `
+.c2 {
+  box-sizing: border-box;
+  padding: 40px;
+  flex: 3;
+}
+
+.c5 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c5:active {
+  opacity: 0.56;
+}
+
+.c5:hover,
+.c5:focus {
+  background: #651FFF;
+}
+
+.c5:active {
+  background: #354AA4;
+}
+
+.c5:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c0 {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  width: 600px;
+  background-color: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-radius: 8px;
+}
+
+.c3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 28px;
+  line-height: 32px;
+  margin: 0px;
+  margin-bottom: 16px;
+  color: #FFFFFF;
+  text-align: center;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 32px;
+  word-break: break-all;
+  margin: 0px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.c1 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+<form
+  class="c0"
+  width="600px"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+        color="light"
+      >
+        Get Started with Teleport
+      </div>
+      <div
+        class="c4"
+      >
+        Please click the link below to create an account
+      </div>
+      <button
+        class="c5"
+        kind="primary"
+        width="100%"
+      >
+        Create Account
+      </button>
+    </div>
+  </div>
+</form>
+`;

--- a/packages/teleport/src/components/FormAccept/index.ts
+++ b/packages/teleport/src/components/FormAccept/index.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import FormAccept from './FormAccept';
+export default FormAccept;

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -74,6 +74,7 @@ const cfg = {
     loginError: '/web/msg/error/login',
     loginErrorCallback: '/web/msg/error/login/callback',
     userInvite: '/web/invite/:tokenId',
+    userAccept: '/web/accept/:tokenId',
     userReset: '/web/reset/:tokenId',
     kubernetes: '/web/cluster/:clusterId/kubernetes',
     // whitelist sso handlers
@@ -283,6 +284,10 @@ const cfg = {
   getUserResetTokenRoute(tokenId = '', invite = true) {
     const route = invite ? cfg.routes.userInvite : cfg.routes.userReset;
     return cfg.baseUrl + generatePath(route, { tokenId });
+  },
+
+  getUserInviteTokenPath(tokenId = '') {
+    return generatePath(cfg.routes.userInvite, { tokenId });
   },
 
   getKubernetesRoute(clusterId: string) {


### PR DESCRIPTION
This change introduces a new endpoint (/web/accept/:tokenId) that simply
prompts the user to create an account by clicking a button, when they do
so they will be redirected to /web/invite/:tokenId (which is what is
used currently)

This change is aimed at preventing web crawlers/proxies and malware link
scanners in email clients that are hitting the /invite/ endpoint
directly shortly after the user clicks the link, which invalidates the
URL.

Please see https://github.com/gravitational/cloud/issues/1079 for
further investigation and justification.

It is proposed that this link will be used for any outbound email
communication, or other situations where it's plausible that clients may
interfere with the invite link. It will not replace the invite link
entirely.