### PR TITLE
Address eslint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build-teleport-e": "yarn workspace @gravitational/teleport.e build --output-path=../../../dist/e/teleport/app",
     "build-oss": "yarn build-teleport-oss",
     "build-e": "yarn build-teleport-e",
-    "build": "yarn type-check && yarn build-oss && yarn build-e",
+    "build": "yarn lint && yarn type-check && yarn build-oss && yarn build-e",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx packages/",
     "type-check": "yarn tsc"
   },
   "private": true,

--- a/packages/build/.eslintrc.js
+++ b/packages/build/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 6,
-    sourceType: 'module',
     ecmaFeatures: {
       jsx: true,
       experimentalObjectRestSpread: true,

--- a/packages/build/bin/g-start.js
+++ b/packages/build/bin/g-start.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+/* eslint-disable no-console */
+
 process.on('unhandledRejection', err => {
   throw err;
 });

--- a/packages/build/devserver/index.js
+++ b/packages/build/devserver/index.js
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/* eslint-disable no-console */
+
 const uri = require('url');
 const WebpackDevServer = require('webpack-dev-server');
 const httpProxy = require('http-proxy');

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -51,7 +51,6 @@
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-jest": "^25.3.0",
     "eslint-plugin-react": "^7.27.1",
-    "eslint-webpack-plugin": "^3.1.1",
     "events": "1.0.2",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",

--- a/packages/build/webpack/webpack.base.js
+++ b/packages/build/webpack/webpack.base.js
@@ -17,7 +17,6 @@ limitations under the License.
 const fs = require('fs');
 const path = require('path');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
-const ESLintPlugin = require('eslint-webpack-plugin');
 const ReactRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
 const appDirectory = fs.realpathSync(process.cwd());
@@ -28,15 +27,6 @@ const configFactory = {
   plugins: {
     reactRefresh(options) {
       return new ReactRefreshPlugin(options);
-    },
-    eslint(options) {
-      return new ESLintPlugin({
-        context: '../',
-        extensions: ['ts', 'tsx', 'js', 'jsx'],
-        failOnError: false,
-        failOnWarning: false,
-        ...options,
-      });
     },
     indexHtml(options) {
       return new HtmlWebPackPlugin({

--- a/packages/build/webpack/webpack.dev.config.js
+++ b/packages/build/webpack/webpack.dev.config.js
@@ -32,7 +32,6 @@ module.exports = {
   devtool: false,
   mode: 'development',
   plugins: [
-    configFactory.plugins.eslint(),
     configFactory.plugins.reactRefresh(),
   ],
   module: {

--- a/packages/build/webpack/webpack.prod.config.js
+++ b/packages/build/webpack/webpack.prod.config.js
@@ -39,5 +39,4 @@ module.exports = {
       configFactory.rules.css(),
     ],
   },
-  plugins: [configFactory.plugins.eslint()],
 };

--- a/packages/build/webpack/webpack.prod.config.js
+++ b/packages/build/webpack/webpack.prod.config.js
@@ -20,7 +20,7 @@ process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
 
 /**
- * @type { import("webpack").webpack.Configuration }
+ * @type { import('webpack').webpack.Configuration }
  */
 module.exports = {
   ...configFactory.createDefaultConfig(),
@@ -39,4 +39,5 @@ module.exports = {
       configFactory.rules.css(),
     ],
   },
+  plugins: [],
 };

--- a/packages/design/src/Button/Button.test.js
+++ b/packages/design/src/Button/Button.test.js
@@ -21,7 +21,7 @@ import { render, theme } from 'design/utils/testing';
 describe('design/Button', () => {
   it('renders a <button> and respects default "kind" prop == primary', () => {
     const { container } = render(<Button />);
-    expect(container.firstChild.nodeName).toEqual('BUTTON');
+    expect(container.firstChild.nodeName).toBe('BUTTON');
     expect(container.firstChild).toHaveStyle({
       background: theme.colors.secondary.main,
     });

--- a/packages/design/src/ButtonIcon/ButtonIcon.test.js
+++ b/packages/design/src/ButtonIcon/ButtonIcon.test.js
@@ -21,7 +21,7 @@ import { render } from 'design/utils/testing';
 describe('design/ButtonIcon', () => {
   it('renders a <button> and respects default "size" to 1', () => {
     const { container } = render(<ButtonIcon />);
-    expect(container.firstChild.nodeName).toEqual('BUTTON');
+    expect(container.firstChild.nodeName).toBe('BUTTON');
     expect(container.firstChild).toHaveStyle('font-size: 16px');
   });
 

--- a/packages/design/src/ButtonLink/ButtonLink.test.js
+++ b/packages/design/src/ButtonLink/ButtonLink.test.js
@@ -21,7 +21,7 @@ import { render } from 'design/utils/testing';
 describe('design/ButtonLink', () => {
   it('respects the "as" prop', () => {
     const { container } = render(<ButtonLink />);
-    expect(container.firstChild.nodeName).toEqual('A');
+    expect(container.firstChild.nodeName).toBe('A');
   });
 
   it('respects the button size prop', () => {

--- a/packages/design/src/ButtonOutlined/ButtonOutlined.test.js
+++ b/packages/design/src/ButtonOutlined/ButtonOutlined.test.js
@@ -21,7 +21,7 @@ import { render, theme } from 'design/utils/testing';
 describe('design/ButtonOutlined', () => {
   it('renders a <button> and respects default props', () => {
     const { container } = render(<ButtonOutlined />);
-    expect(container.firstChild.nodeName).toEqual('BUTTON');
+    expect(container.firstChild.nodeName).toBe('BUTTON');
     expect(container.firstChild).toHaveStyle('font-size: 12px');
     expect(container.firstChild).toHaveStyle({
       'border-color': theme.colors.text.primary,

--- a/packages/design/src/LabelState/LabelState.test.js
+++ b/packages/design/src/LabelState/LabelState.test.js
@@ -45,7 +45,7 @@ describe('design/LabelState', () => {
       background: expected,
     });
 
-    expect(getComputedStyle(container.firstChild).boxShadow).toEqual('');
+    expect(getComputedStyle(container.firstChild).boxShadow).toBe('');
   });
 
   it('respects shadow prop', () => {

--- a/packages/design/src/Modal/Portal.test.js
+++ b/packages/design/src/Modal/Portal.test.js
@@ -23,7 +23,7 @@ describe('design/Modal/Portal', () => {
     const { getByTestId, container } = renderPortal();
     const content = getByTestId('content');
     expect(container).not.toContainElement(content);
-    expect(content.parentNode.nodeName).toEqual('BODY');
+    expect(content.parentNode.nodeName).toBe('BODY');
   });
 
   test('container to be attached to custom element', () => {

--- a/packages/shared/components/FormPassword/FormPassword.test.tsx
+++ b/packages/shared/components/FormPassword/FormPassword.test.tsx
@@ -116,7 +116,7 @@ test('prop auth2faType: webauthn form with mocked error', async () => {
   );
 
   // Rendering of mfa dropdown.
-  expect(screen.getByTestId('mfa-select')).not.toBeEmpty();
+  expect(screen.getByTestId('mfa-select')).not.toBeEmptyDOMElement();
 
   // fill out form
   fireEvent.change(getByPlaceholderText(placeholdCurrPass), inputVal);
@@ -146,7 +146,7 @@ test('prop auth2faType: OTP form', async () => {
   );
 
   // rendering of mfa dropdown
-  expect(screen.getByTestId('mfa-select')).not.toBeEmpty();
+  expect(screen.getByTestId('mfa-select')).not.toBeEmptyDOMElement();
 
   // test input validation error state
   await wait(() => fireEvent.click(getByText(btnSubmitText)));
@@ -188,7 +188,7 @@ test('prop auth2faType: U2f form with mocked error', async () => {
   );
 
   // rendering of mfa dropdown
-  expect(screen.getByTestId('mfa-select')).not.toBeEmpty();
+  expect(screen.getByTestId('mfa-select')).not.toBeEmptyDOMElement();
 
   // fill out form
   fireEvent.change(getByPlaceholderText(placeholdCurrPass), inputVal);

--- a/packages/shared/components/Validation/Validation.test.js
+++ b/packages/shared/components/Validation/Validation.test.js
@@ -40,14 +40,14 @@ test('methods of Validator: sub, unsub, validate', () => {
   validator.subscribe(mockCb2);
 
   // test validate runs all subscribed cb's
-  expect(validator.validate()).toEqual(true);
+  expect(validator.validate()).toBe(true);
   expect(mockCb1).toHaveBeenCalledTimes(1);
   expect(mockCb2).toHaveBeenCalledTimes(1);
   jest.clearAllMocks();
 
   // test unsubscribe method removes correct cb
   validator.unsubscribe(mockCb2);
-  expect(validator.validate()).toEqual(true);
+  expect(validator.validate()).toBe(true);
   expect(mockCb1).toHaveBeenCalledTimes(1);
   expect(mockCb2).toHaveBeenCalledTimes(0);
 });

--- a/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
@@ -30,7 +30,7 @@ const fakeClient = () => {
   client.init = () => {
     client.emit('init');
   };
-  client.resize = (w: number, h: number) => {};
+  client.resize = () => {};
   client.disconnect = () => {
     client.emit('disconnect');
   };
@@ -55,15 +55,15 @@ const props: State = {
     fillGray(canvas);
   },
   onConnect: () => {},
-  onRender: (ctx: CanvasRenderingContext2D, data: ImageData) => {},
+  onRender: () => {},
   onDisconnect: () => {},
-  onError: (err: Error) => {},
-  onKeyDown: (cli: TdpClient, e: KeyboardEvent) => {},
-  onKeyUp: (cli: TdpClient, e: KeyboardEvent) => {},
-  onMouseMove: (cli: TdpClient, canvas: HTMLCanvasElement, e: MouseEvent) => {},
-  onMouseDown: (cli: TdpClient, e: MouseEvent) => {},
-  onMouseUp: (cli: TdpClient, e: MouseEvent) => {},
-  onMouseWheelScroll: (cli: TdpClient, e: WheelEvent) => {},
+  onError: () => {},
+  onKeyDown: () => {},
+  onKeyUp: () => {},
+  onMouseMove: () => {},
+  onMouseDown: () => {},
+  onMouseUp: () => {},
+  onMouseWheelScroll: () => {},
 };
 
 export const Processing = () => (

--- a/packages/teleport/src/Desktops/Desktops.story.tsx
+++ b/packages/teleport/src/Desktops/Desktops.story.tsx
@@ -45,6 +45,6 @@ const props: State = {
   clusterId: 'im-a-cluster',
   searchValue: '',
   setSearchValue: () => {},
-  getWindowsLoginOptions: (desktopName: string) => [{ login: '', url: '' }],
-  openRemoteDesktopTab: (username: string, desktopName: string) => {},
+  getWindowsLoginOptions: () => [{ login: '', url: '' }],
+  openRemoteDesktopTab: () => {},
 };

--- a/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.story.test.tsx
+++ b/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.story.test.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import { render } from 'design/utils/testing';
-import { Local, SSO } from './ConnectDialog.story';
+import { Local, Sso } from './ConnectDialog.story';
 
 test('kube connect dialogue local', () => {
   const { baseElement } = render(<Local />);
@@ -24,6 +24,6 @@ test('kube connect dialogue local', () => {
 });
 
 test('kube connect dialogue sso', () => {
-  const { baseElement } = render(<SSO />);
+  const { baseElement } = render(<Sso />);
   expect(baseElement).toMatchSnapshot();
 });

--- a/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.story.tsx
+++ b/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.story.tsx
@@ -32,7 +32,7 @@ export const Local = () => {
   );
 };
 
-export const SSO = () => {
+export const Sso = () => {
   return (
     <Component
       onClose={() => null}

--- a/packages/teleport/src/PlayerNext/PlayerNext.jsx
+++ b/packages/teleport/src/PlayerNext/PlayerNext.jsx
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useParams } from 'react-router';
 import React from 'react';
 import styled from 'styled-components';
 import SplitPane from 'shared/components/SplitPane';

--- a/packages/teleport/src/components/Empty/Empty.test.tsx
+++ b/packages/teleport/src/components/Empty/Empty.test.tsx
@@ -6,13 +6,15 @@ import Empty, { Props } from './Empty';
 test('empty state for enterprise or oss, with create perms', async () => {
   const { findByText } = render(<Empty {...props} />);
 
-  expect(await findByText(/ADD YOUR FIRST SERVER/i)).toBeVisible();
+  await expect(findByText(/ADD YOUR FIRST SERVER/i)).resolves.toBeVisible();
 });
 
 test('empty state for cant create or leaf cluster', async () => {
   const { findByText } = render(<Empty {...props} canCreate={false} />);
 
-  expect(await findByText(/Either there are no servers in the/i)).toBeVisible();
+  await expect(
+    findByText(/Either there are no servers in the/i)
+  ).resolves.toBeVisible();
 });
 
 const props: Props = {

--- a/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
+++ b/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
@@ -48,7 +48,7 @@ test('auth2faType: otp', () => {
   );
 
   // Rendering of mfa dropdown.
-  expect(getByTestId('mfa-select')).not.toBeEmpty();
+  expect(getByTestId('mfa-select')).not.toBeEmptyDOMElement();
 
   // fill form
   fireEvent.change(getByPlaceholderText(/username/i), {
@@ -73,7 +73,7 @@ test('auth2faType: u2f', async () => {
   );
 
   // Rendering of mfa dropdown.
-  expect(getByTestId('mfa-select')).not.toBeEmpty();
+  expect(getByTestId('mfa-select')).not.toBeEmptyDOMElement();
 
   // fill form
   fireEvent.change(getByPlaceholderText(/username/i), {
@@ -119,7 +119,7 @@ test('auth2faType: webauthn', async () => {
   );
 
   // Rendering of mfa dropdown.
-  expect(getByTestId('mfa-select')).not.toBeEmpty();
+  expect(getByTestId('mfa-select')).not.toBeEmptyDOMElement();
 
   // fill form
   fireEvent.change(getByPlaceholderText(/username/i), {

--- a/packages/teleport/src/lib/tdp/client.test.ts
+++ b/packages/teleport/src/lib/tdp/client.test.ts
@@ -10,7 +10,7 @@ test('only the first png frame causes a "connect" event to be emitted', () => {
   // Set up listener to check for connect event.
   tdpClient.on('connect', () => {
     connectEmitted = true;
-    expect(i).toEqual(0); // check only emitted on the first frame
+    expect(i).toBe(0); // check only emitted on the first frame
   });
 
   arrayBufFirst2Pngs.forEach(pngFrame => {
@@ -18,5 +18,5 @@ test('only the first png frame causes a "connect" event to be emitted', () => {
     i++;
   });
 
-  expect(connectEmitted).toEqual(true); // check that connect was emitted at all
+  expect(connectEmitted).toBe(true); // check that connect was emitted at all
 });

--- a/packages/teleport/src/lib/tdp/codec.test.ts
+++ b/packages/teleport/src/lib/tdp/codec.test.ts
@@ -157,8 +157,8 @@ test('decodes regions', () => {
   view.setUint32(13, 64);
 
   const region = codec.decodeRegion(buffer);
-  expect(region.top).toEqual(0);
-  expect(region.left).toEqual(0);
-  expect(region.bottom).toEqual(64);
-  expect(region.right).toEqual(64);
+  expect(region.top).toBe(0);
+  expect(region.left).toBe(0);
+  expect(region.bottom).toBe(64);
+  expect(region.right).toBe(64);
 });

--- a/packages/teleport/src/lib/term/protobuf.test.js
+++ b/packages/teleport/src/lib/term/protobuf.test.js
@@ -26,7 +26,7 @@ describe('lib/term/protobuf', () => {
       const array = Uint8Array.from(input);
       const msg = pb.decode(array);
 
-      expect(msg.type).toEqual('a');
+      expect(msg.type).toBe('a');
       expect(msg.payload).toEqual(
         `{"addr.local":"172.10.1.20:3022","addr.remote":"172.10.1.254:59590","event":"session.join","login":"root","namespace":"default","server_id":"75f4fc80-76c5-4372-bc61-1e665fd7ef96","sid":"cc8d05f4-69d1-11e8-a61d-0242ac0a0101","user":"mama"}`
       );
@@ -36,7 +36,7 @@ describe('lib/term/protobuf', () => {
       const input = [10, 1, 49, 18, 1, 99];
       const array = Uint8Array.from(input);
       const msg = pb.decode(array);
-      expect(msg.type).toEqual('c');
+      expect(msg.type).toBe('c');
       expect(msg.payload).toEqual(``);
     });
 
@@ -46,8 +46,8 @@ describe('lib/term/protobuf', () => {
       const array = Uint8Array.from(input);
       const msg = pb.decode(array);
 
-      expect(msg.version).toEqual('1');
-      expect(msg.type).toEqual('r');
+      expect(msg.version).toBe('1');
+      expect(msg.type).toBe('r');
       expect(msg.payload).toEqual(`[33;1mcontainer(f1ff295e4127)[0;33m ~[00m: `);
     });
   });
@@ -57,9 +57,9 @@ describe('lib/term/protobuf', () => {
       const buffer = pb.encodeRawMessage('mama');
       const array = Uint8Array.from(buffer);
       const msg = pb.decode(array);
-      expect(msg.version).toEqual('1');
-      expect(msg.type).toEqual('r');
-      expect(msg.payload).toEqual('mama');
+      expect(msg.version).toBe('1');
+      expect(msg.type).toBe('r');
+      expect(msg.payload).toBe('mama');
     });
 
     it('should encode "resize" message', () => {
@@ -67,9 +67,9 @@ describe('lib/term/protobuf', () => {
       const buffer = pb.encodeResizeMessage(payload);
       const array = Uint8Array.from(buffer);
       const msg = pb.decode(array);
-      expect(msg.version).toEqual('1');
-      expect(msg.type).toEqual('w');
-      expect(msg.payload).toEqual(payload);
+      expect(msg.version).toBe('1');
+      expect(msg.type).toBe('w');
+      expect(msg.payload).toBe(payload);
     });
   });
 });

--- a/packages/teleport/src/lib/term/ttyPlayer.test.js
+++ b/packages/teleport/src/lib/term/ttyPlayer.test.js
@@ -20,20 +20,19 @@ import EventProvider, { MAX_SIZE } from './ttyPlayerEventProvider';
 import { TermEventEnum } from 'teleport/lib/term/enums';
 import sample from './fixtures/streamData';
 
-// TODO: fixed below tests
-describe.skip('lib/term/ttyPlayer/eventProvider', () => {
-  afterEach(function() {
+describe('lib/term/ttyPlayer/eventProvider', () => {
+  afterEach(function () {
     jest.clearAllMocks();
   });
 
-  describe.skip('new()', () => {
+  describe('new()', () => {
     it('should create an instance', () => {
       const provider = new EventProvider({ url: 'sample.com' });
       expect(provider.events).toEqual([]);
     });
   });
 
-  describe.skip('init()', () => {
+  describe('init()', () => {
     it('should load events and initialize itself', async () => {
       const provider = new EventProvider({ url: 'sample.com' });
 
@@ -55,7 +54,7 @@ describe.skip('lib/term/ttyPlayer/eventProvider', () => {
     });
   });
 
-  describe.skip('_createEvents()', () => {
+  describe('_createEvents()', () => {
     it('should create event objects', () => {
       const provider = new EventProvider({ url: 'sample.com' });
       const events = provider._createEvents(sample.events);
@@ -72,12 +71,12 @@ describe.skip('lib/term/ttyPlayer/eventProvider', () => {
         msNormalized: 1744,
       };
 
-      expect(events.length).toBe(32);
+      expect(events).toHaveLength(32);
       expect(events[30]).toEqual(eventObj);
     });
   });
 
-  describe.skip('fetchContent()', () => {
+  describe('fetchContent()', () => {
     it('should fetch session content', async () => {
       const provider = new EventProvider({ url: 'sample.com' });
 
@@ -111,26 +110,26 @@ describe.skip('lib/term/ttyPlayer/eventProvider', () => {
   });
 });
 
-describe.skip('lib/ttyPlayer', () => {
+describe('lib/ttyPlayer', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe.skip('new()', () => {
+  describe('new()', () => {
     it('should create an instance', () => {
       const ttyPlayer = new TtyPlayer({ url: 'testSid' });
-      expect(ttyPlayer.isReady).toBe(false);
-      expect(ttyPlayer.isPlaying).toBe(false);
-      expect(ttyPlayer.isError).toBe(false);
-      expect(ttyPlayer.isLoading).toBe(true);
+      expect(ttyPlayer.isReady()).toBe(false);
+      expect(ttyPlayer.isPlaying()).toBe(false);
+      expect(ttyPlayer.isError()).toBe(false);
+      expect(ttyPlayer.isLoading()).toBe(true);
       expect(ttyPlayer.duration).toBe(0);
       expect(ttyPlayer.current).toBe(0);
     });
   });
 
-  describe.skip('connect()', () => {
-    it('should initialize event provider', async () => {
-      const ttyPlayer = new TtyPlayer({ url: 'testSid' });
+  describe('connect()', () => {
+    it('should connect using event provider', async () => {
+      const ttyPlayer = new TtyPlayer(new EventProvider({ url: 'testSid' }));
 
       jest.spyOn(api, 'get').mockImplementation(() => Promise.resolve(sample));
       jest
@@ -139,47 +138,43 @@ describe.skip('lib/ttyPlayer', () => {
 
       await ttyPlayer.connect();
 
-      expect(ttyPlayer.isReady).toBe(true);
+      expect(ttyPlayer.isReady()).toBe(true);
       expect(ttyPlayer.getEventCount()).toBe(32);
     });
 
-    it('should indicate its loading status', cb => {
-      const ttyPlayer = new TtyPlayer({ url: 'testSid' });
+    it('should indicate its loading status', async () => {
+      const ttyPlayer = new TtyPlayer(new EventProvider({ url: 'testSid' }));
       jest
         .spyOn(api, 'get')
         .mockImplementation(() => Promise.resolve({ events: [] }));
 
-      ttyPlayer.connect().then(() => {
-        cb();
-      });
-
-      expect(ttyPlayer.isLoading).toBe(true);
+      ttyPlayer.connect();
+      expect(ttyPlayer.isLoading()).toBe(true);
     });
 
-    it('should indicate its error status', cb => {
+    it('should indicate its error status', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
       jest.spyOn(api, 'get').mockImplementation(() => Promise.reject('!!'));
 
-      const ttyPlayer = new TtyPlayer({ url: 'testSid' });
+      const ttyPlayer = new TtyPlayer(new EventProvider({ url: 'testSid' }));
 
-      ttyPlayer.connect().finally(() => {
-        expect(ttyPlayer.isError).toBe(true);
-        cb();
-      });
+      await ttyPlayer.connect();
+      expect(ttyPlayer.isError()).toBe(true);
     });
   });
 
-  describe.skip('move()', () => {
+  describe('move()', () => {
     var tty = null;
 
     beforeEach(() => {
-      tty = new TtyPlayer({ url: 'sample.com' });
+      tty = new TtyPlayer(new EventProvider({ url: 'testSid' }));
       jest.spyOn(api, 'get').mockImplementation(() => Promise.resolve(sample));
       jest
         .spyOn(tty._eventProvider, '_fetchContent')
         .mockImplementation(() => Promise.resolve(sample.data));
     });
 
-    afterEach(function() {
+    afterEach(function () {
       jest.clearAllMocks();
     });
 
@@ -192,7 +187,7 @@ describe.skip('lib/ttyPlayer', () => {
       });
 
       tty.move();
-      expect(renderedData.length).toBe(42);
+      expect(renderedData).toHaveLength(42);
     });
 
     it('should move from 1 to 478 position (forward)', async () => {
@@ -258,17 +253,17 @@ describe.skip('lib/ttyPlayer', () => {
       });
 
       tty.move(2);
-      expect(renderedData.length).toEqual(42);
+      expect(renderedData).toHaveLength(42);
     });
 
     it('should stop playing if new position is greater than session length', async () => {
       await tty.connect();
-      tty.isPlaying = true;
+      tty.play();
 
       const someBigNumber = 20000;
       tty.move(someBigNumber);
 
-      expect(tty.isPlaying).toBe(false);
+      expect(tty.isPlaying()).toBe(false);
     });
   });
 });

--- a/packages/teleport/src/services/audit/audit.test.ts
+++ b/packages/teleport/src/services/audit/audit.test.ts
@@ -81,8 +81,8 @@ test('fetch events', async () => {
   jest.spyOn(api, 'get').mockResolvedValue(unknownEvent);
   response = await audit.fetchEvents('clusterId', params);
 
-  expect(response.events[0].codeDesc).toEqual('Unknown');
-  expect(response.events[0].message).toEqual('Unknown');
+  expect(response.events[0].codeDesc).toBe('Unknown');
+  expect(response.events[0].message).toBe('Unknown');
 });
 
 const params = {

--- a/packages/teleport/src/services/auth/auth.test.js
+++ b/packages/teleport/src/services/auth/auth.test.js
@@ -18,6 +18,8 @@ import cfg from 'teleport/config';
 import auth from 'teleport/services/auth';
 import api from 'teleport/services/api';
 
+/* eslint-disable jest/no-conditional-expect */
+
 describe('services/auth', () => {
   beforeEach(() => {
     // setup u2f mocks
@@ -95,7 +97,7 @@ describe('services/auth', () => {
       await auth.loginWithU2f(email, password);
     } catch (err) {
       expect(window.u2f.sign).toHaveBeenCalled();
-      expect(err.message).not.toBeUndefined();
+      expect(err.message).toBeDefined();
     }
     expect.assertions(2);
   });

--- a/packages/teleport/src/services/mfa/utils.test.ts
+++ b/packages/teleport/src/services/mfa/utils.test.ts
@@ -18,7 +18,7 @@ import { getMfaOptions } from './utils';
 import { Auth2faType, PreferredMfaType } from 'shared/services';
 
 describe('test retrieving mfa options', () => {
-  const tests: {
+  const testCases: {
     name: string;
     type?: Auth2faType;
     preferred?: PreferredMfaType;
@@ -78,16 +78,15 @@ describe('test retrieving mfa options', () => {
     },
   ];
 
-  tests.forEach(tc => {
-    test(`${tc.name}`, () => {
-      const vals = getMfaOptions(tc.type, tc.preferred).map(o => o.value);
-      // Order matters.
-      expect(vals).toEqual(tc.expect);
-    });
+  test.each(testCases)('$name', testCase => {
+    const mfa = getMfaOptions(testCase.type, testCase.preferred).map(
+      o => o.value
+    );
+    expect(mfa).toEqual(testCase.expect);
   });
 
   test('no "none" option if requireMfa=true', () => {
-    const vals = getMfaOptions('optional', 'webauthn', true).map(o => o.value);
-    expect(vals).toEqual(['webauthn', 'otp']);
+    const mfa = getMfaOptions('optional', 'webauthn', true).map(o => o.value);
+    expect(mfa).toEqual(['webauthn', 'otp']);
   });
 });

--- a/packages/teleport/src/useUrlQueryParams.test.tsx
+++ b/packages/teleport/src/useUrlQueryParams.test.tsx
@@ -108,7 +108,7 @@ test('toggle filter', () => {
 describe('test decoding of urls', () => {
   const enc = encodeURIComponent;
 
-  const tests: {
+  const testCases: {
     name: string;
     url: string;
     expect: Filter[];
@@ -193,22 +193,19 @@ describe('test decoding of urls', () => {
     },
   ];
 
-  // eslint-disable-next-line jest/require-hook
-  tests.forEach(tc => {
-    test(`${tc.name}`, () => {
-      let result;
-      act(() => {
-        result = renderHook(() => useUrlQueryParams(), {
-          wrapper: Wrapper,
-          wrapperProps: {
-            history: createMemoryHistory({ initialEntries: [tc.url] }),
-          },
-        });
+  test.each(testCases)('$name', testCase => {
+    let result;
+    act(() => {
+      result = renderHook(() => useUrlQueryParams(), {
+        wrapper: Wrapper,
+        wrapperProps: {
+          history: createMemoryHistory({ initialEntries: [testCase.url] }),
+        },
       });
-
-      let hook: State = result.current;
-      expect(hook.filters).toMatchObject(tc.expect);
     });
+
+    const hook: State = result.current;
+    expect(hook.filters).toMatchObject(testCase.expect);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2468,14 +2468,6 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/eslint@^7.28.2":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.29.0.tgz#e56ddc8e542815272720bb0b4ccc2aff9c3e1c78"
-  integrity sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==
-  dependencies:
-    "@types/estree" "*"
-    "@types/json-schema" "*"
-
 "@types/estree@*", "@types/estree@^0.0.50":
   version "0.0.50"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
@@ -6173,17 +6165,6 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
   integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
-eslint-webpack-plugin@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-3.1.1.tgz#83dad2395e5f572d6f4d919eedaa9cf902890fcb"
-  integrity sha512-xSucskTN9tOkfW7so4EaiFIkulWLXwCB/15H917lR6pTv0Zot6/fetFucmENRb7J5whVSFKIvwnrnsa78SG2yg==
-  dependencies:
-    "@types/eslint" "^7.28.2"
-    jest-worker "^27.3.1"
-    micromatch "^4.0.4"
-    normalize-path "^3.0.0"
-    schema-utils "^3.1.1"
-
 eslint@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.3.0.tgz#a3c2409507403c1c7f6c42926111d6cbefbc3e85"
@@ -8663,7 +8644,7 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest-worker@^27.0.6, jest-worker@^27.3.1:
+jest-worker@^27.0.6:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.3.1.tgz#0def7feae5b8042be38479799aeb7b5facac24b2"
   integrity sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==


### PR DESCRIPTION
Closes #497 
- Addressed ESLint warnings
- Enabled skipped tests
- Removed `eslint-webpack-plugin` so linting won't be performed on Webpack rebuilds. This plugin operated only files which came into a bundle, so test files weren't checked. Lining will be done as a step on CI (during `yarn build`), locally please use [ESLint plugin ](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) & `yarn lint`