### PR TITLE
Make xterm understand resize sequence

### DIFF
--- a/packages/teleterm/src/ui/DocumentTerminal/DocumentTerminal.tsx
+++ b/packages/teleterm/src/ui/DocumentTerminal/DocumentTerminal.tsx
@@ -25,9 +25,10 @@ export default function DocumentTerminal(props: Props & { visible: boolean }) {
   const { ptyProcess } = useDocumentTerminal(doc);
 
   useEffect(() => {
-    if (refTerminal?.current && ptyProcess) {
+    if (refTerminal?.current && ptyProcess && visible) {
       // when switching tabs or closing tabs, focus on visible terminal
       refTerminal.current.terminal.term.focus();
+      window.dispatchEvent(new Event('resize'));
     }
   }, [visible, ptyProcess]);
 

--- a/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
+++ b/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
@@ -64,22 +64,21 @@ export default class Terminal extends React.Component<{
 
 const StyledXterm = styled(Box)(
   props => `
-  height: 100%;
-  width: 100%;
-  font-size: 14px;
-  line-height: normal;
-  overflow: hidden;
-  background-color: ${colors.bgTerminal};
-  .terminal {
-    font-family: ${props.theme.fonts.mono};
-    border: none;
-    font-size: inherit;
-    line-height: normal;
-    position: relative;
-  }
-  .terminal .xterm-viewport {
-    background-color: ${colors.bgTerminal};
-  }
-
-}`
+   height: 100%;
+   width: 100%;
+   font-size: 14px;
+   line-height: normal;
+   overflow: auto;
+   background-color: ${colors.bgTerminal};
+   .terminal {
+     font-family: ${props.theme.fonts.mono};
+     border: none;
+     font-size: inherit;
+     line-height: normal;
+     position: relative;
+   }
+   .terminal .xterm-viewport {
+     background-color: ${colors.bgTerminal};
+   }
+ }`
 );


### PR DESCRIPTION
Handles `\033[8;30;80t` sequence.
Imported xterm styling from the `teleport` because it has `overflow: auto` set and I wanted to avoid copy&paste.