### PR TITLE
Add error message for failed SSO authorization

### DIFF
--- a/packages/teleport/src/Login/LoginFailed.tsx
+++ b/packages/teleport/src/Login/LoginFailed.tsx
@@ -26,6 +26,9 @@ export default function Container() {
       <Route path={cfg.routes.loginErrorCallback}>
         <LoginFailed message="unable to process callback" />
       </Route>
+      <Route path={cfg.routes.loginErrorUnauthorized}>
+        <LoginFailed message="You are not authorized, please contact your SSO administrator." />
+      </Route>
       <Route component={LoginFailed} />
     </Switch>
   );

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -71,6 +71,7 @@ const cfg = {
     loginErrorLegacy: '/web/msg/error/login_failed',
     loginError: '/web/msg/error/login',
     loginErrorCallback: '/web/msg/error/login/callback',
+    loginErrorUnauthorized: '/web/msg/error/login/auth',
     userInvite: '/web/invite/:tokenId',
     userInviteContinue: '/web/invite/:tokenId/continue',
     userReset: '/web/reset/:tokenId',
@@ -89,7 +90,8 @@ const cfg = {
     clustersPath: '/v1/webapi/sites',
     clusterEventsPath: `/v1/webapi/sites/:clusterId/events/search?from=:start?&to=:end?&limit=:limit?&startKey=:startKey?&include=:include?`,
     clusterEventsRecordingsPath: `/v1/webapi/sites/:clusterId/events/search/sessions?from=:start?&to=:end?&limit=:limit?&startKey=:startKey?`,
-    scp: '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
+    scp:
+      '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
     renewTokenPath: '/v1/webapi/sessions/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
     sessionPath: '/v1/webapi/sessions',


### PR DESCRIPTION
This PR adds a new error message for when a user successfully authenticates with SSO but fails to match any roles.

Part of gravitational/teleport#6409.