### PR TITLE
Table V2 Tweaks

### DIFF
--- a/packages/design/src/DataTableNext/Cells.tsx
+++ b/packages/design/src/DataTableNext/Cells.tsx
@@ -33,7 +33,7 @@ export const SortIndicator = ({
   return <Icons.Sort />;
 };
 
-export const TextCell = ({ data }) => <Cell>{`${data}`}</Cell>;
+export const TextCell = ({ data }) => <Cell>{`${data || ''}`}</Cell>;
 
 export const LabelCell = ({ data }: { data: string[] }) =>
   renderLabelCell(data);

--- a/packages/design/src/DataTableNext/StyledTable.tsx
+++ b/packages/design/src/DataTableNext/StyledTable.tsx
@@ -46,6 +46,10 @@ export const StyledTable = styled.table(
     }
   }
 
+  & > tbody > tr > td {
+    vertical-align: baseline;
+  }
+
   & > thead > tr > th {
     background: ${props.theme.colors.primary.dark};
     color: ${props.theme.colors.primary.contrastText};

--- a/packages/design/src/DataTableNext/Table.tsx
+++ b/packages/design/src/DataTableNext/Table.tsx
@@ -24,6 +24,7 @@ export function Table<T>({
   isSearchable,
   fetching,
   className,
+  style,
 }: State<T>) {
   const renderHeaders = () => {
     const headers = columns.map(column => {
@@ -82,6 +83,7 @@ export function Table<T>({
   if (state.pagination) {
     return (
       <PagedTable
+        style={style}
         className={className}
         data={state.data}
         renderHeaders={renderHeaders}
@@ -99,6 +101,7 @@ export function Table<T>({
   if (isSearchable) {
     return (
       <SearchableBasicTable
+        style={style}
         className={className}
         data={state.data}
         renderHeaders={renderHeaders}
@@ -111,6 +114,7 @@ export function Table<T>({
 
   return (
     <BasicTable
+      style={style}
       className={className}
       data={state.data}
       renderHeaders={renderHeaders}
@@ -124,9 +128,10 @@ function BasicTable<T>({
   renderHeaders,
   renderBody,
   className,
+  style,
 }: BasicTableProps<T>) {
   return (
-    <StyledTable className={className}>
+    <StyledTable className={className} style={style}>
       {renderHeaders()}
       {renderBody(data)}
     </StyledTable>
@@ -140,6 +145,7 @@ function SearchableBasicTable<T>({
   searchValue,
   setSearchValue,
   className,
+  style,
 }: SearchableBasicTableProps<T>) {
   return (
     <>
@@ -153,6 +159,7 @@ function SearchableBasicTable<T>({
         className={className}
         borderTopLeftRadius={0}
         borderTopRightRadius={0}
+        style={style}
       >
         {renderHeaders()}
         {renderBody(data)}
@@ -172,6 +179,7 @@ function PagedTable<T>({
   setSearchValue,
   fetching,
   className,
+  style,
 }: PagedTableProps<T>) {
   const { pagerPosition, paginatedData, currentPage } = pagination;
   const isTopPager = pagerPosition === 'top';
@@ -207,7 +215,7 @@ function PagedTable<T>({
           />
         </StyledPanel>
       )}
-      <StyledTable {...radiusProps} className={className}>
+      <StyledTable {...radiusProps} className={className} style={style}>
         {renderHeaders()}
         {renderBody(paginatedData[currentPage])}
       </StyledTable>
@@ -258,6 +266,7 @@ type BasicTableProps<T> = {
   renderHeaders: () => JSX.Element;
   renderBody: (data: T[]) => JSX.Element;
   className?: string;
+  style?: React.CSSProperties;
 };
 
 type SearchableBasicTableProps<T> = BasicTableProps<T> & {

--- a/packages/design/src/DataTableNext/Table.tsx
+++ b/packages/design/src/DataTableNext/Table.tsx
@@ -23,6 +23,7 @@ export function Table<T>({
   setSearchValue,
   isSearchable,
   fetching,
+  className,
 }: State<T>) {
   const renderHeaders = () => {
     const headers = columns.map(column => {
@@ -81,6 +82,7 @@ export function Table<T>({
   if (state.pagination) {
     return (
       <PagedTable
+        className={className}
         data={state.data}
         renderHeaders={renderHeaders}
         renderBody={renderBody}
@@ -97,6 +99,7 @@ export function Table<T>({
   if (isSearchable) {
     return (
       <SearchableBasicTable
+        className={className}
         data={state.data}
         renderHeaders={renderHeaders}
         renderBody={renderBody}
@@ -108,6 +111,7 @@ export function Table<T>({
 
   return (
     <BasicTable
+      className={className}
       data={state.data}
       renderHeaders={renderHeaders}
       renderBody={renderBody}
@@ -119,9 +123,10 @@ function BasicTable<T>({
   data,
   renderHeaders,
   renderBody,
+  className,
 }: BasicTableProps<T>) {
   return (
-    <StyledTable>
+    <StyledTable className={className}>
       {renderHeaders()}
       {renderBody(data)}
     </StyledTable>
@@ -134,6 +139,7 @@ function SearchableBasicTable<T>({
   renderBody,
   searchValue,
   setSearchValue,
+  className,
 }: SearchableBasicTableProps<T>) {
   return (
     <>
@@ -143,7 +149,11 @@ function SearchableBasicTable<T>({
           setSearchValue={setSearchValue}
         />
       </StyledPanel>
-      <StyledTable borderTopLeftRadius={0} borderTopRightRadius={0}>
+      <StyledTable
+        className={className}
+        borderTopLeftRadius={0}
+        borderTopRightRadius={0}
+      >
         {renderHeaders()}
         {renderBody(data)}
       </StyledTable>
@@ -161,6 +171,7 @@ function PagedTable<T>({
   searchValue,
   setSearchValue,
   fetching,
+  className,
 }: PagedTableProps<T>) {
   const { pagerPosition, paginatedData, currentPage } = pagination;
   const isTopPager = pagerPosition === 'top';
@@ -196,7 +207,7 @@ function PagedTable<T>({
           />
         </StyledPanel>
       )}
-      <StyledTable {...radiusProps}>
+      <StyledTable {...radiusProps} className={className}>
         {renderHeaders()}
         {renderBody(paginatedData[currentPage])}
       </StyledTable>
@@ -246,6 +257,7 @@ type BasicTableProps<T> = {
   data: T[];
   renderHeaders: () => JSX.Element;
   renderBody: (data: T[]) => JSX.Element;
+  className?: string;
 };
 
 type SearchableBasicTableProps<T> = BasicTableProps<T> & {

--- a/packages/design/src/DataTableNext/types.ts
+++ b/packages/design/src/DataTableNext/types.ts
@@ -7,6 +7,7 @@ export type TableProps<T> = {
   initialSort?: InitialSort<T>;
   fetching?: FetchingConfig;
   showFirst?: (data: T[]) => T;
+  className?: string;
 };
 
 type TableColumnBase<T> = {

--- a/packages/design/src/DataTableNext/types.ts
+++ b/packages/design/src/DataTableNext/types.ts
@@ -8,6 +8,7 @@ export type TableProps<T> = {
   fetching?: FetchingConfig;
   showFirst?: (data: T[]) => T;
   className?: string;
+  style?: React.CSSProperties;
 };
 
 type TableColumnBase<T> = {

--- a/packages/design/src/DataTableNext/useTable.ts
+++ b/packages/design/src/DataTableNext/useTable.ts
@@ -187,4 +187,5 @@ export type State<T> = Omit<
   'columns' | 'initialSort'
 > & {
   columns: TableColumn<T>[];
+  className?: string;
 };

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -783,6 +783,10 @@ exports[`loaded state 1`] = `
   padding-right: 24px;
 }
 
+.c12 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c12 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -529,7 +529,7 @@ exports[`loaded state 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c17 {
+.c18 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -558,22 +558,22 @@ exports[`loaded state 1`] = `
   width: 88px;
 }
 
-.c17:active {
+.c18:active {
   opacity: 0.56;
 }
 
-.c17:hover,
-.c17:focus {
+.c18:hover,
+.c18:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c17:active {
+.c18:active {
   opacity: 0.24;
 }
 
-.c17:disabled {
+.c18:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -585,20 +585,20 @@ exports[`loaded state 1`] = `
   font-size: 16px;
 }
 
-.c13 {
+.c14 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c15 {
+.c16 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
   font-size: 22px;
 }
 
-.c18 {
+.c19 {
   display: inline-block;
   transition: color .3s;
   margin-left: 4px;
@@ -606,7 +606,7 @@ exports[`loaded state 1`] = `
   font-size: 14px;
 }
 
-.c16 {
+.c17 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -634,7 +634,7 @@ exports[`loaded state 1`] = `
   color: #FFFFFF;
 }
 
-.c20 {
+.c21 {
   overflow: hidden;
   text-overflow: ellipsis;
   text-transform: uppercase;
@@ -656,7 +656,7 @@ exports[`loaded state 1`] = `
   align-items: center;
 }
 
-.c21 {
+.c22 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -667,7 +667,7 @@ exports[`loaded state 1`] = `
   justify-content: center;
 }
 
-.c22 {
+.c23 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -678,7 +678,7 @@ exports[`loaded state 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c20 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -689,7 +689,7 @@ exports[`loaded state 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c15 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -889,6 +889,10 @@ exports[`loaded state 1`] = `
   font-size: 12px;
 }
 
+.c13 > tbody > tr > td {
+  vertical-align: middle;
+}
+
 <div>
   <div
     class="c0"
@@ -969,7 +973,7 @@ exports[`loaded state 1`] = `
       </div>
     </nav>
     <table
-      class="c12"
+      class="c12 c13"
     >
       <thead>
         <tr>
@@ -978,7 +982,7 @@ exports[`loaded state 1`] = `
             <a>
               Name
               <span
-                class="c10 c13 icon icon-chevron-up "
+                class="c10 c14 icon icon-chevron-up "
                 color="light"
               />
             </a>
@@ -987,7 +991,7 @@ exports[`loaded state 1`] = `
             <a>
               Description
               <span
-                class="c10 c13 icon icon-chevrons-expand-vertical "
+                class="c10 c14 icon icon-chevrons-expand-vertical "
                 color="light"
               />
             </a>
@@ -996,7 +1000,7 @@ exports[`loaded state 1`] = `
             <a>
               Address
               <span
-                class="c10 c13 icon icon-chevrons-expand-vertical "
+                class="c10 c14 icon icon-chevrons-expand-vertical "
                 color="light"
               />
             </a>
@@ -1013,12 +1017,12 @@ exports[`loaded state 1`] = `
             style="user-select: none;"
           >
             <div
-              class="c14"
+              class="c15"
               height="32px"
               width="32px"
             >
               <span
-                class="c10 c15 icon icon-amazonaws "
+                class="c10 c16 icon icon-amazonaws "
                 color="light"
                 font-size="6"
               />
@@ -1036,19 +1040,19 @@ exports[`loaded state 1`] = `
           </td>
           <td>
             <div
-              class="c16"
+              class="c17"
               kind="secondary"
             >
               aws_account_id: A1234
             </div>
             <div
-              class="c16"
+              class="c17"
               kind="secondary"
             >
               env: dev
             </div>
             <div
-              class="c16"
+              class="c17"
               kind="secondary"
             >
               cluster: two
@@ -1058,13 +1062,13 @@ exports[`loaded state 1`] = `
             align="right"
           >
             <button
-              class="c17"
+              class="c18"
               kind="border"
               width="88px"
             >
               LAUNCH
               <span
-                class="c10 c18 icon icon-caret-down "
+                class="c10 c19 icon icon-caret-down "
                 color="text.secondary"
                 font-size="2"
               />
@@ -1076,12 +1080,12 @@ exports[`loaded state 1`] = `
             style="user-select: none;"
           >
             <div
-              class="c19"
+              class="c20"
               height="32px"
               width="32px"
             >
               <div
-                class="c20"
+                class="c21"
                 font-size="3"
               >
                 G
@@ -1100,13 +1104,13 @@ exports[`loaded state 1`] = `
           </td>
           <td>
             <div
-              class="c16"
+              class="c17"
               kind="secondary"
             >
               env: dev
             </div>
             <div
-              class="c16"
+              class="c17"
               kind="secondary"
             >
               cluster: one
@@ -1116,64 +1120,8 @@ exports[`loaded state 1`] = `
             align="right"
           >
             <a
-              class="c17"
+              class="c18"
               href="/web/launch/grafana.one/one/grafana.teleport-proxy.com"
-              kind="border"
-              rel="noreferrer"
-              target="_blank"
-              width="88px"
-            >
-              LAUNCH
-            </a>
-          </td>
-        </tr>
-        <tr>
-          <td
-            style="user-select: none;"
-          >
-            <div
-              class="c21"
-              height="32px"
-              width="32px"
-            >
-              <div
-                class="c20"
-                font-size="3"
-              >
-                J
-              </div>
-            </div>
-          </td>
-          <td>
-            Jenkins
-          </td>
-          <td>
-            This is a Jenkins app
-          </td>
-          <td>
-            https://
-            jenkins.teleport-proxy.com
-          </td>
-          <td>
-            <div
-              class="c16"
-              kind="secondary"
-            >
-              env: prod
-            </div>
-            <div
-              class="c16"
-              kind="secondary"
-            >
-              cluster: one
-            </div>
-          </td>
-          <td
-            align="right"
-          >
-            <a
-              class="c17"
-              href="/web/launch/jenkins.one/one/jenkins.teleport-proxy.com"
               kind="border"
               rel="noreferrer"
               target="_blank"
@@ -1193,7 +1141,63 @@ exports[`loaded state 1`] = `
               width="32px"
             >
               <div
-                class="c20"
+                class="c21"
+                font-size="3"
+              >
+                J
+              </div>
+            </div>
+          </td>
+          <td>
+            Jenkins
+          </td>
+          <td>
+            This is a Jenkins app
+          </td>
+          <td>
+            https://
+            jenkins.teleport-proxy.com
+          </td>
+          <td>
+            <div
+              class="c17"
+              kind="secondary"
+            >
+              env: prod
+            </div>
+            <div
+              class="c17"
+              kind="secondary"
+            >
+              cluster: one
+            </div>
+          </td>
+          <td
+            align="right"
+          >
+            <a
+              class="c18"
+              href="/web/launch/jenkins.one/one/jenkins.teleport-proxy.com"
+              kind="border"
+              rel="noreferrer"
+              target="_blank"
+              width="88px"
+            >
+              LAUNCH
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td
+            style="user-select: none;"
+          >
+            <div
+              class="c23"
+              height="32px"
+              width="32px"
+            >
+              <div
+                class="c21"
                 font-size="3"
               >
                 M
@@ -1212,13 +1216,13 @@ exports[`loaded state 1`] = `
           </td>
           <td>
             <div
-              class="c16"
+              class="c17"
               kind="secondary"
             >
               env: dev
             </div>
             <div
-              class="c16"
+              class="c17"
               kind="secondary"
             >
               cluster: two
@@ -1228,7 +1232,7 @@ exports[`loaded state 1`] = `
             align="right"
           >
             <a
-              class="c17"
+              class="c18"
               href="/web/launch/mattermost.one/one/mattermost.teleport-proxy.com"
               kind="border"
               rel="noreferrer"

--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -138,6 +138,10 @@ exports[`list of all events 1`] = `
   padding-right: 24px;
 }
 
+.c9 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c9 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
@@ -2687,6 +2691,10 @@ exports[`loaded audit log screen 1`] = `
 .c13 > tbody > tr > td:last-child,
 .c13 > tfoot > tr > td:last-child {
   padding-right: 24px;
+}
+
+.c13 > tbody > tr > td {
+  vertical-align: baseline;
 }
 
 .c13 > thead > tr > th {

--- a/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`render clusters 1`] = `
-.c14 {
+.c15 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -30,22 +30,22 @@ exports[`render clusters 1`] = `
   height: 24px;
 }
 
-.c14:active {
+.c15:active {
   opacity: 0.56;
 }
 
-.c14:hover,
-.c14:focus {
+.c15:hover,
+.c15:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c14:active {
+.c15:active {
   opacity: 0.24;
 }
 
-.c14:disabled {
+.c15:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -57,13 +57,13 @@ exports[`render clusters 1`] = `
   font-size: 16px;
 }
 
-.c12 {
+.c13 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c15 {
+.c16 {
   display: inline-block;
   transition: color .3s;
   margin-left: 8px;
@@ -72,7 +72,7 @@ exports[`render clusters 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c14 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -192,6 +192,10 @@ exports[`render clusters 1`] = `
   padding-right: 24px;
 }
 
+.c11 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c11 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
@@ -298,6 +302,10 @@ exports[`render clusters 1`] = `
   font-size: 12px;
 }
 
+.c12 td {
+  height: 22px;
+}
+
 <div
   class="c0"
 >
@@ -369,7 +377,7 @@ exports[`render clusters 1`] = `
     </div>
   </nav>
   <table
-    class="c11"
+    class="c11 c12"
   >
     <thead>
       <tr>
@@ -378,7 +386,7 @@ exports[`render clusters 1`] = `
           <a>
             Name
             <span
-              class="c9 c12 icon icon-chevron-up "
+              class="c9 c13 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -392,7 +400,7 @@ exports[`render clusters 1`] = `
           style="width: 40px;"
         >
           <div
-            class="c13"
+            class="c14"
             kind="primary"
           >
             ROOT
@@ -405,13 +413,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -429,13 +437,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -453,13 +461,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -477,13 +485,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -501,13 +509,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -525,13 +533,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -549,13 +557,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -573,13 +581,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -597,13 +605,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -621,13 +629,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -645,13 +653,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -669,13 +677,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -693,13 +701,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -717,13 +725,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -741,13 +749,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -765,13 +773,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -789,13 +797,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -813,13 +821,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -837,13 +845,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -861,13 +869,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -885,13 +893,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -909,13 +917,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -933,13 +941,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -957,13 +965,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -981,13 +989,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1005,13 +1013,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1029,13 +1037,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1053,13 +1061,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1077,13 +1085,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1101,13 +1109,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1125,13 +1133,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1149,13 +1157,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1173,13 +1181,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1197,13 +1205,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1221,13 +1229,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1245,13 +1253,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1269,13 +1277,13 @@ exports[`render clusters 1`] = `
           align="right"
         >
           <button
-            class="c14"
+            class="c15"
             height="24px"
             kind="border"
           >
             OPTIONS
             <span
-              class="c9 c15 icon icon-caret-down "
+              class="c9 c16 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />

--- a/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`render DocumentNodes 1`] = `
   width: 336px;
 }
 
-.c22 {
+.c23 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -36,22 +36,22 @@ exports[`render DocumentNodes 1`] = `
   height: 24px;
 }
 
-.c22:active {
+.c23:active {
   opacity: 0.56;
 }
 
-.c22:hover,
-.c22:focus {
+.c23:hover,
+.c23:focus {
   background: #092F52;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c22:active {
+.c23:active {
   opacity: 0.24;
 }
 
-.c22:disabled {
+.c23:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -63,13 +63,13 @@ exports[`render DocumentNodes 1`] = `
   font-size: 16px;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c23 {
+.c24 {
   display: inline-block;
   transition: color .3s;
   margin-left: 8px;
@@ -78,7 +78,7 @@ exports[`render DocumentNodes 1`] = `
   font-size: 14px;
 }
 
-.c21 {
+.c22 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -298,6 +298,10 @@ exports[`render DocumentNodes 1`] = `
 .c12::placeholder {
   color: rgba(255,255,255,0.24);
   font-size: 12px;
+}
+
+.c20 > tbody > tr > td {
+  vertical-align: baseline;
 }
 
 .c8 {
@@ -803,7 +807,7 @@ exports[`render DocumentNodes 1`] = `
         </div>
       </nav>
       <table
-        class="c19"
+        class="c19 c20"
       >
         <thead>
           <tr>
@@ -811,7 +815,7 @@ exports[`render DocumentNodes 1`] = `
               <a>
                 Hostname
                 <span
-                  class="c17 c20 icon icon-chevron-up "
+                  class="c17 c21 icon icon-chevron-up "
                   color="light"
                 />
               </a>
@@ -820,7 +824,7 @@ exports[`render DocumentNodes 1`] = `
               <a>
                 Address
                 <span
-                  class="c17 c20 icon icon-chevrons-expand-vertical "
+                  class="c17 c21 icon icon-chevrons-expand-vertical "
                   color="light"
                 />
               </a>
@@ -846,13 +850,13 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -862,13 +866,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c22"
+                class="c23"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c23 icon icon-caret-down "
+                  class="c17 c24 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -884,13 +888,13 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -900,13 +904,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c22"
+                class="c23"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c23 icon icon-caret-down "
+                  class="c17 c24 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -922,13 +926,13 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -938,13 +942,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c22"
+                class="c23"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c23 icon icon-caret-down "
+                  class="c17 c24 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -965,13 +969,13 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -981,13 +985,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c22"
+                class="c23"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c23 icon icon-caret-down "
+                  class="c17 c24 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -1003,37 +1007,37 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 lortavma: one
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 lenisret: 4.15.0-51-generic
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 lofdevod: one
               </div>
               <div
-                class="c21"
+                class="c22"
                 kind="secondary"
               >
                 llhurlaz: 4.15.0-51-generic
@@ -1043,13 +1047,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c22"
+                class="c23"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c23 icon icon-caret-down "
+                  class="c17 c24 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />

--- a/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`render DocumentNodes 1`] = `
   width: 336px;
 }
 
-.c23 {
+.c22 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -36,22 +36,22 @@ exports[`render DocumentNodes 1`] = `
   height: 24px;
 }
 
-.c23:active {
+.c22:active {
   opacity: 0.56;
 }
 
-.c23:hover,
-.c23:focus {
+.c22:hover,
+.c22:focus {
   background: #092F52;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c23:active {
+.c22:active {
   opacity: 0.24;
 }
 
-.c23:disabled {
+.c22:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -63,13 +63,13 @@ exports[`render DocumentNodes 1`] = `
   font-size: 16px;
 }
 
-.c21 {
+.c20 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   transition: color .3s;
   margin-left: 8px;
@@ -78,7 +78,7 @@ exports[`render DocumentNodes 1`] = `
   font-size: 14px;
 }
 
-.c22 {
+.c21 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -194,6 +194,10 @@ exports[`render DocumentNodes 1`] = `
   padding-right: 24px;
 }
 
+.c19 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c19 > thead > tr > th {
   background: #01172C;
   color: #FFFFFF;
@@ -298,10 +302,6 @@ exports[`render DocumentNodes 1`] = `
 .c12::placeholder {
   color: rgba(255,255,255,0.24);
   font-size: 12px;
-}
-
-.c20 > tbody > tr > td {
-  vertical-align: baseline;
 }
 
 .c8 {
@@ -807,7 +807,7 @@ exports[`render DocumentNodes 1`] = `
         </div>
       </nav>
       <table
-        class="c19 c20"
+        class="c19"
       >
         <thead>
           <tr>
@@ -815,7 +815,7 @@ exports[`render DocumentNodes 1`] = `
               <a>
                 Hostname
                 <span
-                  class="c17 c21 icon icon-chevron-up "
+                  class="c17 c20 icon icon-chevron-up "
                   color="light"
                 />
               </a>
@@ -824,7 +824,7 @@ exports[`render DocumentNodes 1`] = `
               <a>
                 Address
                 <span
-                  class="c17 c21 icon icon-chevrons-expand-vertical "
+                  class="c17 c20 icon icon-chevrons-expand-vertical "
                   color="light"
                 />
               </a>
@@ -850,13 +850,13 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -866,13 +866,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c23"
+                class="c22"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c24 icon icon-caret-down "
+                  class="c17 c23 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -888,13 +888,13 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -904,13 +904,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c23"
+                class="c22"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c24 icon icon-caret-down "
+                  class="c17 c23 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -926,13 +926,13 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -942,13 +942,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c23"
+                class="c22"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c24 icon icon-caret-down "
+                  class="c17 c23 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -969,13 +969,13 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
@@ -985,13 +985,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c23"
+                class="c22"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c24 icon icon-caret-down "
+                  class="c17 c23 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />
@@ -1007,37 +1007,37 @@ exports[`render DocumentNodes 1`] = `
             </td>
             <td>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 cluster: one
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 kernel: 4.15.0-51-generic
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 lortavma: one
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 lenisret: 4.15.0-51-generic
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 lofdevod: one
               </div>
               <div
-                class="c22"
+                class="c21"
                 kind="secondary"
               >
                 llhurlaz: 4.15.0-51-generic
@@ -1047,13 +1047,13 @@ exports[`render DocumentNodes 1`] = `
               align="right"
             >
               <button
-                class="c23"
+                class="c22"
                 height="24px"
                 kind="border"
               >
                 CONNECT
                 <span
-                  class="c17 c24 icon icon-caret-down "
+                  class="c17 c23 icon icon-caret-down "
                   color="text.secondary"
                   font-size="2"
                 />

--- a/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
+++ b/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { ButtonBorder } from 'design';
 import Table, { Cell, LabelCell } from 'design/DataTableNext';
 import { AuthType } from 'teleport/services/user';
@@ -38,7 +37,7 @@ function DatabaseList(props: Props) {
 
   return (
     <>
-      <StyledTable
+      <Table
         data={databases}
         columns={[
           {
@@ -115,12 +114,6 @@ function ConnectButton({
     </Cell>
   );
 }
-
-const StyledTable = styled(Table)`
-  & > tbody > tr > td {
-    vertical-align: baseline;
-  }
-` as typeof Table;
 
 type Props = {
   databases: Database[];

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -527,7 +527,7 @@ exports[`open source loaded 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c16 {
+.c15 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -555,22 +555,22 @@ exports[`open source loaded 1`] = `
   padding: 0px 16px;
 }
 
-.c16:active {
+.c15:active {
   opacity: 0.56;
 }
 
-.c16:hover,
-.c16:focus {
+.c15:hover,
+.c15:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c16:active {
+.c15:active {
   opacity: 0.24;
 }
 
-.c16:disabled {
+.c15:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -582,13 +582,13 @@ exports[`open source loaded 1`] = `
   font-size: 16px;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c15 {
+.c14 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -712,6 +712,10 @@ exports[`open source loaded 1`] = `
   padding-right: 24px;
 }
 
+.c12 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c12 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
@@ -818,10 +822,6 @@ exports[`open source loaded 1`] = `
   font-size: 12px;
 }
 
-.c13 > tbody > tr > td {
-  vertical-align: baseline;
-}
-
 <div
   class="c0"
 >
@@ -901,7 +901,7 @@ exports[`open source loaded 1`] = `
     </div>
   </nav>
   <table
-    class="c12 c13"
+    class="c12"
   >
     <thead>
       <tr>
@@ -909,7 +909,7 @@ exports[`open source loaded 1`] = `
           <a>
             Name
             <span
-              class="c10 c14 icon icon-chevron-up "
+              class="c10 c13 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -918,7 +918,7 @@ exports[`open source loaded 1`] = `
           <a>
             Description
             <span
-              class="c10 c14 icon icon-chevrons-expand-vertical "
+              class="c10 c13 icon icon-chevrons-expand-vertical "
               color="light"
             />
           </a>
@@ -927,7 +927,7 @@ exports[`open source loaded 1`] = `
           <a>
             Type
             <span
-              class="c10 c14 icon icon-chevrons-expand-vertical "
+              class="c10 c13 icon icon-chevrons-expand-vertical "
               color="light"
             />
           </a>
@@ -951,13 +951,13 @@ exports[`open source loaded 1`] = `
         </td>
         <td>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             cluster: root
           </div>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             env: aws
@@ -967,7 +967,7 @@ exports[`open source loaded 1`] = `
           align="right"
         >
           <button
-            class="c16"
+            class="c15"
             kind="border"
           >
             Connect
@@ -986,13 +986,13 @@ exports[`open source loaded 1`] = `
         </td>
         <td>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             cluster: root
           </div>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             env: aws
@@ -1002,7 +1002,7 @@ exports[`open source loaded 1`] = `
           align="right"
         >
           <button
-            class="c16"
+            class="c15"
             kind="border"
           >
             Connect
@@ -1021,13 +1021,13 @@ exports[`open source loaded 1`] = `
         </td>
         <td>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             cluster: env
           </div>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             value: gcp
@@ -1037,7 +1037,7 @@ exports[`open source loaded 1`] = `
           align="right"
         >
           <button
-            class="c16"
+            class="c15"
             kind="border"
           >
             Connect

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -527,7 +527,7 @@ exports[`open source loaded 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c15 {
+.c16 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -555,22 +555,22 @@ exports[`open source loaded 1`] = `
   padding: 0px 16px;
 }
 
-.c15:active {
+.c16:active {
   opacity: 0.56;
 }
 
-.c15:hover,
-.c15:focus {
+.c16:hover,
+.c16:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c15:active {
+.c16:active {
   opacity: 0.24;
 }
 
-.c15:disabled {
+.c16:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -582,13 +582,13 @@ exports[`open source loaded 1`] = `
   font-size: 16px;
 }
 
-.c13 {
+.c14 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c14 {
+.c15 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -818,6 +818,10 @@ exports[`open source loaded 1`] = `
   font-size: 12px;
 }
 
+.c13 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 <div
   class="c0"
 >
@@ -897,7 +901,7 @@ exports[`open source loaded 1`] = `
     </div>
   </nav>
   <table
-    class="c12"
+    class="c12 c13"
   >
     <thead>
       <tr>
@@ -905,7 +909,7 @@ exports[`open source loaded 1`] = `
           <a>
             Name
             <span
-              class="c10 c13 icon icon-chevron-up "
+              class="c10 c14 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -914,7 +918,7 @@ exports[`open source loaded 1`] = `
           <a>
             Description
             <span
-              class="c10 c13 icon icon-chevrons-expand-vertical "
+              class="c10 c14 icon icon-chevrons-expand-vertical "
               color="light"
             />
           </a>
@@ -923,7 +927,7 @@ exports[`open source loaded 1`] = `
           <a>
             Type
             <span
-              class="c10 c13 icon icon-chevrons-expand-vertical "
+              class="c10 c14 icon icon-chevrons-expand-vertical "
               color="light"
             />
           </a>
@@ -947,13 +951,13 @@ exports[`open source loaded 1`] = `
         </td>
         <td>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             cluster: root
           </div>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             env: aws
@@ -963,7 +967,7 @@ exports[`open source loaded 1`] = `
           align="right"
         >
           <button
-            class="c15"
+            class="c16"
             kind="border"
           >
             Connect
@@ -982,13 +986,13 @@ exports[`open source loaded 1`] = `
         </td>
         <td>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             cluster: root
           </div>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             env: aws
@@ -998,7 +1002,7 @@ exports[`open source loaded 1`] = `
           align="right"
         >
           <button
-            class="c15"
+            class="c16"
             kind="border"
           >
             Connect
@@ -1017,13 +1021,13 @@ exports[`open source loaded 1`] = `
         </td>
         <td>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             cluster: env
           </div>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             value: gcp
@@ -1033,7 +1037,7 @@ exports[`open source loaded 1`] = `
           align="right"
         >
           <button
-            class="c15"
+            class="c16"
             kind="border"
           >
             Connect

--- a/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
+++ b/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import React from 'react';
-import styled from 'styled-components';
 import Table, { Cell, LabelCell } from 'design/DataTableNext';
 import { Desktop } from 'teleport/services/desktops';
 import MenuSshLogin, { LoginItem } from 'shared/components/MenuSshLogin';
@@ -38,7 +37,7 @@ function DesktopList(props: Props) {
   }
 
   return (
-    <StyledTable
+    <Table
       data={desktops}
       columns={[
         {
@@ -123,12 +122,6 @@ function LoginCell({
     </Cell>
   );
 }
-
-const StyledTable = styled(Table)`
-  & > tbody > tr > td {
-    vertical-align: baseline;
-  }
-` as typeof Table;
 
 type Props = {
   desktops: Desktop[];

--- a/packages/teleport/src/Kubes/KubeList/KubeList.tsx
+++ b/packages/teleport/src/Kubes/KubeList/KubeList.tsx
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import Table, { Cell, LabelCell } from 'design/DataTableNext';
 import { ButtonBorder } from 'design';
 import { Kube } from 'teleport/services/kube';
@@ -29,7 +28,7 @@ function KubeList(props: Props) {
 
   return (
     <>
-      <StyledTable
+      <Table
         data={kubes}
         columns={[
           {
@@ -83,12 +82,6 @@ export const ConnectButtonCell = ({
     </Cell>
   );
 };
-
-const StyledTable = styled(Table)`
-  & > tbody > tr > td {
-    vertical-align: baseline;
-  }
-` as typeof Table;
 
 type Props = {
   kubes: Kube[];

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -531,7 +531,7 @@ exports[`loaded 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c16 {
+.c15 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -559,22 +559,22 @@ exports[`loaded 1`] = `
   padding: 0px 16px;
 }
 
-.c16:active {
+.c15:active {
   opacity: 0.56;
 }
 
-.c16:hover,
-.c16:focus {
+.c15:hover,
+.c15:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c16:active {
+.c15:active {
   opacity: 0.24;
 }
 
-.c16:disabled {
+.c15:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -586,13 +586,13 @@ exports[`loaded 1`] = `
   font-size: 16px;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c15 {
+.c14 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -673,6 +673,10 @@ exports[`loaded 1`] = `
 .c12 > tbody > tr > td:last-child,
 .c12 > tfoot > tr > td:last-child {
   padding-right: 24px;
+}
+
+.c12 > tbody > tr > td {
+  vertical-align: baseline;
 }
 
 .c12 > thead > tr > th {
@@ -779,10 +783,6 @@ exports[`loaded 1`] = `
 .c5::placeholder {
   color: rgba(255,255,255,0.24);
   font-size: 12px;
-}
-
-.c13 > tbody > tr > td {
-  vertical-align: baseline;
 }
 
 .c1 {
@@ -907,7 +907,7 @@ exports[`loaded 1`] = `
     </div>
   </nav>
   <table
-    class="c12 c13"
+    class="c12"
   >
     <thead>
       <tr>
@@ -915,7 +915,7 @@ exports[`loaded 1`] = `
           <a>
             Name
             <span
-              class="c10 c14 icon icon-chevron-up "
+              class="c10 c13 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -933,13 +933,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             cluster-name: some-cluster-name
           </div>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             env: idk
@@ -949,7 +949,7 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c16"
+            class="c15"
             kind="border"
           >
             Connect
@@ -962,13 +962,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             kernal: 4.15.0-51-generic
           </div>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             env: prod
@@ -978,7 +978,7 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c16"
+            class="c15"
             kind="border"
           >
             Connect
@@ -991,7 +991,7 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c15"
+            class="c14"
             kind="secondary"
           >
             env: staging
@@ -1001,7 +1001,7 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c16"
+            class="c15"
             kind="border"
           >
             Connect

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -531,7 +531,7 @@ exports[`loaded 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c15 {
+.c16 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -559,22 +559,22 @@ exports[`loaded 1`] = `
   padding: 0px 16px;
 }
 
-.c15:active {
+.c16:active {
   opacity: 0.56;
 }
 
-.c15:hover,
-.c15:focus {
+.c16:hover,
+.c16:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c15:active {
+.c16:active {
   opacity: 0.24;
 }
 
-.c15:disabled {
+.c16:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -586,13 +586,13 @@ exports[`loaded 1`] = `
   font-size: 16px;
 }
 
-.c13 {
+.c14 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c14 {
+.c15 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -781,6 +781,10 @@ exports[`loaded 1`] = `
   font-size: 12px;
 }
 
+.c13 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c1 {
   box-sizing: border-box;
   margin-bottom: 24px;
@@ -903,7 +907,7 @@ exports[`loaded 1`] = `
     </div>
   </nav>
   <table
-    class="c12"
+    class="c12 c13"
   >
     <thead>
       <tr>
@@ -911,7 +915,7 @@ exports[`loaded 1`] = `
           <a>
             Name
             <span
-              class="c10 c13 icon icon-chevron-up "
+              class="c10 c14 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -929,13 +933,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             cluster-name: some-cluster-name
           </div>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             env: idk
@@ -945,7 +949,7 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c15"
+            class="c16"
             kind="border"
           >
             Connect
@@ -958,13 +962,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             kernal: 4.15.0-51-generic
           </div>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             env: prod
@@ -974,7 +978,7 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c15"
+            class="c16"
             kind="border"
           >
             Connect
@@ -987,7 +991,7 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c14"
+            class="c15"
             kind="secondary"
           >
             env: staging
@@ -997,7 +1001,7 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c15"
+            class="c16"
             kind="border"
           >
             Connect

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -529,7 +529,7 @@ exports[`loaded 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c19 {
+.c18 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -558,22 +558,22 @@ exports[`loaded 1`] = `
   height: 24px;
 }
 
-.c19:active {
+.c18:active {
   opacity: 0.56;
 }
 
-.c19:hover,
-.c19:focus {
+.c18:hover,
+.c18:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c19:active {
+.c18:active {
   opacity: 0.24;
 }
 
-.c19:disabled {
+.c18:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -585,13 +585,13 @@ exports[`loaded 1`] = `
   font-size: 16px;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   transition: color .3s;
   margin-left: 8px;
@@ -600,7 +600,7 @@ exports[`loaded 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c17 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -782,6 +782,10 @@ exports[`loaded 1`] = `
   padding-right: 24px;
 }
 
+.c15 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c15 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
@@ -888,10 +892,6 @@ exports[`loaded 1`] = `
   font-size: 12px;
 }
 
-.c16 > tbody > tr > td {
-  vertical-align: baseline;
-}
-
 <div
   class="c0"
 >
@@ -990,7 +990,7 @@ exports[`loaded 1`] = `
     </div>
   </nav>
   <table
-    class="c15 c16"
+    class="c15"
   >
     <thead>
       <tr>
@@ -998,7 +998,7 @@ exports[`loaded 1`] = `
           <a>
             Hostname
             <span
-              class="c13 c17 icon icon-chevron-up "
+              class="c13 c16 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -1007,7 +1007,7 @@ exports[`loaded 1`] = `
           <a>
             Address
             <span
-              class="c13 c17 icon icon-chevrons-expand-vertical "
+              class="c13 c16 icon icon-chevrons-expand-vertical "
               color="light"
             />
           </a>
@@ -1028,13 +1028,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1044,13 +1044,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c19"
+            class="c18"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c20 icon icon-caret-down "
+              class="c13 c19 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1066,13 +1066,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1082,13 +1082,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c19"
+            class="c18"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c20 icon icon-caret-down "
+              class="c13 c19 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1104,13 +1104,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1120,13 +1120,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c19"
+            class="c18"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c20 icon icon-caret-down "
+              class="c13 c19 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1142,13 +1142,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1158,13 +1158,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c19"
+            class="c18"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c20 icon icon-caret-down "
+              class="c13 c19 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1180,13 +1180,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1196,13 +1196,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c19"
+            class="c18"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c20 icon icon-caret-down "
+              class="c13 c19 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1223,13 +1223,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1239,13 +1239,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c19"
+            class="c18"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c20 icon icon-caret-down "
+              class="c13 c19 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1266,13 +1266,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c18"
+            class="c17"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1282,13 +1282,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c19"
+            class="c18"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c20 icon icon-caret-down "
+              class="c13 c19 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -529,7 +529,7 @@ exports[`loaded 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c18 {
+.c19 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -558,22 +558,22 @@ exports[`loaded 1`] = `
   height: 24px;
 }
 
-.c18:active {
+.c19:active {
   opacity: 0.56;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c18:active {
+.c19:active {
   opacity: 0.24;
 }
 
-.c18:disabled {
+.c19:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -585,13 +585,13 @@ exports[`loaded 1`] = `
   font-size: 16px;
 }
 
-.c16 {
+.c17 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c19 {
+.c20 {
   display: inline-block;
   transition: color .3s;
   margin-left: 8px;
@@ -600,7 +600,7 @@ exports[`loaded 1`] = `
   font-size: 14px;
 }
 
-.c17 {
+.c18 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -888,6 +888,10 @@ exports[`loaded 1`] = `
   font-size: 12px;
 }
 
+.c16 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 <div
   class="c0"
 >
@@ -986,7 +990,7 @@ exports[`loaded 1`] = `
     </div>
   </nav>
   <table
-    class="c15"
+    class="c15 c16"
   >
     <thead>
       <tr>
@@ -994,7 +998,7 @@ exports[`loaded 1`] = `
           <a>
             Hostname
             <span
-              class="c13 c16 icon icon-chevron-up "
+              class="c13 c17 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -1003,7 +1007,7 @@ exports[`loaded 1`] = `
           <a>
             Address
             <span
-              class="c13 c16 icon icon-chevrons-expand-vertical "
+              class="c13 c17 icon icon-chevrons-expand-vertical "
               color="light"
             />
           </a>
@@ -1024,13 +1028,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1040,13 +1044,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c18"
+            class="c19"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c19 icon icon-caret-down "
+              class="c13 c20 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1062,13 +1066,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1078,13 +1082,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c18"
+            class="c19"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c19 icon icon-caret-down "
+              class="c13 c20 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1100,13 +1104,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1116,13 +1120,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c18"
+            class="c19"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c19 icon icon-caret-down "
+              class="c13 c20 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1138,13 +1142,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1154,13 +1158,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c18"
+            class="c19"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c19 icon icon-caret-down "
+              class="c13 c20 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1176,13 +1180,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1192,13 +1196,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c18"
+            class="c19"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c19 icon icon-caret-down "
+              class="c13 c20 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1219,13 +1223,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1235,13 +1239,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c18"
+            class="c19"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c19 icon icon-caret-down "
+              class="c13 c20 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1262,13 +1266,13 @@ exports[`loaded 1`] = `
         </td>
         <td>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c17"
+            class="c18"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1278,13 +1282,13 @@ exports[`loaded 1`] = `
           align="right"
         >
           <button
-            class="c18"
+            class="c19"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c13 c19 icon icon-caret-down "
+              class="c13 c20 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />

--- a/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -182,6 +182,10 @@ exports[`loaded 1`] = `
   padding-right: 24px;
 }
 
+.c11 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c11 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;

--- a/packages/teleport/src/Users/UserList/UserList.tsx
+++ b/packages/teleport/src/Users/UserList/UserList.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
 import { Label } from 'design';
 import Table, { Cell } from 'design/DataTableNext';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
@@ -29,7 +28,7 @@ export default function UserList({
   onReset,
 }: Props) {
   return (
-    <StyledTable
+    <Table
       data={users}
       columns={[
         {
@@ -113,9 +112,3 @@ type Props = {
   onDelete(user: User): void;
   onReset(user: User): void;
 };
-
-const StyledTable = styled(Table)`
-  & > tbody > tr > td {
-    vertical-align: baseline;
-  }
-` as typeof Table;

--- a/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -241,6 +241,10 @@ exports[`success state 1`] = `
   padding-right: 24px;
 }
 
+.c12 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
 .c12 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import React from 'react';
-import styled from 'styled-components';
 import Table, { Cell, LabelCell } from 'design/DataTableNext';
 import MenuSshLogin, { LoginItem } from 'shared/components/MenuSshLogin';
 import { Node } from 'teleport/services/nodes';
@@ -24,7 +23,7 @@ function NodeList(props: Props) {
   const { nodes = [], onLoginMenuOpen, onLoginSelect, pageSize = 100 } = props;
 
   return (
-    <StyledTable
+    <Table
       columns={[
         {
           key: 'hostname',
@@ -116,12 +115,6 @@ function renderTunnel() {
     >{`⟵ tunnel`}</span>
   );
 }
-
-const StyledTable = styled(Table)`
-  & > tbody > tr > td {
-    vertical-align: baseline;
-  }
-` as typeof Table;
 
 type Props = {
   nodes: Node[];


### PR DESCRIPTION
## Purpose

Makes some improvements to Table V2.

## Implementation

Styled Components requires a `className` prop for custom components, this was missing and so custom styles were not applying properly. Added the `className` component to Table.

Make `TextCell` show empty text if data is missing rather than `undefined`.

Make `vertical-align: baseline` the default style for `td`'s so we don't have to keep adding it to Tables.

Add an optional `style` prop for passing in custom styles.