### PR TITLE
Add prompt prior to form for Invite and Reset

### DIFF
--- a/packages/build/index.ejs
+++ b/packages/build/index.ejs
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="grv_csrf_token" content="{{ .XCSRF }}" />
     <meta name="grv_bearer_token" content="{{ .Session }}" />
+    <meta name="robots" content="noindex" />
     <title><%= htmlWebpackPlugin.options.title %></title>
     <script src="/web/config.js"></script>
   </head>

--- a/packages/teleport/src/Invite/CardWelcome.tsx
+++ b/packages/teleport/src/Invite/CardWelcome.tsx
@@ -23,7 +23,7 @@ export default function CardWelcome({ tokenId, inviteMode = true }: Props) {
   const title = inviteMode ? 'Welcome to Teleport' : 'Reset Password';
   const description = inviteMode
     ? 'Please click the button below to create an account'
-    : 'Please click the button below to recover your account';
+    : 'Please click the button below to begin recovery of your account';
   const buttonText = inviteMode ? 'Get started' : 'Continue';
 
   const nextStepPath = inviteMode
@@ -36,7 +36,7 @@ export default function CardWelcome({ tokenId, inviteMode = true }: Props) {
         <Text typography="h2" mb={3} textAlign="center" color="light">
           {title}
         </Text>
-        <Text typography="h4" mb={3} textAlign="center">
+        <Text typography="h5" mb={3} textAlign="center">
           {description}
         </Text>
         <ButtonPrimary

--- a/packages/teleport/src/Invite/CardWelcome.tsx
+++ b/packages/teleport/src/Invite/CardWelcome.tsx
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import { Card, Box, Text, ButtonPrimary } from 'design';
+import cfg from 'teleport/config';
+import history from 'teleport/services/history';
+
+export default function CardWelcome({ tokenId, inviteMode = true }: Props) {
+  const title = inviteMode ? 'Welcome to Teleport' : 'Reset Password';
+  const description = inviteMode
+    ? 'Please click the button below to create an account'
+    : 'Please click the button below to recover your account';
+  const buttonText = inviteMode ? 'Get started' : 'Continue';
+
+  const nextStepPath = inviteMode
+    ? cfg.getUserInviteTokenContinueRoute(tokenId)
+    : cfg.getUserResetTokenContinueRoute(tokenId);
+
+  return (
+    <Card bg="primary.light" my={6} mx="auto" width="464px">
+      <Box p={6}>
+        <Text typography="h2" mb={3} textAlign="center" color="light">
+          {title}
+        </Text>
+        <Text typography="h4" mb={3} textAlign="center">
+          {description}
+        </Text>
+        <ButtonPrimary
+          width="100%"
+          mt={3}
+          size="large"
+          onClick={() => history.push(nextStepPath)}
+        >
+          {buttonText}
+        </ButtonPrimary>
+      </Box>
+    </Card>
+  );
+}
+
+type Props = {
+  tokenId: string;
+  inviteMode?: boolean;
+};

--- a/packages/teleport/src/Invite/Invite.story.tsx
+++ b/packages/teleport/src/Invite/Invite.story.tsx
@@ -15,15 +15,21 @@ limitations under the License.
 */
 
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { State } from './useInvite';
 import { Invite as Component, Props } from './Invite';
+import CardWelcome from './CardWelcome';
 
 export default {
   title: 'Teleport/Invite',
   component: Component,
 };
 
-export const Invite = () => <Component {...props} />;
+export const Invite = () => (
+  <Wrapper>
+    <Component {...props} />
+  </Wrapper>
+);
 
 export const Expired = () => (
   <Component
@@ -33,19 +39,51 @@ export const Expired = () => (
 );
 
 export const ResetPasswordScreen = () => (
-  <Component {...props} passwordResetMode={true} />
+  <Wrapper url="/web/reset/1234/continue">
+    <Component {...props} passwordResetMode={true} />
+  </Wrapper>
 );
 
-export const AuthMfaOn = () => <Component {...props} auth2faType="on" />;
+export const AuthMfaOn = () => (
+  <Wrapper>
+    <Component {...props} auth2faType="on" />
+  </Wrapper>
+);
 
 export const AuthMfaOnWithU2f = () => (
-  <Component {...props} auth2faType="on" preferredMfaType="u2f" />
+  <Wrapper>
+    <Component {...props} auth2faType="on" preferredMfaType="u2f" />
+  </Wrapper>
 );
-AuthMfaOnWithU2f.storyName = 'Auth Mfa Optional with U2f';
+AuthMfaOnWithU2f.storyName = 'Auth Mfa On with U2f';
 
 export const AuthMfaOptional = () => (
-  <Component {...props} auth2faType="optional" />
+  <Wrapper>
+    <Component {...props} auth2faType="optional" />
+  </Wrapper>
 );
+
+export const WelcomeCardInvite = () => (
+  <Wrapper url="/web/invite/1234">
+    <CardWelcome tokenId="1234" />
+  </Wrapper>
+);
+
+export const WelcomeCardReset = () => (
+  <Wrapper url="/web/reset/1234">
+    <CardWelcome tokenId="1234" inviteMode={false} />
+  </Wrapper>
+);
+
+function Wrapper({
+  children,
+  url = '/web/invite/1234/continue',
+}: {
+  children: JSX.Element;
+  url?: string;
+}) {
+  return <MemoryRouter initialEntries={[url]}>{children}</MemoryRouter>;
+}
 
 const props: State & Props = {
   auth2faType: 'off',

--- a/packages/teleport/src/Invite/Invite.test.tsx
+++ b/packages/teleport/src/Invite/Invite.test.tsx
@@ -37,6 +37,18 @@ describe('teleport/components/Invite', () => {
     jest.clearAllMocks();
   });
 
+  it('should show "get started" prompt before showing form', async () => {
+    await act(async () =>
+      render(
+        <MemoryRouter initialEntries={['/web/invite/5182']}>
+          <Invite />
+        </MemoryRouter>
+      )
+    );
+
+    expect(screen.getByText(/get started/i)).toBeInTheDocument();
+  });
+
   it('reset password', async () => {
     jest.spyOn(cfg, 'getAuth2faType').mockImplementation(() => 'off');
     jest
@@ -152,21 +164,29 @@ describe('teleport/components/Invite', () => {
     expect(screen.getByText('server_error')).toBeDefined();
   });
 
-  it('auth type "on" should render form with hardware key as first option in dropdown', async () => {
-    const { container } = render(<AuthMfaOn />);
+  it('auth type "on" should render form with hardware key as first option in dropdown', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/web/invite/5182/continue']}>
+        <AuthMfaOn />
+      </MemoryRouter>
+    );
     expect(container).toMatchSnapshot();
   });
 
-  it('auth type "optional" should render form with hardware key as first option in dropdown', async () => {
-    const { container } = render(<AuthMfaOptional />);
+  it('auth type "optional" should render form with hardware key as first option in dropdown', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/web/invite/5182/continue']}>
+        <AuthMfaOptional />
+      </MemoryRouter>
+    );
     expect(container).toMatchSnapshot();
   });
 });
 
-function renderInvite(url = `/web/invite/5182`) {
+function renderInvite(url = `/web/invite/5182/continue`) {
   render(
     <MemoryRouter initialEntries={[url]}>
-      <Route path={cfg.routes.userInvite}>
+      <Route path={cfg.routes.userInviteContinue}>
         <Invite />
       </Route>
     </MemoryRouter>

--- a/packages/teleport/src/Invite/Invite.tsx
+++ b/packages/teleport/src/Invite/Invite.tsx
@@ -16,8 +16,11 @@ limitations under the License.
 
 import React from 'react';
 import { useParams } from 'react-router';
+import cfg from 'teleport/config';
+import { Route, Switch } from 'teleport/components/Router';
 import InviteForm, { Expired } from 'teleport/components/FormInvite';
 import LogoHero from 'teleport/components/LogoHero';
+import CardWelcome from './CardWelcome';
 import useInvite, { State } from './useInvite';
 
 export default function Container({ passwordResetMode = false }) {
@@ -53,8 +56,10 @@ export function Invite(props: State & Props) {
     return null;
   }
 
-  const { user, qrCode } = passwordToken;
+  const { user, qrCode, tokenId } = passwordToken;
+
   const title = passwordResetMode ? 'Reset Password' : 'Welcome to Teleport';
+
   const submitBtnText = passwordResetMode
     ? 'Change Password'
     : 'Create Account';
@@ -62,19 +67,31 @@ export function Invite(props: State & Props) {
   return (
     <>
       <LogoHero />
-      <InviteForm
-        submitBtnText={submitBtnText}
-        title={title}
-        user={user}
-        qr={qrCode}
-        auth2faType={auth2faType}
-        preferredMfaType={preferredMfaType}
-        attempt={submitAttempt}
-        clearSubmitAttempt={clearSubmitAttempt}
-        onSubmitWithU2f={onSubmitWithU2f}
-        onSubmitWithWebauthn={onSubmitWithWebauthn}
-        onSubmit={onSubmit}
-      />
+      <Switch>
+        <Route
+          path={[cfg.routes.userInviteContinue, cfg.routes.userResetContinue]}
+        >
+          <InviteForm
+            submitBtnText={submitBtnText}
+            title={title}
+            user={user}
+            qr={qrCode}
+            auth2faType={auth2faType}
+            preferredMfaType={preferredMfaType}
+            attempt={submitAttempt}
+            clearSubmitAttempt={clearSubmitAttempt}
+            onSubmitWithU2f={onSubmitWithU2f}
+            onSubmitWithWebauthn={onSubmitWithWebauthn}
+            onSubmit={onSubmit}
+          />
+        </Route>
+        <Route path={cfg.routes.userInvite}>
+          <CardWelcome tokenId={tokenId} />
+        </Route>
+        <Route path={cfg.routes.userReset}>
+          <CardWelcome tokenId={tokenId} inviteMode={false} />
+        </Route>
+      </Switch>
     </>
   );
 }

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -74,7 +74,9 @@ const cfg = {
     loginError: '/web/msg/error/login',
     loginErrorCallback: '/web/msg/error/login/callback',
     userInvite: '/web/invite/:tokenId',
+    userInviteContinue: '/web/invite/:tokenId/continue',
     userReset: '/web/reset/:tokenId',
+    userResetContinue: '/web/reset/:tokenId/continue',
     kubernetes: '/web/cluster/:clusterId/kubernetes',
     // whitelist sso handlers
     oidcHandler: '/v1/webapi/oidc/*',
@@ -283,6 +285,18 @@ const cfg = {
   getUserResetTokenRoute(tokenId = '', invite = true) {
     const route = invite ? cfg.routes.userInvite : cfg.routes.userReset;
     return cfg.baseUrl + generatePath(route, { tokenId });
+  },
+
+  getUserResetTokenContinueRoute(tokenId = '') {
+    return generatePath(cfg.routes.userResetContinue, { tokenId });
+  },
+
+  getUserInviteTokenRoute(tokenId = '') {
+    return generatePath(cfg.routes.userInvite, { tokenId });
+  },
+
+  getUserInviteTokenContinueRoute(tokenId = '') {
+    return generatePath(cfg.routes.userInviteContinue, { tokenId });
   },
 
   getKubernetesRoute(clusterId: string) {


### PR DESCRIPTION
## Purpose

Alternate implementation of https://github.com/gravitational/webapps/pull/475

Adds a new `/continue` route for the invite/reset form that the user gets to by first clicking the button on the initial prompt. This is to prevent crawlers (eg. in gmail) from triggering the OTP QR code generation before the user.

## Demo

### Invite
![image](https://user-images.githubusercontent.com/56373201/143951679-5badcb7a-b727-4c5b-a055-fec482130d52.png)

### Reset
![image](https://user-images.githubusercontent.com/56373201/143952108-515578fa-86c2-4496-b9eb-3db001ab31ed.png)

