### PR TITLE
desktop access backports

### DIFF
--- a/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -112,7 +112,7 @@ export function DesktopSession(props: State) {
       <TdpClientCanvas
         style={{
           display: attempt.status === 'success' ? 'flex' : 'none',
-          flex: 1,
+          flex: 1, // ensures the canvas fills available screen space
         }}
         tdpClient={tdpClient}
         connectionAttempt={connectionAttempt}

--- a/packages/teleport/src/DesktopSession/TdpClientCanvas/TdpClientCanvas.tsx
+++ b/packages/teleport/src/DesktopSession/TdpClientCanvas/TdpClientCanvas.tsx
@@ -102,6 +102,7 @@ export default function TdpClientCanvas(props: Props) {
       onInit(tdpClient, canvas);
     });
 
+    // TODO(ibm): do we need the connect event at all now that we send initial params in the wss string?
     tdpClient.on('connect', () => {
       onConnect();
     });

--- a/packages/teleport/src/DesktopSession/TdpClientCanvas/useTdpClientCanvas.tsx
+++ b/packages/teleport/src/DesktopSession/TdpClientCanvas/useTdpClientCanvas.tsx
@@ -32,33 +32,30 @@ export default function useTdpClientCanvas(props: Props) {
 
   // Build a client based on url parameters.
   const tdpClient = useMemo(() => {
+    const { width, height } = getDisplaySize();
+
     const addr = cfg.api.desktopWsAddr
       .replace(':fqdm', getHostName())
       .replace(':clusterId', clusterId)
       .replace(':desktopName', desktopName)
-      .replace(':token', getAccessToken());
+      .replace(':token', getAccessToken())
+      .replace(':username', username)
+      .replace(':width', width.toString())
+      .replace(':height', height.toString());
 
     return new TdpClient(addr, username);
   }, [clusterId, username, desktopName]);
 
-  const syncCanvasSizeToClientSize = (canvas: HTMLCanvasElement) => {
-    // Calculate the size of the canvas to be displayed.
-    // Setting flex to "1" ensures the canvas will fill out the area available to it,
-    // which we calculate based on the window dimensions and TopBarHeight below.
-    const width = window.innerWidth;
-    const height = window.innerHeight - TopBarHeight;
+  const syncCanvasSizeToDisplaySize = (canvas: HTMLCanvasElement) => {
+    const { width, height } = getDisplaySize();
 
-    // If it's resolution does not match change it
-    if (canvas.width !== width || canvas.height !== height) {
-      canvas.width = width;
-      canvas.height = height;
-    }
+    canvas.width = width;
+    canvas.height = height;
   };
 
   const onInit = (cli: TdpClient, canvas: HTMLCanvasElement) => {
     setConnectionAttempt({ status: 'processing' });
-    syncCanvasSizeToClientSize(canvas);
-    cli.connect(canvas.width, canvas.height);
+    syncCanvasSizeToDisplaySize(canvas);
   };
 
   const onConnect = () => {
@@ -138,6 +135,16 @@ export default function useTdpClientCanvas(props: Props) {
     onMouseDown,
     onMouseUp,
     onMouseWheelScroll,
+  };
+}
+
+// Calculates the size (in pixels) of the display.
+// Since we want to maximize the display size for the user, this is simply
+// the full width of the screen and the full height sans top bar.
+function getDisplaySize() {
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight - TopBarHeight,
   };
 }
 

--- a/packages/teleport/src/DesktopSession/TdpClientCanvas/useTdpClientCanvas.tsx
+++ b/packages/teleport/src/DesktopSession/TdpClientCanvas/useTdpClientCanvas.tsx
@@ -16,15 +16,14 @@ limitations under the License.
 
 import { useMemo } from 'react';
 import TdpClient, { ImageData } from 'teleport/lib/tdp/client';
-import { useParams } from 'react-router';
 import { TopBarHeight } from './TopBar';
-import cfg, { UrlDesktopParams } from 'teleport/config';
+import cfg from 'teleport/config';
 import { getAccessToken, getHostName } from 'teleport/services/api';
 import { ButtonState, ScrollAxis } from 'teleport/lib/tdp/codec';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
-export default function useTdpClientCanvas() {
-  const { clusterId, username, desktopId } = useParams<UrlDesktopParams>();
+export default function useTdpClientCanvas(props: Props) {
+  const { username, desktopName, clusterId } = props;
   // status === '' means disconnected
   const {
     attempt: connectionAttempt,
@@ -36,11 +35,11 @@ export default function useTdpClientCanvas() {
     const addr = cfg.api.desktopWsAddr
       .replace(':fqdm', getHostName())
       .replace(':clusterId', clusterId)
-      .replace(':desktopId', desktopId)
+      .replace(':desktopName', desktopName)
       .replace(':token', getAccessToken());
 
     return new TdpClient(addr, username);
-  }, [clusterId, username, desktopId]);
+  }, [clusterId, username, desktopName]);
 
   const syncCanvasSizeToClientSize = (canvas: HTMLCanvasElement) => {
     // Calculate the size of the canvas to be displayed.
@@ -141,3 +140,9 @@ export default function useTdpClientCanvas() {
     onMouseWheelScroll,
   };
 }
+
+type Props = {
+  username: string;
+  desktopName: string;
+  clusterId: string;
+};

--- a/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
+++ b/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
@@ -67,10 +67,10 @@ function DesktopList(props: Props) {
   function onDesktopSelect(
     e: React.MouseEvent,
     username: string,
-    desktopId: string
+    desktopName: string
   ) {
     e.preventDefault();
-    onLoginSelect(username, desktopId);
+    onLoginSelect(username, desktopName);
   }
 
   const data = sortAndFilter(searchValue);
@@ -108,19 +108,10 @@ function DesktopList(props: Props) {
   );
 }
 
-// Strips default rdp port from an ip address since this unimportant to display
-export const stripRdpPort = (addr: string): string => {
-  const splitAddr = addr.split(':');
-  if (splitAddr.length > 1 && splitAddr[1] === '3389') {
-    return splitAddr[0];
-  }
-  return addr;
-};
-
 const AddressCell = props => {
   // If default RDP port (3389) is present, don't show it
   const { rowIndex, data, columnKey, ...rest } = props;
-  const addr = stripRdpPort(data[rowIndex][columnKey]);
+  const addr = data[rowIndex][columnKey];
 
   return <Cell {...rest}>{addr}</Cell>;
 };
@@ -130,16 +121,16 @@ const LoginCell: React.FC<Required<{
   onSelect?: (
     e: React.SyntheticEvent,
     username: string,
-    desktopId: string
+    desktopName: string
   ) => void;
   onOpen: (serverUuid: string) => LoginItem[];
   [key: string]: any;
 }>> = props => {
   const { rowIndex, data, onOpen, onSelect } = props;
   const { name } = data[rowIndex] as Desktop;
-  const desktopId = name;
+  const desktopName = name;
   function handleOnOpen() {
-    return onOpen(desktopId);
+    return onOpen(desktopName);
   }
 
   function handleOnSelect(e: React.SyntheticEvent, login: string) {
@@ -147,7 +138,7 @@ const LoginCell: React.FC<Required<{
       return [];
     }
 
-    return onSelect(e, login, desktopId);
+    return onSelect(e, login, desktopName);
   }
 
   return (
@@ -198,8 +189,8 @@ type Props = {
   username: string;
   clusterId: string;
   searchValue: string;
-  onLoginMenuOpen(desktopId: string): { login: string; url: string }[];
-  onLoginSelect(username: string, desktopId: string): void;
+  onLoginMenuOpen(desktopName: string): { login: string; url: string }[];
+  onLoginSelect(username: string, desktopName: string): void;
 };
 
 export default DesktopList;

--- a/packages/teleport/src/Desktops/DesktopList/index.ts
+++ b/packages/teleport/src/Desktops/DesktopList/index.ts
@@ -14,6 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import DesktopList, { stripRdpPort } from './DesktopList';
-export { stripRdpPort };
+import DesktopList from './DesktopList';
 export default DesktopList;

--- a/packages/teleport/src/Desktops/Desktops.story.tsx
+++ b/packages/teleport/src/Desktops/Desktops.story.tsx
@@ -45,6 +45,6 @@ const props: State = {
   clusterId: 'im-a-cluster',
   searchValue: '',
   setSearchValue: () => {},
-  getWindowsLoginOptions: (desktopId: string) => [{ login: '', url: '' }],
-  openRemoteDesktopTab: (username: string, desktopId: string) => {},
+  getWindowsLoginOptions: (desktopName: string) => [{ login: '', url: '' }],
+  openRemoteDesktopTab: (username: string, desktopName: string) => {},
 };

--- a/packages/teleport/src/Desktops/useDesktops.ts
+++ b/packages/teleport/src/Desktops/useDesktops.ts
@@ -32,17 +32,17 @@ export default function useDesktops(ctx: Ctx) {
 
   const [desktops, setDesktops] = useState<Desktop[]>([]);
 
-  const getWindowsLoginOptions = (desktopId: string) =>
-    makeOptions(clusterId, desktopId, windowsLogins);
+  const getWindowsLoginOptions = (desktopName: string) =>
+    makeOptions(clusterId, desktopName, windowsLogins);
 
   useEffect(() => {
     run(() => ctx.desktopService.fetchDesktops(clusterId).then(setDesktops));
   }, [clusterId]);
 
-  const openRemoteDesktopTab = (username: string, desktopId: string) => {
+  const openRemoteDesktopTab = (username: string, desktopName: string) => {
     const url = cfg.getDesktopRoute({
       clusterId,
-      desktopId,
+      desktopName,
       username,
     });
 
@@ -63,13 +63,13 @@ export default function useDesktops(ctx: Ctx) {
 
 function makeOptions(
   clusterId: string,
-  desktopId = '',
+  desktopName = '',
   logins = [] as string[]
 ) {
   return logins.map(username => {
     const url = cfg.getDesktopRoute({
       clusterId,
-      desktopId,
+      desktopName,
       username,
     });
 

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -59,7 +59,7 @@ const cfg = {
     recordings: '/web/cluster/:clusterId/recordings',
     databases: '/web/cluster/:clusterId/databases',
     desktops: '/web/cluster/:clusterId/desktops',
-    desktop: '/web/cluster/:clusterId/desktops/:desktopId/:username',
+    desktop: '/web/cluster/:clusterId/desktops/:desktopName/:username',
     users: '/web/users',
     console: '/web/cluster/:clusterId/console',
     consoleNodes: '/web/cluster/:clusterId/console/nodes',
@@ -102,8 +102,9 @@ const cfg = {
     nodesPath: '/v1/webapi/sites/:clusterId/nodes',
     databasesPath: `/v1/webapi/sites/:clusterId/databases`,
     desktopsPath: `/v1/webapi/sites/:clusterId/desktops`,
+    desktopPath: `/v1/webapi/sites/:clusterId/desktops/:desktopName`,
     desktopWsAddr:
-      'wss://:fqdm/v1/webapi/sites/:clusterId/desktop/:desktopId/connect?access_token=:token',
+      'wss://:fqdm/v1/webapi/sites/:clusterId/desktops/:desktopName/connect?access_token=:token',
     siteSessionPath: '/v1/webapi/sites/:siteId/sessions',
     ttyWsAddr:
       'wss://:fqdm/v1/webapi/sites/:clusterId/connect?access_token=:token&params=:params',
@@ -236,10 +237,10 @@ const cfg = {
     });
   },
 
-  getDesktopRoute({ clusterId, username, desktopId }) {
+  getDesktopRoute({ clusterId, username, desktopName }) {
     return generatePath(cfg.routes.desktop, {
       clusterId,
-      desktopId,
+      desktopName,
       username,
     });
   },
@@ -324,6 +325,10 @@ const cfg = {
 
   getDesktopsUrl(clusterId: string) {
     return generatePath(cfg.api.desktopsPath, { clusterId });
+  },
+
+  getDesktopUrl(clusterId: string, desktopName: string) {
+    return generatePath(cfg.api.desktopPath, { clusterId, desktopName });
   },
 
   getApplicationsUrl(clusterId: string) {
@@ -430,10 +435,10 @@ export interface UrlPlayerParams {
   sid: string;
 }
 
-// /web/cluster/:clusterId/desktops/:desktopId/:username
+// /web/cluster/:clusterId/desktops/:desktopName/:username
 export interface UrlDesktopParams {
   username?: string;
-  desktopId?: string;
+  desktopName?: string;
   clusterId: string;
 }
 

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -104,7 +104,7 @@ const cfg = {
     desktopsPath: `/v1/webapi/sites/:clusterId/desktops`,
     desktopPath: `/v1/webapi/sites/:clusterId/desktops/:desktopName`,
     desktopWsAddr:
-      'wss://:fqdm/v1/webapi/sites/:clusterId/desktops/:desktopName/connect?access_token=:token',
+      'wss://:fqdm/v1/webapi/sites/:clusterId/desktops/:desktopName/connect?access_token=:token&username=:username&width=:width&height=:height',
     siteSessionPath: '/v1/webapi/sites/:siteId/sessions',
     ttyWsAddr:
       'wss://:fqdm/v1/webapi/sites/:clusterId/connect?access_token=:token&params=:params',

--- a/packages/teleport/src/lib/tdp/client.ts
+++ b/packages/teleport/src/lib/tdp/client.ts
@@ -73,12 +73,6 @@ export default class Client extends EventEmitter {
     };
   }
 
-  // After websocket is connected, caller can initialize the tdp connection by calling connect.
-  connect(initialWidth: number, initialHeight: number) {
-    this.sendUsername(this.username);
-    this.resize(initialWidth, initialHeight);
-  }
-
   processMessage(buffer: ArrayBuffer) {
     const messageType = this.codec.decodeMessageType(buffer);
     try {

--- a/packages/teleport/src/services/desktops/desktops.ts
+++ b/packages/teleport/src/services/desktops/desktops.ts
@@ -20,10 +20,16 @@ import cfg from 'teleport/config';
 import makeDesktop from './makeDesktop';
 
 class DesktopService {
-  fetchDesktops(clusterId?: string) {
+  fetchDesktops(clusterId: string) {
     return api
       .get(cfg.getDesktopsUrl(clusterId))
       .then(json => map(json, makeDesktop));
+  }
+
+  fetchDesktop(clusterId: string, desktopPath: string) {
+    return api
+      .get(cfg.getDesktopUrl(clusterId, desktopPath))
+      .then(json => makeDesktop(json));
   }
 }
 


### PR DESCRIPTION
Backports https://github.com/gravitational/webapps/pull/448 and https://github.com/gravitational/webapps/pull/480, which are needed to update webassets to keep the client compatible with an impending Teleport proxy patch release that will include https://github.com/gravitational/teleport/pull/9201