### PR TITLE
Improve the PNG rendering process

### DIFF
--- a/packages/teleport/src/components/TdpClientCanvas/TdpClientCanvas.tsx
+++ b/packages/teleport/src/components/TdpClientCanvas/TdpClientCanvas.tsx
@@ -55,6 +55,7 @@ export default function TdpClientCanvas(props: Props) {
         if (buffer.length) {
           for (let i = 0; i < buffer.length; i++) {
             tdpCliOnImageFragment(ctx, buffer[i]);
+            buffer[i].image.close()
           }
           buffer = [];
         }

--- a/packages/teleport/src/lib/tdp/client.ts
+++ b/packages/teleport/src/lib/tdp/client.ts
@@ -97,10 +97,9 @@ export default class Client extends EventEmitter {
   // bounds and png bitmap and emit a render event.
   processFrame(buffer: ArrayBuffer) {
     const { left, top } = this.codec.decodeRegion(buffer);
-    const image = new Image();
-    image.onload = () =>
-      this.emit(TdpClientEvent.IMAGE_FRAGMENT, { image, left, top });
-    image.src = this.codec.decodePng(buffer);
+    createImageBitmap(new Blob([buffer.slice(17)], { type: 'image/png' })).then(image => {
+      this.emit(TdpClientEvent.IMAGE_FRAGMENT, { image, left, top })
+    })
   }
 
   sendUsername(username: string) {
@@ -147,7 +146,7 @@ export default class Client extends EventEmitter {
 }
 
 export type ImageFragment = {
-  image: HTMLImageElement;
+  image: ImageBitmap;
   left: number;
   top: number;
 };

--- a/packages/teleport/src/lib/tdp/codec.ts
+++ b/packages/teleport/src/lib/tdp/codec.ts
@@ -338,16 +338,4 @@ export default class Codec {
       bottom: dv.getUint32(13),
     };
   }
-
-  // Taken as the winning algorithm of https://jsbench.me/vjk9nczxst/1
-  // jsbench link was discovered in https://gist.github.com/jonleighton/958841
-  toBase64(buffer: ArrayBuffer) {
-    const binary = String.fromCharCode.apply(null, new Uint8Array(buffer, 17));
-    return btoa(binary);
-  }
-
-  // decodePng creates a data:image uri from the png data part of a PNG_FRAME tdp message.
-  decodePng(buffer: ArrayBuffer): string {
-    return `data:image/png;base64,${this.toBase64(buffer)}`;
-  }
 }


### PR DESCRIPTION
Prior to this, for each PNG (there are lots!) we would:

- create a new `<img>` element in the document
- convert the PNG data from raw bytes to a base64-encoded string,
  which allocates a second (even larger) copy of the data we
  already have
- tell the `<img>` element to render the PNG data and then draw the
  `<img>` element on the canvas

Instead of wasting cycles converting the data to a string just so
that the browser can decode it a moment later, we generate a bitmap
with a raw bytes and draw it directly to the canvas, also bypassing
the need for an `<img>` element for each PNG.