### PR TITLE
GCB build support

### DIFF
--- a/.cloudbuild/ci/test.yaml
+++ b/.cloudbuild/ci/test.yaml
@@ -1,0 +1,7 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - '--build-arg'
+      - NPM_SCRIPT=test
+      - .


### PR DESCRIPTION
Uses the existing webapps docker-based test by piggy-backing on GCB's ability to build docker images. The tests being run are a by product of the image being built, and the image is then discarded.