### PR TITLE
[v6.2] backport #532 (`access_request.delete` event)

### DIFF
--- a/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -62,6 +62,7 @@ const EventIconMap: Record<EventCode, React.FC> = {
   [eventCodes.ACCESS_REQUEST_CREATED]: Icons.Info,
   [eventCodes.ACCESS_REQUEST_UPDATED]: Icons.Info,
   [eventCodes.ACCESS_REQUEST_REVIEWED]: Icons.Info,
+  [eventCodes.ACCESS_REQUEST_DELETED]: Icons.Info,
   [eventCodes.USER_LOCAL_LOGIN]: Icons.Info,
   [eventCodes.USER_LOCAL_LOGINFAILURE]: Icons.Info,
   [eventCodes.USER_SSO_LOGIN]: Icons.Info,

--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -676,12 +676,12 @@ exports[`loaded 1`] = `
           </strong>
            - 
           <strong>
-            37
+            38
           </strong>
            
           of 
           <strong>
-            37
+            38
           </strong>
         </div>
       </div>
@@ -1324,6 +1324,41 @@ exports[`loaded 1`] = `
             style="word-break: break-word;"
           >
             User [Ivan_Jordan] has changed a password
+          </td>
+          <td
+            style="min-width: 120px;"
+          >
+            2020-06-05 19:26:53
+          </td>
+          <td
+            align="right"
+          >
+            <button
+              class="c17"
+              kind="border"
+              width="87px"
+            >
+              Details
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <div
+              class="c15"
+            >
+              <span
+                class="c11 c16 icon icon-info_outline c11 c16"
+                color="light"
+                font-size="3"
+              />
+              Access Request Deleted
+            </div>
+          </td>
+          <td
+            style="word-break: break-word;"
+          >
+            Access request [66b827b2-1b0b-512b-965d-6c789388d3c9] has been deleted
           </td>
           <td
             style="min-width: 120px;"

--- a/packages/teleport/src/Audit/fixtures/index.ts
+++ b/packages/teleport/src/Audit/fixtures/index.ts
@@ -106,6 +106,13 @@ export const events = [
     updated_by: 'Sam_Waters',
   },
   {
+    id: '66b827b2-1b0b-512b-965d-6c789388d3c9',
+    code: 'T5003I',
+    event: 'access_request.delete',
+    time: '2020-06-05T19:26:53Z',
+    uid: '68a83a99-73ce-4bd7-bbf7-99103c2ba6a0',
+  },
+  {
     'addr.local': '172.10.1.1:3022',
     'addr.remote': '172.10.1.254:46992',
     code: 'T2006I',

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -36,6 +36,12 @@ export const formatters: Formatters = {
     format: ({ id, reviewer }) =>
       `User [${reviewer}] reviewed access request [${id}]`,
   },
+  [eventCodes.ACCESS_REQUEST_DELETED]: {
+    type: 'access_request.delete',
+    desc: 'Access Request Deleted',
+    format: ({ id }) =>
+      `Access request [${id}] has been deleted`,
+  },
   [eventCodes.SESSION_COMMAND]: {
     type: 'session.command',
     desc: 'Session Command',

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -43,6 +43,7 @@ export const eventCodes = {
   ACCESS_REQUEST_CREATED: 'T5000I',
   ACCESS_REQUEST_REVIEWED: 'T5002I',
   ACCESS_REQUEST_UPDATED: 'T5001I',
+  ACCESS_REQUEST_DELETED: 'T5003I',
   APP_SESSION_CHUNK: 'T2008I',
   APP_SESSION_START: 'T2007I',
   AUTH_ATTEMPT_FAILURE: 'T3007W',
@@ -113,6 +114,9 @@ export type RawEvents = {
   >;
   [eventCodes.ACCESS_REQUEST_REVIEWED]: RawEventAccess<
     typeof eventCodes.ACCESS_REQUEST_REVIEWED
+  >;
+  [eventCodes.ACCESS_REQUEST_DELETED]: RawEventAccess<
+    typeof eventCodes.ACCESS_REQUEST_DELETED
   >;
   [eventCodes.AUTH_ATTEMPT_FAILURE]: RawEventAuthFailure<
     typeof eventCodes.AUTH_ATTEMPT_FAILURE


### PR DESCRIPTION
Backport of #532 with no practical changes.

Subordinate to
* https://github.com/gravitational/teleport/pull/9785