### PR TITLE
Replace both `waitForElement` and `wait` with `waitFor` in tests

### DIFF
--- a/packages/design/src/Indicator/Indicator.test.js
+++ b/packages/design/src/Indicator/Indicator.test.js
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import Indicator from './Indicator';
-import { render, waitForElement, getByTestId } from 'design/utils/testing';
+import { render, waitFor, getByTestId } from 'design/utils/testing';
 
 describe('design/Indicator', () => {
   it('renders', async () => {
@@ -25,7 +25,7 @@ describe('design/Indicator', () => {
     );
     expect(container.firstChild).toBeNull();
 
-    await waitForElement(() => getByTestId(container, 'spinner'), {
+    await waitFor(() => getByTestId(container, 'spinner'), {
       container,
     });
 

--- a/packages/design/src/utils/testing.tsx
+++ b/packages/design/src/utils/testing.tsx
@@ -50,12 +50,11 @@ type RenderOptions = {
 export {
   act,
   screen,
-  waitFor as wait,  //TODO: refactor everything to use `waitFor`
   fireEvent,
   theme,
   render,
   prettyDOM,
-  waitFor as waitForElement,
+  waitFor,
   getByTestId,
   Router,
 };

--- a/packages/shared/components/FormPassword/FormPassword.test.tsx
+++ b/packages/shared/components/FormPassword/FormPassword.test.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import FormPassword from './FormPassword';
 import { On, Optional } from './FormPassword.story';
-import { render, fireEvent, wait, screen } from 'design/utils/testing';
+import { render, fireEvent, waitFor, screen } from 'design/utils/testing';
 
 jest.mock('../../libs/logger', () => {
   const mockLogger = {
@@ -53,7 +53,7 @@ test('input validation error states', async () => {
   );
 
   // test input validation error states
-  await wait(() => fireEvent.click(getByText(btnSubmitText)));
+  await waitFor(() => fireEvent.click(getByText(btnSubmitText)));
   expect(onChangePass).not.toHaveBeenCalled();
   expect(onChangePassWithU2f).not.toHaveBeenCalled();
 
@@ -86,7 +86,7 @@ test('prop auth2faType: off', async () => {
   fireEvent.change(getByPlaceholderText(placeholdConfirm), inputVal);
 
   // test the correct cb is called when submitting
-  await wait(() => fireEvent.click(getByText(btnSubmitText)));
+  await waitFor(() => fireEvent.click(getByText(btnSubmitText)));
   expect(onChangePass).toHaveBeenCalledWith(inputValText, inputValText, '');
   expect(onChangePassWithU2f).not.toHaveBeenCalled();
 
@@ -124,7 +124,7 @@ test('prop auth2faType: webauthn form with mocked error', async () => {
   fireEvent.change(getByPlaceholderText(placeholdConfirm), inputVal);
 
   // test correct cb is called
-  await wait(() => fireEvent.click(getByText(btnSubmitText)));
+  await waitFor(() => fireEvent.click(getByText(btnSubmitText)));
   expect(onChangePassWithWebauthn).toHaveBeenCalledTimes(1);
 
   // test rendering of status message after submit
@@ -149,7 +149,7 @@ test('prop auth2faType: OTP form', async () => {
   expect(screen.getByTestId('mfa-select')).not.toBeEmptyDOMElement();
 
   // test input validation error state
-  await wait(() => fireEvent.click(getByText(btnSubmitText)));
+  await waitFor(() => fireEvent.click(getByText(btnSubmitText)));
 
   // fill out form
   fireEvent.change(getByPlaceholderText(placeholdCurrPass), inputVal);
@@ -158,7 +158,7 @@ test('prop auth2faType: OTP form', async () => {
   fireEvent.change(getByPlaceholderText(/123 456/i), inputVal);
 
   // test the correct cb is called when submitting
-  await wait(() => fireEvent.click(getByText(btnSubmitText)));
+  await waitFor(() => fireEvent.click(getByText(btnSubmitText)));
   expect(onChangePass).toHaveBeenCalledWith(
     inputValText,
     inputValText,
@@ -197,7 +197,7 @@ test('prop auth2faType: U2f form with mocked error', async () => {
 
   // test U2F status message
 
-  await wait(() => {
+  await waitFor(() => {
     fireEvent.click(getByText(btnSubmitText));
     const statusMsg = getByText(
       /Insert your U2F key and press the button on the key/i

--- a/packages/shared/components/Validation/useRule.test.js
+++ b/packages/shared/components/Validation/useRule.test.js
@@ -16,11 +16,11 @@
 
 import React from 'react';
 import Validation, { useRule } from '.';
-import { render, fireEvent, wait, screen } from 'design/utils/testing';
+import { render, fireEvent, waitFor, screen } from 'design/utils/testing';
 
 test('basic usage', async () => {
   let results;
-  await wait(() => {
+  await waitFor(() => {
     results = render(<Component value="" rule={required} />);
   });
 

--- a/packages/shared/libs/stores/useStore.test.tsx
+++ b/packages/shared/libs/stores/useStore.test.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import useStore from './useStore';
 import Store from './store';
-import { render, wait } from 'design/utils/testing';
+import { render, waitFor } from 'design/utils/testing';
 
 test('components subscribes to store changes and unsubscribes on unmount', async () => {
   const store = new Store();
@@ -31,7 +31,7 @@ test('components subscribes to store changes and unsubscribes on unmount', async
 
   expect(container.innerHTML).toBe(JSON.stringify(store.state));
 
-  await wait(() => {
+  await waitFor(() => {
     store.setState({
       firstname: 'alex',
     });

--- a/packages/teleport/src/Account/ManageDevices/ManageDevices.test.tsx
+++ b/packages/teleport/src/Account/ManageDevices/ManageDevices.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { render, fireEvent, wait, screen } from 'design/utils/testing';
+import { render, fireEvent, waitFor, screen } from 'design/utils/testing';
 import { Context, ContextProvider } from 'teleport';
 import authService from 'teleport/services/auth';
 import ManageDevices from './ManageDevices';
@@ -99,7 +99,7 @@ describe('mfa device dashboard testing', () => {
   });
 
   test('re-authenticating with totp and adding a u2f device', async () => {
-    await wait(() => renderManageDevices());
+    await waitFor(() => renderManageDevices());
 
     fireEvent.click(screen.getByText(/add two-factor device/i));
 
@@ -114,7 +114,7 @@ describe('mfa device dashboard testing', () => {
     const tokenField = screen.getByPlaceholderText('123 456');
     fireEvent.change(tokenField, { target: { value: '321321' } });
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText('Continue'));
     });
 
@@ -127,7 +127,7 @@ describe('mfa device dashboard testing', () => {
     const deviceNameField = screen.getByPlaceholderText('Name');
     fireEvent.change(deviceNameField, { target: { value: 'yubikey' } });
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText('Add device'));
     });
 
@@ -140,13 +140,13 @@ describe('mfa device dashboard testing', () => {
   });
 
   test('re-authenticating with u2f and adding a totp device', async () => {
-    await wait(() => renderManageDevices());
+    await waitFor(() => renderManageDevices());
 
     fireEvent.click(screen.getByText(/add two-factor device/i));
 
     expect(screen.getByText('Verify your identity')).toBeInTheDocument();
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText('Continue'));
     });
 
@@ -166,7 +166,7 @@ describe('mfa device dashboard testing', () => {
     const deviceNameField = screen.getByPlaceholderText('Name');
     fireEvent.change(deviceNameField, { target: { value: 'iphone 12' } });
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText('Add device'));
     });
 
@@ -181,13 +181,13 @@ describe('mfa device dashboard testing', () => {
 
   test('re-authenticating with webauthn and adding a totp device', async () => {
     jest.spyOn(cfg, 'getPreferredMfaType').mockReturnValue('webauthn');
-    await wait(() => renderManageDevices());
+    await waitFor(() => renderManageDevices());
 
     fireEvent.click(screen.getByText(/add two-factor device/i));
 
     expect(screen.getByText('Verify your identity')).toBeInTheDocument();
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText('Continue'));
     });
 
@@ -207,7 +207,7 @@ describe('mfa device dashboard testing', () => {
     const deviceNameField = screen.getByPlaceholderText('Name');
     fireEvent.change(deviceNameField, { target: { value: 'iphone 12' } });
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText('Add device'));
     });
 
@@ -223,9 +223,9 @@ describe('mfa device dashboard testing', () => {
   test('adding a first device', async () => {
     jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([]);
 
-    await wait(() => renderManageDevices());
+    await waitFor(() => renderManageDevices());
 
-    await wait(() =>
+    await waitFor(() =>
       fireEvent.click(screen.getByText(/add two-factor device/i))
     );
 
@@ -236,7 +236,7 @@ describe('mfa device dashboard testing', () => {
     const deviceNameField = screen.getByPlaceholderText('Name');
     fireEvent.change(deviceNameField, { target: { value: 'yubikey' } });
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText('Add device'));
     });
 
@@ -249,13 +249,13 @@ describe('mfa device dashboard testing', () => {
   });
 
   test('removing a device', async () => {
-    await wait(() => renderManageDevices());
+    await waitFor(() => renderManageDevices());
 
     fireEvent.click(screen.getAllByText(/remove/i)[0]);
 
     expect(screen.getByText('Verify your identity')).toBeInTheDocument();
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText('Continue'));
     });
 
@@ -265,7 +265,7 @@ describe('mfa device dashboard testing', () => {
       screen.getByText(/Are you sure you want to remove device/i)
     ).toBeInTheDocument();
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getAllByText('Remove')[2]);
     });
 

--- a/packages/teleport/src/Clusters/Clusters.story.test.tsx
+++ b/packages/teleport/src/Clusters/Clusters.story.test.tsx
@@ -16,11 +16,11 @@ limitations under the License.
 
 import React from 'react';
 import { Story, createContext } from './Clusters.story';
-import { render, waitForElement } from 'design/utils/testing';
+import { render, waitFor } from 'design/utils/testing';
 
 test('render clusters', async () => {
   const ctx = createContext();
   const { container } = render(<Story value={ctx} />);
-  await waitForElement(() => document.querySelector('table'));
+  await waitFor(() => document.querySelector('table'));
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import { Document, createContext } from './DocumentNodes.story';
-import { wait, render } from 'design/utils/testing';
+import { waitFor, render } from 'design/utils/testing';
 
 test('render DocumentNodes', async () => {
   const ctx = createContext();
@@ -24,7 +24,7 @@ test('render DocumentNodes', async () => {
   jest.spyOn(ctx, 'fetchNodes');
 
   const { container } = render(<Document value={ctx} />);
-  await wait(() => expect(ctx.fetchClusters).toHaveBeenCalledTimes(1));
-  await wait(() => expect(ctx.fetchNodes).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(ctx.fetchClusters).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(ctx.fetchNodes).toHaveBeenCalledTimes(1));
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/packages/teleport/src/Login/Login.test.tsx
+++ b/packages/teleport/src/Login/Login.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent, wait, screen } from 'design/utils/testing';
+import { render, fireEvent, waitFor, screen } from 'design/utils/testing';
 import auth from 'teleport/services/auth/auth';
 import history from 'teleport/services/history';
 import cfg from 'teleport/config';
@@ -51,7 +51,7 @@ test('login with username and password', async () => {
   fireEvent.change(password, { target: { value: '123' } });
 
   // test login pathways
-  await wait(() => fireEvent.click(getByText(/login/i)));
+  await waitFor(() => fireEvent.click(getByText(/login/i)));
   expect(auth.login).toHaveBeenCalledWith('username', '123', '');
   expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
 });
@@ -73,7 +73,7 @@ test('login with password and u2f', async () => {
   fireEvent.change(password, { target: { value: '123' } });
 
   // test login pathways
-  await wait(() => fireEvent.click(getByText(/login/i)));
+  await waitFor(() => fireEvent.click(getByText(/login/i)));
   expect(auth.loginWithU2f).toHaveBeenCalledWith('username', '123');
   expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
 });
@@ -99,7 +99,7 @@ test('login with password and otp', async () => {
   const token = screen.getByPlaceholderText('123 456');
   fireEvent.change(token, { target: { value: '0' } });
 
-  await wait(() => fireEvent.click(screen.getByText(/login/i)));
+  await waitFor(() => fireEvent.click(screen.getByText(/login/i)));
   expect(auth.login).toHaveBeenCalledWith('username', '123', '0');
   expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
 });
@@ -121,7 +121,7 @@ test('login with password and webauthn', async () => {
   fireEvent.change(password, { target: { value: '123' } });
 
   // test login pathways
-  await wait(() => fireEvent.click(getByText(/login/i)));
+  await waitFor(() => fireEvent.click(getByText(/login/i)));
   expect(auth.loginWithWebauthn).toHaveBeenCalledWith('username', '123');
   expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
 });
@@ -166,7 +166,7 @@ test('login with 2fa set to "optional", select option: none', async () => {
   fireEvent.change(username, { target: { value: 'username' } });
   fireEvent.change(password, { target: { value: '123' } });
 
-  await wait(() => fireEvent.click(screen.getByText(/login/i)));
+  await waitFor(() => fireEvent.click(screen.getByText(/login/i)));
   expect(auth.login).toHaveBeenCalledWith('username', '123', '');
 });
 

--- a/packages/teleport/src/Recordings/Recordings.story.test.tsx
+++ b/packages/teleport/src/Recordings/Recordings.story.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Loaded } from './Recordings.story';
-import { render, waitForElement } from 'design/utils/testing';
+import { render, waitFor } from 'design/utils/testing';
 
 test('rendering of Session Recordings', async () => {
   const { container } = render(<Loaded />);
 
-  await waitForElement(() => document.querySelector('table'));
+  await waitFor(() => document.querySelector('table'));
   expect(container).toMatchSnapshot();
 });

--- a/packages/teleport/src/Welcome/Welcome.test.tsx
+++ b/packages/teleport/src/Welcome/Welcome.test.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 import { MemoryRouter, Route, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
-import { screen, fireEvent, act, render, wait } from 'design/utils/testing';
+import { screen, fireEvent, act, render, waitFor } from 'design/utils/testing';
 import { Logger } from 'shared/libs/logger';
 import cfg from 'teleport/config';
 import history from 'teleport/services/history';
@@ -65,7 +65,7 @@ describe('teleport/components/Welcome', () => {
 
     expect(auth.fetchPasswordToken).not.toHaveBeenCalled();
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText(/get started/i));
       mockHistory.push(inviteContinuePath);
     });
@@ -99,7 +99,7 @@ describe('teleport/components/Welcome', () => {
 
     expect(auth.fetchPasswordToken).not.toHaveBeenCalled();
 
-    await wait(() => {
+    await waitFor(() => {
       fireEvent.click(screen.getByText(/Continue/i));
       mockHistory.push(resetContinuePath);
     });

--- a/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
+++ b/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import FormLogin, { Props } from './FormLogin';
-import { render, fireEvent, wait } from 'design/utils/testing';
+import { render, fireEvent, waitFor } from 'design/utils/testing';
 
 test('auth2faType: off', () => {
   const onLogin = jest.fn();
@@ -150,7 +150,7 @@ test('input validation error handling', async () => {
     />
   );
 
-  await wait(() => {
+  await waitFor(() => {
     fireEvent.click(getByText(/login/i));
   });
 


### PR DESCRIPTION
`waitForElement` and `wait` have been removed from the `@testing-library` after version update.
These functions were re-exported by `design/utils/testing`, but in order to have the same API as `@testing-library` I'm replacing them with `waitFor`.
