### PR TITLE
Add resizable navigator panes

### DIFF
--- a/packages/teleterm/src/ui/Navigator/ContextualExpander.tsx
+++ b/packages/teleterm/src/ui/Navigator/ContextualExpander.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { ExpanderHeader, ExpanderHeaderProps } from './Expander';
+import { Flex } from 'design';
+import styled from 'styled-components';
+
+const AccordingContext = React.createContext<AccordingContextState>(null);
+
+export const ContextualExpander: React.FC = props => {
+  const [expanded, setExpanded] = React.useState(true);
+  const [header, ...children] = React.Children.toArray(props.children);
+  const toggle = () => setExpanded(!expanded);
+
+  return (
+    <AccordingContext.Provider value={{ expanded, toggle }}>
+      {header}
+      {children}
+    </AccordingContext.Provider>
+  );
+};
+
+export const ContextualExpanderHeader: React.FC<
+  ContextualExpanderHeaderProps
+> = props => {
+  const { children, ...otherProps } = props;
+  const ctx = React.useContext(AccordingContext);
+
+  return (
+    <ExpanderHeader
+      {...otherProps}
+      expanded={ctx.expanded}
+      onToggle={ctx.toggle}
+    >
+      {children}
+    </ExpanderHeader>
+  );
+};
+
+export const ContextualExpanderContent = styled(Flex)(props => {
+  const ctx = React.useContext(AccordingContext);
+  return {
+    display: ctx.expanded ? 'block' : 'none',
+    color: props.theme.colors.text.secondary,
+    flexDirection: 'column',
+  };
+});
+
+type AccordingContextState = {
+  expanded: boolean;
+  toggle(): void;
+};
+
+type ContextualExpanderHeaderProps = Omit<
+  ExpanderHeaderProps,
+  'onToggle' | 'expanded'
+>;

--- a/packages/teleterm/src/ui/Navigator/Expander.tsx
+++ b/packages/teleterm/src/ui/Navigator/Expander.tsx
@@ -17,47 +17,35 @@ limitations under the License.
 import React from 'react';
 import styled from 'styled-components';
 import { space, color } from 'design/system';
-import * as Icons from 'design/Icon';
 import { Flex } from 'design';
 import Icon from 'design/Icon';
+import * as Icons from 'design/Icon';
 import { ButtonIcon } from 'teleterm/ui/components/ButtonIcon';
 
-const AccordingContext = React.createContext<AccordingContextState>(null);
-
-const Expander: React.FC = props => {
-  const [expanded, setExpanded] = React.useState(true);
-  const [header, ...children] = React.Children.toArray(props.children);
-  const toggle = () => setExpanded(!expanded);
-
-  return (
-    <AccordingContext.Provider value={{ expanded, toggle }}>
-      {header}
-      {children}
-    </AccordingContext.Provider>
-  );
-};
-
-export const ExpanderHeader: React.FC<ExpanderHeaderProps> = props => {
+export const ExpanderHeader: React.FC<
+  ExpanderHeaderProps
+  > = props => {
   const {
     onContextMenu,
     children,
     toggleTrigger = 'header',
     icons: { Expanded = Icons.CarrotDown, Collapsed = Icons.CarrotRight } = {},
+    expanded,
+    onToggle,
     ...styles
   } = props;
-  const ctx = React.useContext(AccordingContext);
-  const ArrowIcon = ctx.expanded ? Expanded : Collapsed;
+  const ArrowIcon = expanded ? Expanded : Collapsed;
 
   function handleHeaderClick(event: MouseEvent) {
     if (toggleTrigger === 'header') {
-      ctx.toggle();
+      onToggle?.();
       event.stopPropagation();
     }
   }
 
   function handleIconClick(event: MouseEvent) {
     if (toggleTrigger === 'icon') {
-      ctx.toggle();
+      onToggle?.();
       event.stopPropagation();
     }
   }
@@ -79,15 +67,12 @@ export const ExpanderHeader: React.FC<ExpanderHeaderProps> = props => {
 };
 
 export const ExpanderContent = styled(Flex)(props => {
-  const ctx = React.useContext(AccordingContext);
   return {
-    display: ctx.expanded ? 'block' : 'none',
     color: props.theme.colors.text.secondary,
     flexDirection: 'column',
+    height: '100%',
   };
 });
-
-export default Expander;
 
 export const StyledHeader = styled(Flex)(props => {
   const theme = props.theme;
@@ -96,6 +81,7 @@ export const StyledHeader = styled(Flex)(props => {
     margin: '0',
     boxSizing: 'border-box',
     display: 'flex',
+    flexShrink: 0,
     alignItems: 'center',
     justifyContent: 'flex-start',
     border: 'none',
@@ -129,17 +115,14 @@ export const StyledHeader = styled(Flex)(props => {
   };
 });
 
-type AccordingContextState = {
-  expanded: boolean;
-  toggle(): void;
-};
-
-type ExpanderHeaderProps = {
+export type ExpanderHeaderProps = {
   onContextMenu?: () => void;
   toggleTrigger?: 'icon' | 'header';
   icons?: {
     Expanded: typeof Icon;
     Collapsed: typeof Icon;
   };
+  onToggle?(): void;
+  expanded?: boolean;
   [key: string]: any;
 };

--- a/packages/teleterm/src/ui/Navigator/ExpanderClusters/ExpanderClusterItem.tsx
+++ b/packages/teleterm/src/ui/Navigator/ExpanderClusters/ExpanderClusterItem.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import Expander, { ExpanderHeader, ExpanderContent } from './../Expander';
+import {
+  ContextualExpander,
+  ContextualExpanderHeader,
+  ContextualExpanderContent,
+} from './../ContextualExpander';
 import { ClusterNavItem } from './types';
 import NavItem from 'teleterm/ui/Navigator/NavItem';
 import LinearProgress from 'teleterm/ui/components/LinearProgress';
@@ -22,7 +26,7 @@ function ExpanderClusterWithLeaves(props: ExpanderClusterItem) {
   const { item } = props;
 
   return (
-    <Expander>
+    <ContextualExpander>
       <StyledExpanderHeader
         toggleTrigger="icon"
         pl="25px"
@@ -30,7 +34,7 @@ function ExpanderClusterWithLeaves(props: ExpanderClusterItem) {
       >
         <ClusterItem {...props} />
       </StyledExpanderHeader>
-      <ExpanderContent>
+      <ContextualExpanderContent>
         <Box>
           {item.leaves.map(tc => (
             <ClusterItem
@@ -42,8 +46,8 @@ function ExpanderClusterWithLeaves(props: ExpanderClusterItem) {
             />
           ))}
         </Box>
-      </ExpanderContent>
-    </Expander>
+      </ContextualExpanderContent>
+    </ContextualExpander>
   );
 }
 
@@ -92,7 +96,7 @@ type ExpanderClusterItem = {
   onOpen(clusterUri: string): void;
 };
 
-const StyledExpanderHeader = styled(ExpanderHeader)(props => {
+const StyledExpanderHeader = styled(ContextualExpanderHeader)(props => {
   const colors = props.$active
     ? {
         color: props.theme.colors.primary.contrastText,
@@ -102,6 +106,6 @@ const StyledExpanderHeader = styled(ExpanderHeader)(props => {
 
   return {
     ...colors,
-    height: '32px'
+    height: '32px',
   };
 });

--- a/packages/teleterm/src/ui/Navigator/ExpanderClusters/ExpanderClusters.story.tsx
+++ b/packages/teleterm/src/ui/Navigator/ExpanderClusters/ExpanderClusters.story.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { ExpanderClustersPresentational } from 'teleterm/ui/Navigator/ExpanderClusters/ExpanderClusters';
+import { ExpanderClustersBodyPresentational } from 'teleterm/ui/Navigator/ExpanderClusters/ExpanderClusters';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { ExpanderClusterState } from './types';
 
@@ -80,7 +80,7 @@ export function Syncing() {
   });
   return (
     <MockAppContextProvider>
-      <ExpanderClustersPresentational {...state} />
+      <ExpanderClustersBodyPresentational {...state} />
     </MockAppContextProvider>
   );
 }
@@ -89,7 +89,7 @@ export function ClusterItems() {
   const state = getState();
   return (
     <MockAppContextProvider>
-      <ExpanderClustersPresentational {...state} />
+      <ExpanderClustersBodyPresentational {...state} />
     </MockAppContextProvider>
   );
 }

--- a/packages/teleterm/src/ui/Navigator/ExpanderClusters/ExpanderClusters.test.tsx
+++ b/packages/teleterm/src/ui/Navigator/ExpanderClusters/ExpanderClusters.test.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { fireEvent, render } from 'design/utils/testing';
-import { ExpanderClustersPresentational } from './ExpanderClusters';
+import { ExpanderClustersBodyPresentational } from './ExpanderClusters';
 import { ExpanderClusterState } from './types';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 
@@ -50,7 +50,7 @@ test('should render simple and trusted clusters', () => {
 
   const { getByText } = render(
     <MockAppContextProvider>
-      <ExpanderClustersPresentational {...state} />
+      <ExpanderClustersBodyPresentational {...state} />
     </MockAppContextProvider>
   );
 
@@ -77,7 +77,7 @@ test('should invoke callback when context menu is clicked', () => {
 
   const { getByText } = render(
     <MockAppContextProvider>
-      <ExpanderClustersPresentational {...state} />
+      <ExpanderClustersBodyPresentational {...state} />
     </MockAppContextProvider>
   );
 

--- a/packages/teleterm/src/ui/Navigator/ExpanderClusters/ExpanderClusters.tsx
+++ b/packages/teleterm/src/ui/Navigator/ExpanderClusters/ExpanderClusters.tsx
@@ -17,30 +17,24 @@ limitations under the License.
 import React from 'react';
 import { Flex, Text, Box } from 'design';
 import { Restore, Add } from 'design/Icon';
-import Expander, { ExpanderHeader, ExpanderContent } from './../Expander';
+import {
+  ExpanderHeader,
+  ExpanderContent,
+} from './../Expander';
 import { useExpanderClusters } from './useExpanderClusters';
 import { ExpanderClusterItem } from './ExpanderClusterItem';
 import { ExpanderClusterState } from './types';
 import { ButtonIcon } from 'teleterm/ui/components/ButtonIcon';
+import styled from 'styled-components';
+import { NavigatorSplitPaneHeaderProps } from '../NavigatorSplitPanes';
 
-export function ExpanderClusters() {
+export function ExpanderClustersBody() {
   const state = useExpanderClusters();
-  return <ExpanderClustersPresentational {...state} />;
+  return <ExpanderClustersBodyPresentational {...state} />;
 }
 
-export function ExpanderClustersPresentational(props: ExpanderClusterState) {
-  const { items, onSyncClusters, onAddCluster, onOpen, onOpenContextMenu } =
-    props;
-
-  const handleSyncClick = (e: React.BaseSyntheticEvent) => {
-    e.stopPropagation();
-    onSyncClusters?.();
-  };
-
-  const handleAddClick = (e: React.BaseSyntheticEvent) => {
-    e.stopPropagation();
-    onAddCluster?.();
-  };
+export function ExpanderClustersBodyPresentational(props: ExpanderClusterState) {
+  const { items, onOpen, onOpenContextMenu } = props;
 
   const $clustersItems = items.map(i => (
     <ExpanderClusterItem
@@ -52,41 +46,65 @@ export function ExpanderClustersPresentational(props: ExpanderClusterState) {
   ));
 
   return (
-    <Expander>
-      <ExpanderHeader toggleTrigger='header'>
-        <Flex
-          justifyContent="space-between"
-          alignItems="center"
-          flex="1"
-          width="100%"
-          minWidth="0"
-        >
-          <Text typography="body1" bold>
-            Clusters
-          </Text>
-          <Flex>
-            <ButtonIcon
-              mr={2}
-              color="text.primary"
-              title="Sync clusters"
-              onClick={handleSyncClick}
-            >
-              <Restore />
-            </ButtonIcon>
-            <ButtonIcon
-              mr={1}
-              color="text.primary"
-              onClick={handleAddClick}
-              title="Add cluster"
-            >
-              <Add />
-            </ButtonIcon>
-          </Flex>
-        </Flex>
-      </ExpanderHeader>
-      <ExpanderContent>
-        <Box>{$clustersItems}</Box>
-      </ExpanderContent>
-    </Expander>
+    <ExpanderContent>
+      <Scrollable>{$clustersItems}</Scrollable>
+    </ExpanderContent>
   );
 }
+
+export function ExpanderClustersHeader(props: NavigatorSplitPaneHeaderProps) {
+  const state = useExpanderClusters();
+
+  const handleSyncClick = (e: React.BaseSyntheticEvent) => {
+    e.stopPropagation();
+    state.onSyncClusters?.();
+  };
+
+  const handleAddClick = (e: React.BaseSyntheticEvent) => {
+    e.stopPropagation();
+    state.onAddCluster?.();
+  };
+
+  return (
+    <ExpanderHeader
+      onToggle={props.onToggle}
+      expanded={props.expanded}
+    >
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        flex="1"
+        width="100%"
+        minWidth="0"
+      >
+        <Text typography="body1" bold>
+          Clusters
+        </Text>
+        <Flex>
+          <ButtonIcon
+            mr={2}
+            color="text.primary"
+            title="Sync clusters"
+            onClick={handleSyncClick}
+          >
+            <Restore />
+          </ButtonIcon>
+          <ButtonIcon
+            mr={1}
+            color="text.primary"
+            onClick={handleAddClick}
+            title="Add cluster"
+          >
+            <Add />
+          </ButtonIcon>
+        </Flex>
+      </Flex>
+    </ExpanderHeader>
+  );
+}
+
+const Scrollable = styled(Box)`
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+`;

--- a/packages/teleterm/src/ui/Navigator/ExpanderClusters/index.ts
+++ b/packages/teleterm/src/ui/Navigator/ExpanderClusters/index.ts
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { ExpanderClusters } from './ExpanderClusters';
+export { ExpanderClustersBody, ExpanderClustersHeader } from './ExpanderClusters';

--- a/packages/teleterm/src/ui/Navigator/ExpanderConnections/ExpanderConnections.story.tsx
+++ b/packages/teleterm/src/ui/Navigator/ExpanderConnections/ExpanderConnections.story.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { ExpanderConnectionsPresentational } from './ExpanderConnections';
+import { ExpanderConnectionsBodyPresentational } from './ExpanderConnections';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { State } from './useExpanderConnections';
 
@@ -61,7 +61,7 @@ function getState(): State {
 export function ExpanderConnections() {
   return (
     <MockAppContextProvider>
-      <ExpanderConnectionsPresentational {...getState()} />
+      <ExpanderConnectionsBodyPresentational {...getState()} />
     </MockAppContextProvider>
   );
 }

--- a/packages/teleterm/src/ui/Navigator/ExpanderConnections/ExpanderConnections.tsx
+++ b/packages/teleterm/src/ui/Navigator/ExpanderConnections/ExpanderConnections.tsx
@@ -15,33 +15,26 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Flex, Text } from 'design';
-import Expander, { ExpanderHeader, ExpanderContent } from '../Expander';
+import { Box, Flex, Text } from 'design';
+import {
+  ExpanderHeader,
+  ExpanderContent,
+} from '../Expander';
 import { useExpanderConnections, State } from './useExpanderConnections';
 import { ExpanderConnectionItem } from './ExpanderConnectionItem';
+import styled from 'styled-components';
+import { NavigatorSplitPaneHeaderProps } from '../NavigatorSplitPanes';
 
-export function ExpanderConnections() {
+export function ExpanderConnectionsBody() {
   const state = useExpanderConnections();
-  return <ExpanderConnectionsPresentational {...state} />;
+  return <ExpanderConnectionsBodyPresentational {...state} />;
 }
 
-export function ExpanderConnectionsPresentational(props: State) {
+export function ExpanderConnectionsBodyPresentational(props: State) {
   const { items } = props;
   return (
-    <Expander>
-      <ExpanderHeader>
-        <Flex
-          justifyContent="space-between"
-          alignItems="center"
-          flex="1"
-          width="100%"
-        >
-          <Text typography="body1" bold>
-            Connections
-          </Text>
-        </Flex>
-      </ExpanderHeader>
-      <ExpanderContent>
+    <ExpanderContent>
+      <Scrollable>
         {items.map(i => (
           <ExpanderConnectionItem
             key={i.id}
@@ -51,7 +44,33 @@ export function ExpanderConnectionsPresentational(props: State) {
             onContextMenu={props.onContextMenu}
           />
         ))}
-      </ExpanderContent>
-    </Expander>
+      </Scrollable>
+    </ExpanderContent>
   );
 }
+
+export function ExpanderConnectionsHeader(props: NavigatorSplitPaneHeaderProps) {
+  return (
+    <ExpanderHeader
+      onToggle={props.onToggle}
+      expanded={props.expanded}
+    >
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        flex="1"
+        width="100%"
+      >
+        <Text typography="body1" bold>
+          Connections
+        </Text>
+      </Flex>
+    </ExpanderHeader>
+  );
+}
+
+const Scrollable = styled(Box)`
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+`;

--- a/packages/teleterm/src/ui/Navigator/ExpanderConnections/index.ts
+++ b/packages/teleterm/src/ui/Navigator/ExpanderConnections/index.ts
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { ExpanderConnections } from './ExpanderConnections';
+export { ExpanderConnectionsBody, ExpanderConnectionsHeader } from './ExpanderConnections';

--- a/packages/teleterm/src/ui/Navigator/Navigator.tsx
+++ b/packages/teleterm/src/ui/Navigator/Navigator.tsx
@@ -17,8 +17,15 @@ limitations under the License.
 import React from 'react';
 import styled from 'styled-components';
 import { Box, Text } from 'design';
-import { ExpanderClusters } from './ExpanderClusters';
-import { ExpanderConnections } from './ExpanderConnections';
+import {
+  ExpanderClustersHeader,
+  ExpanderClustersBody,
+} from './ExpanderClusters';
+import {
+  ExpanderConnectionsHeader,
+  ExpanderConnectionsBody,
+} from './ExpanderConnections';
+import { NavigatorSplitPanes } from './NavigatorSplitPanes';
 
 export function Navigator() {
   return (
@@ -26,12 +33,30 @@ export function Navigator() {
       <Text typography="subtitle2" m={2}>
         NAVIGATOR
       </Text>
-      <Scrollable>
-        <ExpanderConnections />
-        <Separator />
-        <ExpanderClusters />
-        <Separator />
-      </Scrollable>
+      <NavigatorSplitPanes
+        panes={[
+          {
+            key: 'connections',
+            initialSize: '50%',
+            minSize: 100,
+            Header: ({ onToggle, expanded }) => (
+              <ExpanderConnectionsHeader
+                onToggle={onToggle}
+                expanded={expanded}
+              />
+            ),
+            Body: <ExpanderConnectionsBody />,
+          },
+          {
+            key: 'clusters',
+            minSize: 100,
+            Header: ({ onToggle, expanded }) => (
+              <ExpanderClustersHeader onToggle={onToggle} expanded={expanded} />
+            ),
+            Body: <ExpanderClustersBody />,
+          },
+        ]}
+      />
     </Nav>
   );
 }
@@ -41,14 +66,4 @@ const Nav = styled(Box)`
   flex-direction: column;
   height: 100%;
   user-select: none;
-`;
-
-const Scrollable = styled(Box)`
-  height: 100%;
-  overflow: auto;
-`;
-
-const Separator = styled.div`
-  background: ${props => props.theme.colors.primary.lighter};
-  height: 1px;
 `;

--- a/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/NavigatorSplitPanes.tsx
+++ b/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/NavigatorSplitPanes.tsx
@@ -1,0 +1,152 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { Fragment, ReactNode, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { Flex } from 'design';
+import useDraggable from 'shared/hooks/useDraggable';
+import { useNavigatorSplitPanesState } from './useNavigatorSplitPanesState';
+import { ResizablePane } from './ResizablePane';
+import { NavigatorSplitPane, NavigatorSplitPanesOnChangeEvent } from './types';
+
+interface NavigatorSplitPanesProps {
+  panes: NavigatorSplitPane[];
+  onChange?(event: NavigatorSplitPanesOnChangeEvent); //TODO: fire on size or expanded/collapse change and then save to the workspace
+}
+
+export function NavigatorSplitPanes(props: NavigatorSplitPanesProps) {
+  const rootContainerRef = useRef<HTMLDivElement>();
+
+  const {
+    isCollapsed,
+    collapseState,
+    handleToggle,
+    getMinYToResize,
+    getMaxYToResize,
+    isLast,
+    isDraggingDisabled,
+  } = useNavigatorSplitPanesState(props.panes, rootContainerRef);
+
+  const { onMouseDown, isDragging, position } = useDraggable({
+    getMinY: getMinYToResize,
+    getMaxY: getMaxYToResize,
+  });
+
+  useEffect(() => {
+    if (props.panes.length > 2) {
+      throw new Error('NavigatorSplitPanes can handle up to 2 items currently');
+    }
+  }, [props.panes]);
+
+  function renderPane(index: number): ReactNode {
+    const pane = props.panes[index];
+    return (
+      <>
+        {pane.Header({
+          onToggle: () => handleToggle(pane.key),
+          expanded: !collapseState[pane.key],
+        })}
+        <Collapsible
+          $isCollapsed={isCollapsed(index)}
+          $minHeight={pane.minSize}
+        >
+          <>{pane.Body}</>
+        </Collapsible>
+      </>
+    );
+  }
+
+  return (
+    <RootContainer ref={rootContainerRef}>
+      {props.panes.map((pane, index) => {
+        if (isLast(index)) {
+          return (
+            <Fragment key={pane.key}>
+              <FillRemainingSpacePane
+                $isCollapsed={isCollapsed(index)}
+                $isDragging={isDragging}
+                $minHeight={pane.minSize}
+              >
+                {renderPane(index)}
+              </FillRemainingSpacePane>
+              <XHolder $isDisabled={true} />
+            </Fragment>
+          );
+        }
+
+        return (
+          <Fragment key={pane.key}>
+            <ResizablePane
+              isDragging={isDragging}
+              position={position}
+              defaultSize={pane.initialSize}
+              isCollapsed={isCollapsed(index)}
+              minHeight={pane.minSize}
+              isNextCollapsed={isCollapsed(index + 1)}
+            >
+              {renderPane(index)}
+            </ResizablePane>
+            <XHolder
+              $isDisabled={isDraggingDisabled(index)}
+              onMouseDown={onMouseDown}
+            />
+          </Fragment>
+        );
+      })}
+    </RootContainer>
+  );
+}
+
+const RootContainer = styled(Flex)`
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+`;
+
+const FillRemainingSpacePane = styled(Flex)`
+  flex: 1 1;
+  min-height: ${props =>
+    props.$isCollapsed
+      ? '36px'
+      : props.$minHeight + 'px'}; // 36px is height of header
+  flex-direction: column;
+  flex-grow: ${props => (props.$isCollapsed ? 0 : 1)};
+  pointer-events: ${props => (props.$isDragging ? 'none' : 'auto')};
+`;
+
+const Collapsible = styled.div`
+  display: ${props => (props.$isCollapsed ? 'none' : 'block')};
+  height: 100%;
+  min-height: 0;
+`;
+
+const XHolder = styled.div`
+  cursor: ${props => (props.$isDisabled ? 'unset' : 'row-resize')};
+  width: 100%;
+  height: 2px;
+  background: ${props => props.theme.colors.primary.lighter};
+
+  :hover {
+    ${props =>
+      props.$isDisabled
+        ? null
+        : {
+            transform: 'scaleY(2)',
+            background: `${props.theme.colors.accent}`,
+          }}
+  }
+`;

--- a/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/ResizablePane.tsx
+++ b/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/ResizablePane.tsx
@@ -1,0 +1,80 @@
+import React, { ReactNode, useEffect, useRef, useMemo } from 'react';
+import styled from 'styled-components';
+import { Flex } from 'design';
+import { DraggablePosition } from 'shared/hooks/useDraggable';
+
+interface ResizablePaneProps {
+  children?: ReactNode;
+  minHeight: number;
+  position: DraggablePosition;
+  isDragging: boolean;
+  defaultSize: string;
+  isCollapsed: boolean;
+  isNextCollapsed: boolean;
+}
+
+export function ResizablePane(props: ResizablePaneProps) {
+  const {
+    children,
+    minHeight,
+    position,
+    isDragging,
+    defaultSize,
+    isCollapsed,
+    isNextCollapsed,
+  } = props;
+
+  const compRef = useRef<HTMLDivElement>();
+
+  // size contains the width and height of the element to be resized
+  const size = useMemo(() => {
+    return {
+      height: 0,
+    };
+  }, []);
+
+  // remember the element size before and after drag
+  useEffect(() => {
+    const element = compRef.current;
+    size.height = element.clientHeight;
+    // trigger windows resize event so other components can adjust
+    // to the new div size
+    window.dispatchEvent(new Event('resize'));
+  }, [isDragging]);
+
+  // handle drag movements which causes a position to change
+  useEffect(() => {
+    if (!isDragging) {
+      return;
+    }
+
+    const element = compRef.current;
+    const newHeight = size.height + position.y;
+    const parentHeight = compRef.current.parentElement.clientHeight;
+    element.style.flexBasis = (newHeight / parentHeight) * 100 + '%';
+  }, [position.y]);
+
+  return (
+    <PaneContent
+      ref={compRef}
+      $isCollapsed={isCollapsed}
+      $isNextCollapsed={isNextCollapsed}
+      $defaultSize={defaultSize}
+      $isDragging={isDragging}
+      $minHeight={minHeight}
+    >
+      {children}
+    </PaneContent>
+  );
+}
+
+const PaneContent = styled(Flex)`
+  flex: ${props => (props.$isCollapsed ? '0 !important' : '1 1 auto')};
+  min-height: ${props =>
+    props.$isCollapsed ? 'unset' : `${props.$minHeight + 'px' || 0}`};
+  flex-grow: ${props => (props.$isNextCollapsed ? 1 : 0)};
+  flex-basis: ${props => props.$defaultSize};
+  pointer-events: ${props => (props.$isDragging ? 'none' : 'auto')};
+  height: 100%;
+  flex-direction: column;
+`;

--- a/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/index.ts
+++ b/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/index.ts
@@ -1,0 +1,2 @@
+export * from './NavigatorSplitPanes';
+export * from './types';

--- a/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/types.ts
+++ b/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/types.ts
@@ -1,0 +1,34 @@
+import { ReactNode } from 'react';
+
+export interface NavigatorSplitPane {
+  key: string;
+  initiallyCollapsed?: boolean;
+  /**
+   * Initial size of expanded pane. Can be in %, px.
+   */
+  initialSize?: string;
+  /**
+   * Minimal size of expanded pane. Must be in px.
+   */
+  minSize: number;
+
+  Header(props: NavigatorSplitPaneHeaderProps): ReactNode;
+
+  Body: ReactNode;
+}
+
+export interface NavigatorSplitPaneHeaderProps {
+  onToggle(): void;
+
+  expanded: boolean;
+}
+
+export interface NavigatorSplitPanesOnChangeEvent {
+  panes: Record<
+    string,
+    {
+      size: string;
+      collapsed: boolean;
+    }
+  >;
+}

--- a/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/useNavigatorSplitPanesState.ts
+++ b/packages/teleterm/src/ui/Navigator/NavigatorSplitPanes/useNavigatorSplitPanesState.ts
@@ -1,0 +1,67 @@
+import { MutableRefObject, useState } from 'react';
+import { NavigatorSplitPane } from './types';
+
+export function useNavigatorSplitPanesState(
+  panes: NavigatorSplitPane[],
+  rootContainerRef: MutableRefObject<HTMLElement>
+) {
+  function generateCollapseInitialState(): Record<string, boolean> {
+    return panes.reduce((collapseState, pane) => {
+      collapseState[pane.key] =
+        pane.initiallyCollapsed === undefined ? false : pane.initiallyCollapsed;
+      return collapseState;
+    }, {});
+  }
+
+  const [collapseState, setCollapseState] = useState<Record<string, boolean>>(
+    generateCollapseInitialState()
+  );
+
+  function getMinYToResize(): number {
+    const firstPaneMinHeight = panes[0].minSize;
+    return (
+      rootContainerRef.current.getBoundingClientRect().top + firstPaneMinHeight
+    );
+  }
+
+  function getMaxYToResize(): number {
+    const secondPaneMinHeight = panes[1].minSize;
+    return (
+      rootContainerRef.current.getBoundingClientRect().bottom -
+      secondPaneMinHeight
+    );
+  }
+
+  function isCollapsed(index: number): boolean {
+    return collapseState[panes[index].key];
+  }
+
+  function isLast(index: number): boolean {
+    return index === panes.length - 1;
+  }
+
+  function isDraggingDisabled(index: number): boolean {
+    if (index + 1 >= panes.length) {
+      return true;
+    }
+
+    return isCollapsed(index) || isCollapsed(index + 1);
+  }
+
+  function handleToggle(key: string): void {
+    setCollapseState(collapseState => ({
+      ...collapseState,
+      [key]: !collapseState[key],
+    }));
+  }
+
+  return {
+    collapseState,
+    isCollapsed,
+    isLast,
+    handleToggle,
+    getMinYToResize,
+    getMaxYToResize,
+    isDraggingDisabled,
+  };
+}


### PR DESCRIPTION
Adds resizable panes to the navigator.

I had to add new components basing on the existing `SplitPane` component, because it misses some necessary features like: 
- a possibility to expand/collapse a pane and keep the previous size
-  the parent component needs to know which children are collapsed (for example we shouldn't show resize holder when both items are collapsed)

The changes include extracting `ExpanderHeader` and `ExpanderContent` versions witch don't use local context (`NavigatorSplit` handles the state).

`NavigatorSplit` supports up to 2 panes currently, but it is designed to be extended to handle more. 
<img width="1295" alt="image" src="https://user-images.githubusercontent.com/20583051/152565741-44a8ed39-4d0c-4b62-bf64-6a813881a09c.png">
<img width="1295" alt="image" src="https://user-images.githubusercontent.com/20583051/152566641-651a69f5-7ede-4f9f-91df-0e799018b753.png">


(TODO: fix stories)
