### PR TITLE
Add Separate Recordings List Service

### DIFF
--- a/packages/teleport/src/Audit/Audit.tsx
+++ b/packages/teleport/src/Audit/Audit.tsx
@@ -27,7 +27,7 @@ import { Flex, Indicator, Box } from 'design';
 import InputSearch from 'teleport/components/InputSearch';
 import useTeleport from 'teleport/useTeleport';
 import useStickyClusterId from 'teleport/useStickyClusterId';
-import useAuditEvents from 'teleport/useAuditEvents';
+import useAuditEvents, { State } from './useAuditEvents';
 
 export default function Container() {
   const teleCtx = useTeleport();
@@ -36,7 +36,7 @@ export default function Container() {
   return <Audit {...state} />;
 }
 
-export function Audit(props: ReturnType<typeof useAuditEvents>) {
+export function Audit(props: State) {
   const {
     attempt,
     range,

--- a/packages/teleport/src/Audit/EventList/EventList.tsx
+++ b/packages/teleport/src/Audit/EventList/EventList.tsx
@@ -19,12 +19,12 @@ import { sortBy } from 'lodash';
 import isMatch from 'design/utils/match';
 import * as Table from 'design/DataTable';
 import PagedTable from 'design/DataTable/Paged';
+import { displayDateTime } from 'shared/services/loc';
 import { Event } from 'teleport/services/audit';
-import { State } from 'teleport/useAuditEvents';
+import { State } from '../useAuditEvents';
 import { ActionCell, TimeCell, DescCell } from './EventListCells';
 import TypeCell from './EventTypeCell';
 import EventDialog from '../EventDialog';
-import { displayDateTime } from 'shared/services/loc';
 
 export default function EventList(props: Props) {
   const {

--- a/packages/teleport/src/Audit/useAuditEvents.ts
+++ b/packages/teleport/src/Audit/useAuditEvents.ts
@@ -14,10 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import Ctx from 'teleport/teleportContext';
+import {
+  getRangeOptions,
+  EventRange,
+} from 'teleport/components/EventRangePicker';
 import { Event, EventCode, formatters } from 'teleport/services/audit';
 
 export default function useAuditEvents(
@@ -99,47 +102,10 @@ export default function useAuditEvents(
   };
 }
 
-function getRangeOptions(): EventRange[] {
-  return [
-    {
-      name: 'Today',
-      from: moment(new Date())
-        .startOf('day')
-        .toDate(),
-      to: moment(new Date())
-        .endOf('day')
-        .toDate(),
-    },
-    {
-      name: '7 days',
-      from: moment()
-        .subtract(6, 'day')
-        .startOf('day')
-        .toDate(),
-      to: moment(new Date())
-        .endOf('day')
-        .toDate(),
-    },
-    {
-      name: 'Custom Range...',
-      isCustom: true,
-      from: new Date(),
-      to: new Date(),
-    },
-  ];
-}
-
 type EventResult = {
   events: Event[];
   fetchStatus: 'loading' | 'disabled' | '';
   fetchStartKey: string;
-};
-
-export type EventRange = {
-  from: Date;
-  to: Date;
-  isCustom?: boolean;
-  name?: string;
 };
 
 export type State = ReturnType<typeof useAuditEvents>;

--- a/packages/teleport/src/Recordings/Recordings.story.tsx
+++ b/packages/teleport/src/Recordings/Recordings.story.tsx
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 import React from 'react';
-import { makeEvent } from 'teleport/services/audit';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { Context, ContextProvider } from 'teleport';
 import Recordings from './Recordings';
+import makeRecording from 'teleport/services/recordings/makeRecording';
 
 export default {
   title: 'Teleport/Recordings',
@@ -27,9 +27,9 @@ export default {
 
 export const Loaded = () => {
   const ctx = new Context();
-  ctx.auditService.fetchEvents = () =>
+  ctx.recordingsService.fetchRecordings = () =>
     Promise.resolve({
-      events: events.map(makeEvent),
+      recordings: recordings.map(makeRecording),
       startKey: '',
     });
 
@@ -38,9 +38,9 @@ export const Loaded = () => {
 
 export const Overflow = () => {
   const ctx = new Context();
-  ctx.auditService.fetchEvents = () =>
+  ctx.recordingsService.fetchRecordings = () =>
     Promise.resolve({
-      events: [],
+      recordings: [],
       startKey: 'cause-overflow',
     });
 
@@ -49,13 +49,13 @@ export const Overflow = () => {
 
 export const Processing = () => {
   const ctx = new Context();
-  ctx.auditService.fetchEvents = () => new Promise(() => null);
+  ctx.recordingsService.fetchRecordings = () => new Promise(() => null);
   return render(ctx);
 };
 
 export const Failed = () => {
   const ctx = new Context();
-  ctx.auditService.fetchEvents = () =>
+  ctx.recordingsService.fetchRecordings = () =>
     Promise.reject(new Error('server error'));
   return render(ctx);
 };
@@ -75,7 +75,7 @@ function render(ctx) {
   );
 }
 
-const events = [
+const recordings = [
   {
     code: 'T2004I',
     ei: 10,

--- a/packages/teleport/src/Recordings/Recordings.tsx
+++ b/packages/teleport/src/Recordings/Recordings.tsx
@@ -20,37 +20,32 @@ import {
   FeatureHeader,
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
-import RecordList from './RecordList';
+import RecordingsList from './RecordingsList';
 import RangePicker from 'teleport/components/EventRangePicker';
 import { Danger } from 'design/Alert';
 import { Flex, Indicator, Box } from 'design';
 import InputSearch from 'teleport/components/InputSearch';
 import useTeleport from 'teleport/useTeleport';
-import useAuditEvents from 'teleport/useAuditEvents';
-import useStickyClusterId from 'teleport/useStickyClusterId';
-import { eventCodes } from 'teleport/services/audit';
+import useRecordings, { State } from './useRecordings';
 
 export default function Container() {
-  const teleCtx = useTeleport();
-  const { clusterId } = useStickyClusterId();
-  const state = useAuditEvents(teleCtx, clusterId, eventCodes.SESSION_END);
+  const ctx = useTeleport();
+  const state = useRecordings(ctx);
   return <Recordings {...state} />;
 }
 
-export function Recordings(props: ReturnType<typeof useAuditEvents>) {
-  const {
-    attempt,
-    range,
-    rangeOptions,
-    setRange,
-    events,
-    searchValue,
-    clusterId,
-    setSearchValue,
-    fetchMore,
-    fetchStatus,
-  } = props;
-
+export function Recordings({
+  recordings,
+  fetchStatus,
+  fetchMore,
+  range,
+  setRange,
+  rangeOptions,
+  searchValue,
+  setSearchValue,
+  attempt,
+  clusterId,
+}: State) {
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center">
@@ -77,9 +72,9 @@ export function Recordings(props: ReturnType<typeof useAuditEvents>) {
         </Box>
       )}
       {attempt.status === 'success' && (
-        <RecordList
+        <RecordingsList
           searchValue={searchValue}
-          events={events}
+          recordings={recordings}
           clusterId={clusterId}
           pageSize={50}
           fetchMore={fetchMore}

--- a/packages/teleport/src/Recordings/RecordingsList.tsx
+++ b/packages/teleport/src/Recordings/RecordingsList.tsx
@@ -14,64 +14,54 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
-import moment from 'moment';
+import React, { useState } from 'react';
 import { sortBy } from 'lodash';
 import isMatch from 'design/utils/match';
 import { ButtonBorder } from 'design';
 import { displayDateTime } from 'shared/services/loc';
 import * as Table from 'design/DataTable';
 import PagedTable from 'design/DataTable/Paged';
-import { SessionEnd } from 'teleport/services/audit/types';
 import cfg from 'teleport/config';
-import { State } from 'teleport/useAuditEvents';
+import { State } from './useRecordings';
+import { Recording } from 'teleport/services/recordings';
 
-type SortCols = 'created' | 'duration';
-type SortState = {
-  [key in SortCols]?: string;
-};
-
-export default function RecordList(props: Props) {
+export default function RecordingsList(props: Props) {
   const {
+    recordings,
     clusterId,
     searchValue,
     pageSize,
-    events,
     fetchMore,
     fetchStatus,
   } = props;
-  const [colSortDirs, setSort] = React.useState<SortState>(() => {
+  const [sortDir, setSortDir] = useState<Record<string, string>>(() => {
     return {
       created: Table.SortTypes.ASC,
     };
   });
 
-  // sort and filter
-  const data = React.useMemo(() => {
-    const rows = events
-      .filter(e => e.code === 'T2004I')
-      .map(makeRows(clusterId));
-
-    const filtered = rows.filter(obj =>
-      isMatch(obj, searchValue, {
+  function sortAndFilter(search: string) {
+    const filtered = recordings.filter(obj =>
+      isMatch(obj, search, {
         searchableProps,
         cb: null,
       })
     );
 
-    const columnKey = Object.getOwnPropertyNames(colSortDirs)[0];
-    const sortDir = colSortDirs[columnKey];
+    const columnKey = Object.getOwnPropertyNames(sortDir)[0];
     const sorted = sortBy(filtered, columnKey);
-    if (sortDir === Table.SortTypes.ASC) {
+    if (sortDir[columnKey] === Table.SortTypes.ASC) {
       return sorted.reverse();
     }
 
     return sorted;
-  }, [colSortDirs, events, searchValue]);
-
-  function onSortChange(columnKey: SortCols, sortDir: string) {
-    setSort({ [columnKey]: sortDir });
   }
+
+  function onSortChange(columnKey: string, sortDir: string) {
+    setSortDir({ [columnKey]: sortDir });
+  }
+
+  const data = sortAndFilter(searchValue);
 
   const tableProps = { pageSize, data, fetchMore, fetchStatus };
 
@@ -91,7 +81,7 @@ export default function RecordList(props: Props) {
         columnKey="duration"
         header={
           <Table.SortHeaderCell
-            sortDir={colSortDirs.duration}
+            sortDir={sortDir.duration}
             onSortChange={onSortChange}
             title="Duration"
           />
@@ -102,7 +92,7 @@ export default function RecordList(props: Props) {
         columnKey="created"
         header={
           <Table.SortHeaderCell
-            sortDir={colSortDirs.created}
+            sortDir={sortDir.created}
             onSortChange={onSortChange}
             title="Created"
           />
@@ -113,81 +103,45 @@ export default function RecordList(props: Props) {
         header={<Table.Cell>Session ID</Table.Cell>}
         cell={<SidCell />}
       />
-      <Table.Column header={<Table.Cell />} cell={<PlayCell />} />
+      <Table.Column
+        header={<Table.Cell />}
+        cell={<PlayCell clusterId={clusterId} />}
+      />
     </PagedTable>
   );
 }
 
-const makeRows = (clusterId: string) => (event: SessionEnd) => {
-  const { time, raw } = event;
-  const users = raw?.participants || [];
-  const rawEvent = event.raw;
-
-  let durationText = '';
-  let duration = 0;
-  if (rawEvent.session_start && rawEvent.session_stop) {
-    duration = moment(rawEvent.session_stop).diff(rawEvent.session_start);
-    durationText = moment.duration(duration).humanize();
-  }
-
-  let hostname = raw.server_hostname || 'N/A';
-  // For Kubernetes sessions, put the full pod name as 'hostname'.
-  if (raw.proto === 'kube') {
-    hostname = `${raw.kubernetes_cluster}/${raw.kubernetes_pod_namespace}/${raw.kubernetes_pod_name}`;
-  }
-
-  // Description set to play for interactive so users can search by "play".
-  let description = raw.interactive ? 'play' : 'non-interactive';
-  if (raw.session_recording === 'off') {
-    description = 'recording disabled';
-  }
-
-  return {
-    clusterId,
-    duration,
-    durationText,
-    sid: raw.sid,
-    created: time,
-    createdText: displayDateTime(time),
-    users: users.join(', '),
-    hostname: hostname,
-    description,
-  };
-};
-
-type Row = ReturnType<ReturnType<typeof makeRows>>;
-
 function CreatedCell(props) {
   const { rowIndex, data } = props;
-  const row = data[rowIndex] as Row;
-  return <Table.Cell>{row.createdText}</Table.Cell>;
+  const { createdDate } = data[rowIndex] as Recording;
+  return <Table.Cell>{displayDateTime(createdDate)}</Table.Cell>;
 }
 
 function DurationCell(props) {
   const { rowIndex, data } = props;
-  const row = data[rowIndex] as Row;
-  return <Table.Cell>{row.durationText}</Table.Cell>;
+  const { durationText } = data[rowIndex] as Recording;
+  return <Table.Cell>{durationText}</Table.Cell>;
 }
 
 function SidCell(props) {
   const { rowIndex, data } = props;
-  const row = data[rowIndex] as Row;
-  return <Table.Cell>{row.sid}</Table.Cell>;
+  const { sid } = data[rowIndex] as Recording;
+  return <Table.Cell>{sid}</Table.Cell>;
 }
 
 const PlayCell = props => {
-  const { rowIndex, data } = props;
-  const row = data[rowIndex] as Row;
+  const { rowIndex, data, clusterId } = props;
+  const { description, sid } = data[rowIndex] as Recording;
 
-  if (row.description !== 'play') {
+  if (description !== 'play') {
     return (
       <Table.Cell align="right" style={{ color: '#9F9F9F' }}>
-        {row.description}
+        {description}
       </Table.Cell>
     );
   }
 
-  const url = cfg.getSessionAuditPlayerRoute(row);
+  const url = cfg.getSessionAuditPlayerRoute({ clusterId, sid });
   return (
     <Table.Cell align="right">
       <ButtonBorder
@@ -207,7 +161,7 @@ const PlayCell = props => {
 type Props = {
   pageSize?: number;
   searchValue: State['searchValue'];
-  events: State['events'];
+  recordings: State['recordings'];
   clusterId: State['clusterId'];
   fetchMore: State['fetchMore'];
   fetchStatus: State['fetchStatus'];

--- a/packages/teleport/src/Recordings/RecordingsList.tsx
+++ b/packages/teleport/src/Recordings/RecordingsList.tsx
@@ -36,7 +36,7 @@ export default function RecordingsList(props: Props) {
   } = props;
   const [sortDir, setSortDir] = useState<Record<string, string>>(() => {
     return {
-      created: Table.SortTypes.ASC,
+      created: Table.SortTypes.DESC,
     };
   });
 

--- a/packages/teleport/src/Recordings/RecordingsList.tsx
+++ b/packages/teleport/src/Recordings/RecordingsList.tsx
@@ -36,7 +36,7 @@ export default function RecordingsList(props: Props) {
   } = props;
   const [sortDir, setSortDir] = useState<Record<string, string>>(() => {
     return {
-      created: Table.SortTypes.DESC,
+      createdDate: Table.SortTypes.ASC,
     };
   });
 
@@ -89,10 +89,10 @@ export default function RecordingsList(props: Props) {
         cell={<DurationCell />}
       />
       <Table.Column
-        columnKey="created"
+        columnKey="createdDate"
         header={
           <Table.SortHeaderCell
-            sortDir={sortDir.created}
+            sortDir={sortDir.createdDate}
             onSortChange={onSortChange}
             title="Created"
           />
@@ -169,7 +169,7 @@ type Props = {
 
 const searchableProps = [
   'sid',
-  'createdText',
+  'createdDate',
   'users',
   'durationText',
   'hostname',

--- a/packages/teleport/src/Recordings/useRecordings.ts
+++ b/packages/teleport/src/Recordings/useRecordings.ts
@@ -1,0 +1,83 @@
+import { useState, useEffect, useMemo } from 'react';
+import useAttempt from 'shared/hooks/useAttemptNext';
+import Ctx from 'teleport/teleportContext';
+import useStickyClusterId from 'teleport/useStickyClusterId';
+import {
+  getRangeOptions,
+  EventRange,
+} from 'teleport/components/EventRangePicker';
+import { Recording } from 'teleport/services/recordings';
+
+export default function useRecordings(ctx: Ctx) {
+  const { clusterId } = useStickyClusterId();
+  const rangeOptions = useMemo(() => getRangeOptions(), []);
+  const [searchValue, setSearchValue] = useState('');
+  const [range, setRange] = useState<EventRange>(rangeOptions[0]);
+  const { attempt, setAttempt, run } = useAttempt('processing');
+  const [results, setResults] = useState<RecordingsResult>({
+    recordings: [],
+    fetchStartKey: '',
+    fetchStatus: '',
+  });
+
+  useEffect(() => {
+    fetch();
+  }, [clusterId, range]);
+
+  function fetchMore() {
+    setResults({
+      ...results,
+      fetchStatus: 'loading',
+    });
+    ctx.recordingsService
+      .fetchRecordings(clusterId, {
+        ...range,
+        startKey: results.fetchStartKey,
+      })
+      .then(res =>
+        setResults({
+          recordings: [...results.recordings, ...res.recordings],
+          fetchStartKey: res.startKey,
+          fetchStatus: res.startKey ? '' : 'disabled',
+        })
+      )
+      .catch((err: Error) => {
+        setAttempt({ status: 'failed', statusText: err.message });
+      });
+  }
+
+  function fetch() {
+    run(() =>
+      ctx.recordingsService
+        .fetchRecordings(clusterId, {
+          ...range,
+        })
+        .then(res =>
+          setResults({
+            recordings: res.recordings,
+            fetchStartKey: res.startKey,
+            fetchStatus: res.startKey ? '' : 'disabled',
+          })
+        )
+    );
+  }
+  return {
+    ...results,
+    attempt,
+    range,
+    rangeOptions,
+    setRange,
+    searchValue,
+    clusterId,
+    setSearchValue,
+    fetchMore,
+  };
+}
+
+type RecordingsResult = {
+  recordings: Recording[];
+  fetchStatus: 'loading' | 'disabled' | '';
+  fetchStartKey: string;
+};
+
+export type State = ReturnType<typeof useRecordings>;

--- a/packages/teleport/src/Recordings/useRecordings.ts
+++ b/packages/teleport/src/Recordings/useRecordings.ts
@@ -20,10 +20,6 @@ export default function useRecordings(ctx: Ctx) {
     fetchStatus: '',
   });
 
-  useEffect(() => {
-    fetch();
-  }, [clusterId, range]);
-
   function fetchMore() {
     setResults({
       ...results,
@@ -61,6 +57,11 @@ export default function useRecordings(ctx: Ctx) {
         )
     );
   }
+
+  useEffect(() => {
+    fetch();
+  }, [clusterId, range]);
+
   return {
     ...results,
     attempt,

--- a/packages/teleport/src/components/EventRangePicker/EventRangePicker.tsx
+++ b/packages/teleport/src/components/EventRangePicker/EventRangePicker.tsx
@@ -21,8 +21,9 @@ import { Text } from 'design';
 import Dialog from 'design/DialogConfirmation';
 import { displayDate } from 'shared/services/loc';
 import CustomRange from './Custom';
+import { EventRange } from './utils';
 import Select, { Option, DarkStyledSelect } from 'shared/components/Select';
-import { State, EventRange } from 'teleport/useAuditEvents';
+import { State } from 'teleport/Audit/useAuditEvents';
 
 export default function DataRange({ ml, range, onChangeRange, ranges }: Props) {
   const [isPickerOpen, openDayPicker] = useState(false);

--- a/packages/teleport/src/components/EventRangePicker/index.ts
+++ b/packages/teleport/src/components/EventRangePicker/index.ts
@@ -17,3 +17,4 @@ limitations under the License.
 import RangePicker from './EventRangePicker';
 
 export default RangePicker;
+export * from './utils';

--- a/packages/teleport/src/components/EventRangePicker/utils.ts
+++ b/packages/teleport/src/components/EventRangePicker/utils.ts
@@ -1,0 +1,38 @@
+import moment from 'moment';
+
+export function getRangeOptions(): EventRange[] {
+  return [
+    {
+      name: 'Today',
+      from: moment(new Date())
+        .startOf('day')
+        .toDate(),
+      to: moment(new Date())
+        .endOf('day')
+        .toDate(),
+    },
+    {
+      name: '7 days',
+      from: moment()
+        .subtract(6, 'day')
+        .startOf('day')
+        .toDate(),
+      to: moment(new Date())
+        .endOf('day')
+        .toDate(),
+    },
+    {
+      name: 'Custom Range...',
+      isCustom: true,
+      from: new Date(),
+      to: new Date(),
+    },
+  ];
+}
+
+export type EventRange = {
+  from: Date;
+  to: Date;
+  isCustom?: boolean;
+  name?: string;
+};

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -90,7 +90,7 @@ const cfg = {
     applicationsPath: '/v1/webapi/sites/:clusterId/apps',
     clustersPath: '/v1/webapi/sites',
     clusterEventsPath: `/v1/webapi/sites/:clusterId/events/search?from=:start?&to=:end?&limit=:limit?&startKey=:startKey?&include=:include?`,
-    sessionRecordingsPath: `/v1/webapi/sites/:clusterId/events/search/sessions?from=:start?&to=:end?&limit=:limit?&startKey=:startKey?`,
+    clusterEventsRecordingsPath: `/v1/webapi/sites/:clusterId/events/search/sessions?from=:start?&to=:end?&limit=:limit?&startKey=:startKey?`,
     scp: '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
     renewTokenPath: '/v1/webapi/sessions/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
@@ -151,11 +151,11 @@ const cfg = {
     });
   },
 
-  getSessionRecordingsUrl(
+  getClusterEventsRecordingsUrl(
     clusterId: string,
     params: UrlSessionRecordingsParams
   ) {
-    return generatePath(cfg.api.sessionRecordingsPath, {
+    return generatePath(cfg.api.clusterEventsRecordingsPath, {
       clusterId,
       ...params,
     });

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -90,8 +90,8 @@ const cfg = {
     applicationsPath: '/v1/webapi/sites/:clusterId/apps',
     clustersPath: '/v1/webapi/sites',
     clusterEventsPath: `/v1/webapi/sites/:clusterId/events/search?from=:start?&to=:end?&limit=:limit?&startKey=:startKey?&include=:include?`,
-    scp:
-      '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
+    sessionRecordingsPath: `/v1/webapi/sites/:clusterId/events/search/sessions?from=:start?&to=:end?&limit=:limit?&startKey=:startKey?`,
+    scp: '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
     renewTokenPath: '/v1/webapi/sessions/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
     sessionPath: '/v1/webapi/sessions',
@@ -146,6 +146,16 @@ const cfg = {
 
   getClusterEventsUrl(clusterId: string, params: UrlClusterEventsParams) {
     return generatePath(cfg.api.clusterEventsPath, {
+      clusterId,
+      ...params,
+    });
+  },
+
+  getSessionRecordingsUrl(
+    clusterId: string,
+    params: UrlSessionRecordingsParams
+  ) {
+    return generatePath(cfg.api.sessionRecordingsPath, {
       clusterId,
       ...params,
     });
@@ -413,6 +423,13 @@ export interface UrlSshParams {
   serverId?: string;
   sid?: string;
   clusterId: string;
+}
+
+export interface UrlSessionRecordingsParams {
+  start: string;
+  end: string;
+  limit?: number;
+  startKey?: string;
 }
 
 export interface UrlClusterEventsParams {

--- a/packages/teleport/src/features.ts
+++ b/packages/teleport/src/features.ts
@@ -209,7 +209,7 @@ export class FeatureRecordings {
   };
 
   register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().audit) {
+    if (!ctx.getFeatureFlags().recordings) {
       return;
     }
 

--- a/packages/teleport/src/services/recordings/index.ts
+++ b/packages/teleport/src/services/recordings/index.ts
@@ -1,0 +1,4 @@
+import RecordingsService from './recordings';
+
+export * from './types';
+export default RecordingsService;

--- a/packages/teleport/src/services/recordings/makeRecording.ts
+++ b/packages/teleport/src/services/recordings/makeRecording.ts
@@ -1,0 +1,46 @@
+import moment from 'moment';
+import { Recording } from './types';
+
+export default function makeRecording({
+  participants = [],
+  time,
+  session_start,
+  session_stop,
+  server_hostname,
+  interactive,
+  session_recording,
+  proto,
+  sid,
+  kubernetes_cluster,
+  kubernetes_pod_namespace,
+  kubernetes_pod_name,
+}): Recording {
+  let durationText = '';
+  let duration = 0;
+  if (session_start && session_stop) {
+    duration = moment(session_stop).diff(session_start);
+    durationText = moment.duration(duration).humanize();
+  }
+
+  let hostname = server_hostname || 'N/A';
+  // For Kubernetes sessions, put the full pod name as 'hostname'.
+  if (proto === 'kube') {
+    hostname = `${kubernetes_cluster}/${kubernetes_pod_namespace}/${kubernetes_pod_name}`;
+  }
+
+  // Description set to play for interactive so users can search by "play".
+  let description = interactive ? 'play' : 'non-interactive';
+  if (session_recording === 'off') {
+    description = 'recording disabled';
+  }
+
+  return {
+    duration,
+    durationText,
+    sid,
+    createdDate: time,
+    users: participants.join(', '),
+    hostname,
+    description,
+  };
+}

--- a/packages/teleport/src/services/recordings/makeRecording.ts
+++ b/packages/teleport/src/services/recordings/makeRecording.ts
@@ -8,12 +8,12 @@ export default function makeRecording({
   session_stop,
   server_hostname,
   interactive,
-  session_recording,
-  proto,
+  session_recording = 'on',
   sid,
-  kubernetes_cluster,
-  kubernetes_pod_namespace,
-  kubernetes_pod_name,
+  proto = '',
+  kubernetes_cluster = '',
+  kubernetes_pod_namespace = '',
+  kubernetes_pod_name = '',
 }): Recording {
   let durationText = '';
   let duration = 0;

--- a/packages/teleport/src/services/recordings/recordings.ts
+++ b/packages/teleport/src/services/recordings/recordings.ts
@@ -12,7 +12,7 @@ export default class RecordingsService {
     const start = params.from.toISOString();
     const end = params.to.toISOString();
 
-    const url = cfg.getSessionRecordingsUrl(clusterId, {
+    const url = cfg.getClusterEventsRecordingsUrl(clusterId, {
       start,
       end,
       limit: this.maxFetchLimit,

--- a/packages/teleport/src/services/recordings/recordings.ts
+++ b/packages/teleport/src/services/recordings/recordings.ts
@@ -1,0 +1,28 @@
+import cfg from 'teleport/config';
+import api from 'teleport/services/api';
+import { RecordingsQuery, RecordingsResponse } from './types';
+import makeRecording from './makeRecording';
+export default class RecordingsService {
+  maxFetchLimit = 5000;
+
+  fetchRecordings(
+    clusterId: string,
+    params: RecordingsQuery
+  ): Promise<RecordingsResponse> {
+    const start = params.from.toISOString();
+    const end = params.to.toISOString();
+
+    const url = cfg.getSessionRecordingsUrl(clusterId, {
+      start,
+      end,
+      limit: this.maxFetchLimit,
+      startKey: params.startKey || undefined,
+    });
+
+    return api.get(url).then(json => {
+      const events = json.events || [];
+
+      return { recordings: events.map(makeRecording), startKey: json.startKey };
+    });
+  }
+}

--- a/packages/teleport/src/services/recordings/types.ts
+++ b/packages/teleport/src/services/recordings/types.ts
@@ -1,0 +1,21 @@
+export type RecordingsQuery = {
+  from: Date;
+  to: Date;
+  limit?: number;
+  startKey?: string;
+};
+
+export type RecordingsResponse = {
+  recordings: Recording[];
+  startKey: string;
+};
+
+export type Recording = {
+  duration: number;
+  durationText: string;
+  sid: string;
+  createdDate: Date;
+  users: string;
+  hostname: string;
+  description: string;
+};

--- a/packages/teleport/src/stores/storeUserContext.ts
+++ b/packages/teleport/src/stores/storeUserContext.ts
@@ -92,4 +92,8 @@ export default class StoreUserContext extends Store<UserContext> {
   getDesktopAccess() {
     return this.state.acl.desktops;
   }
+
+  getSessionsAccess() {
+    return this.state.acl.sessions;
+  }
 }

--- a/packages/teleport/src/teleportContext.tsx
+++ b/packages/teleport/src/teleportContext.tsx
@@ -18,6 +18,7 @@ import { StoreNav, StoreUserContext } from './stores';
 import cfg from 'teleport/config';
 import * as types from './types';
 import AuditService from './services/audit';
+import RecordingsService from './services/recordings';
 import nodeService from './services/nodes';
 import clusterService from './services/clusters';
 import sshService from './services/ssh';
@@ -39,6 +40,7 @@ class TeleportContext implements types.Context {
 
   // services
   auditService = new AuditService();
+  recordingsService = new RecordingsService();
   nodeService = nodeService;
   clusterService = clusterService;
   sshService = sshService;
@@ -59,8 +61,10 @@ class TeleportContext implements types.Context {
 
   getFeatureFlags() {
     const userContext = this.storeUser;
+
     return {
       audit: userContext.getEventAccess().list,
+      recordings: userContext.getSessionsAccess().list,
       authConnector: userContext.getConnectorAccess().list,
       roles: userContext.getRoleAccess().list,
       trustedClusters: userContext.getTrustedClusterAccess().list,


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/webapps/issues/459
This PR resolves https://github.com/gravitational/webapps/issues/406

Separate the recordings service from the other events service, this allows us to use RBAC to control access to recordings.

## Demo
![recordings](https://user-images.githubusercontent.com/56373201/144627147-8905f047-e52b-4142-b984-5e81c51f757e.gif)


