### PR TITLE
Select filter paginate

### DIFF
--- a/packages/shared/components/Select/types.ts
+++ b/packages/shared/components/Select/types.ts
@@ -39,7 +39,7 @@ export type Props = {
   menuPosition?: 'fixed' | 'absolute';
   inputValue?: string;
   filterOption?(): null | boolean;
-  onInputChange?(value: string, actionMeta: { action: InputAction }): void;
+  onInputChange?(value: string, actionMeta: ActionMeta): void;
 };
 
 export type AsyncProps = Omit<Props, 'options'> & {
@@ -58,4 +58,6 @@ export type Option<T = string> = {
   label: string;
 };
 
-type InputAction = 'set-value' | 'input-change' | 'input-blur' | 'menu-close';
+export type ActionMeta = {
+  action: 'set-value' | 'input-change' | 'input-blur' | 'menu-close';
+};

--- a/packages/shared/components/Select/types.ts
+++ b/packages/shared/components/Select/types.ts
@@ -37,6 +37,9 @@ export type Props = {
   components?: any;
   customProps?: Record<string, any>;
   menuPosition?: 'fixed' | 'absolute';
+  inputValue?: string;
+  filterOption?(): null | boolean;
+  onInputChange?(value: string, actionMeta: { action: InputAction }): void;
 };
 
 export type AsyncProps = Omit<Props, 'options'> & {
@@ -54,3 +57,5 @@ export type Option<T = string> = {
   // label is the value user sees in the select options dropdown.
   label: string;
 };
+
+type InputAction = 'set-value' | 'input-change' | 'input-blur' | 'menu-close';

--- a/packages/teleport/src/components/SelectFilters/Pager.tsx
+++ b/packages/teleport/src/components/SelectFilters/Pager.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2021 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import Icon, { CircleArrowLeft, CircleArrowRight } from 'design/Icon';
+import { Text, Flex } from 'design';
+
+export default function Pager({
+  startFrom = 0,
+  endAt = 0,
+  totalRows = 0,
+  onPrev,
+  onNext,
+}: Props) {
+  const isPrevDisabled = totalRows === 0 || startFrom === 0;
+  const isNextDisabled = totalRows === 0 || endAt === totalRows;
+  const initialStartFrom = totalRows > 0 ? startFrom + 1 : 0;
+
+  return (
+    <Flex m={2} justifyContent="flex-end">
+      <Flex alignItems="center" ml={2}>
+        <Text typography="body2" style={{ color: '#4b4b4b' }}>
+          SHOWING <strong>{initialStartFrom}</strong> - <strong>{endAt}</strong>{' '}
+          of <strong>{totalRows}</strong>
+        </Text>
+      </Flex>
+      <StyledButtons>
+        <button
+          onClick={onPrev}
+          title="Previous Page"
+          disabled={isPrevDisabled}
+        >
+          <CircleArrowLeft fontSize="3" />
+        </button>
+        <button onClick={onNext} title="Next Page" disabled={isNextDisabled}>
+          <CircleArrowRight fontSize="3" />
+        </button>
+      </StyledButtons>
+    </Flex>
+  );
+}
+
+type Props = {
+  startFrom: number;
+  endAt: number;
+  totalRows: number;
+  onPrev(): void;
+  onNext(): void;
+};
+
+export const StyledButtons = styled(Flex)`
+  button {
+    cursor: pointer;
+    padding: 0;
+    margin: 0 0 0 8px;
+    outline: none;
+    transition: all 0.3s;
+    text-align: center;
+    border-radius: 200px;
+    border: none;
+    background: #fff;
+
+    ${Icon} {
+      opacity: 0.8;
+      font-size: 20px;
+      transition: all 0.3s;
+      color: #4b4b4b;
+    }
+
+    &:hover:not(:disabled) {
+      ${Icon} {
+        opacity: 1;
+        color: #000;
+      }
+    }
+
+    &:disabled {
+      ${Icon} {
+        opacity: 0.35;
+      }
+    }
+  }
+`;

--- a/packages/teleport/src/components/SelectFilters/Pager.tsx
+++ b/packages/teleport/src/components/SelectFilters/Pager.tsx
@@ -33,7 +33,7 @@ export default function Pager({
   return (
     <Flex m={2} justifyContent="flex-end">
       <Flex alignItems="center" ml={2}>
-        <Text typography="body2" style={{ color: '#4b4b4b' }}>
+        <Text typography="body2">
           SHOWING <strong>{initialStartFrom}</strong> - <strong>{endAt}</strong>{' '}
           of <strong>{totalRows}</strong>
         </Text>

--- a/packages/teleport/src/components/SelectFilters/SelectFilters.story.tsx
+++ b/packages/teleport/src/components/SelectFilters/SelectFilters.story.tsx
@@ -21,7 +21,8 @@ export default {
   title: 'Teleport/SelectFilters',
 };
 
-export const NoAppliedFilters = () => <SelectFilter {...props} />;
+export const Filters = () => <SelectFilter {...props} />;
+export const FiltersWithPages = () => <SelectFilter {...props} pageSize={3} />;
 export const WithAppliedFilters = () => (
   <SelectFilter {...props} appliedFilters={props.filters} />
 );

--- a/packages/teleport/src/components/SelectFilters/SelectFilters.tsx
+++ b/packages/teleport/src/components/SelectFilters/SelectFilters.tsx
@@ -19,7 +19,10 @@ import styled from 'styled-components';
 import { components } from 'react-select';
 import { Flex, Text, ButtonBorder, ButtonIcon, Box } from 'design';
 import { Close, Add } from 'design/Icon';
-import Select, { Option as BaseOption } from 'shared/components/Select';
+import Select, {
+  Option as BaseOption,
+  ActionMeta,
+} from 'shared/components/Select';
 import { makeLabelTag } from 'teleport/components/formatters';
 import { Filter } from 'teleport/types';
 import usePages from './usePages';
@@ -27,8 +30,8 @@ import Pager from './Pager';
 
 export default function SelectFilters({
   applyFilters,
-  appliedFilters,
-  filters,
+  appliedFilters = [],
+  filters = [],
   mb = 3,
   pageSize = 100,
 }: Props) {
@@ -81,8 +84,8 @@ export default function SelectFilters({
     }
   }
 
-  function onInputChange(value, obj) {
-    if (obj.action === 'menu-close' || obj.action === 'set-value') {
+  function onInputChange(value: string, meta: ActionMeta) {
+    if (meta.action === 'menu-close' || meta.action === 'set-value') {
       return;
     }
     setSearch(value);
@@ -141,7 +144,7 @@ export default function SelectFilters({
             bg="#fff"
             borderRadius={2}
             borderTopLeftRadius={0}
-            style={{ position: 'absolute', zIndex: 1 }}
+            style={{ position: 'absolute', zIndex: 1, color: '#4b4b4b' }}
             ref={selectWrapperRef}
           >
             <StyledSelect>

--- a/packages/teleport/src/components/SelectFilters/SelectFilters.tsx
+++ b/packages/teleport/src/components/SelectFilters/SelectFilters.tsx
@@ -122,7 +122,7 @@ export default function SelectFilters({
   });
 
   return (
-    <Flex flexWrap="wrap" mb={mb}>
+    <Flex flexWrap="wrap" mb={mb} style={{ flexShrink: '0' }}>
       <Box style={{ position: 'relative' }}>
         <AddButton
           pl={2}

--- a/packages/teleport/src/components/SelectFilters/usePages.ts
+++ b/packages/teleport/src/components/SelectFilters/usePages.ts
@@ -16,7 +16,7 @@
 
 import React from 'react';
 
-export default function usePages({ pageSize = 100, data = [] }) {
+export default function usePages({ pageSize, data }) {
   const [startFrom, setFrom] = React.useState(0);
 
   // set current page to 0 when data source length changes

--- a/packages/teleport/src/components/SelectFilters/usePages.ts
+++ b/packages/teleport/src/components/SelectFilters/usePages.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2021 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+export default function usePages({ pageSize = 100, data = [] }) {
+  const [startFrom, setFrom] = React.useState(0);
+
+  // set current page to 0 when data source length changes
+  React.useEffect(() => {
+    setFrom(0);
+  }, [data.length]);
+
+  function onPrev() {
+    let prevPage = startFrom - pageSize;
+    if (prevPage < 0) {
+      prevPage = 0;
+    }
+    setFrom(prevPage);
+  }
+
+  function onNext() {
+    let nextPage = startFrom + pageSize;
+    if (nextPage < data.length) {
+      nextPage = startFrom + pageSize;
+      setFrom(nextPage);
+    }
+  }
+
+  const totalRows = data.length;
+
+  let endAt = 0;
+  let pagedData = data;
+
+  if (data.length > 0) {
+    endAt = startFrom + (pageSize > data.length ? data.length : pageSize);
+    if (endAt > data.length) {
+      endAt = data.length;
+    }
+
+    pagedData = data.slice(startFrom, endAt);
+  }
+
+  return {
+    pageSize,
+    startFrom,
+    endAt,
+    totalRows,
+    data: pagedData,
+    hasPages: totalRows > pageSize,
+    onNext,
+    onPrev,
+  };
+}


### PR DESCRIPTION
#### Description
- Allows pagination for select filter.
  - Default is to list 100 filter per page.
  - Solves UI freezing from react select trying to list every filter
  - searching searches through the entire list of filters (not just what is currently listed)
- Copy and pasted `usePages` and `Pager` from table component

#### Screenshot

Pages

![image](https://user-images.githubusercontent.com/43280172/146699093-a0b3ed74-98ad-473a-8b29-8f2456195712.png)
![image](https://user-images.githubusercontent.com/43280172/146699127-1fc35ad3-a81c-43ce-bab7-e22390354e49.png)
![image](https://user-images.githubusercontent.com/43280172/146699186-c9a38cd8-bd78-439f-894a-117f647c8859.png)


No pages

![image](https://user-images.githubusercontent.com/43280172/146699066-b16ee337-35ef-45b3-8881-faaba3e11949.png)
