### PR TITLE
modifyResponse: Add optional space before /> to regex

### DIFF
--- a/packages/build/devserver/modifyResponse.js
+++ b/packages/build/devserver/modifyResponse.js
@@ -48,7 +48,7 @@ module.exports = function modifyIndexHtmlMiddleware(compiler) {
 
 function injectCsrf(source, target) {
   var value = source.match(
-    new RegExp(/<meta name="grv_csrf_token" content="[a-zA-Z0-9_.-=]*"\/>/)
+    new RegExp(/<meta name="grv_csrf_token" content="[a-zA-Z0-9_.-=]*"( )?\/>/)
   );
   if (value) {
     return target.replace(
@@ -62,7 +62,9 @@ function injectCsrf(source, target) {
 
 function injectBearer(source, target) {
   var value = source.match(
-    new RegExp(/<meta name="grv_bearer_token" content="[a-zA-Z0-9_.-=]*"\/>/)
+    new RegExp(
+      /<meta name="grv_bearer_token" content="[a-zA-Z0-9_.-=]*"( )?\/>/
+    )
   );
   if (value) {
     return target.replace(


### PR DESCRIPTION
## Purpose

6308951f548 changed the regexes used for CSRF & bearer tokens. The previous regexes were matching anything between the end of the `name` attribute and `/>`. The new regex assumes there's no space between the end of the `content` attribute and `/>`, but inspecting the `source` argument shows that there's indeed a space (at least on my machine).

https://github.com/gravitational/webapps/blob/6308951f54871a41a3d8516dad1855608a6182c9/packages/build/devserver/modifyResponse.js#L63-L66

This PR makes it so that the regex accepts an optional space before the end of the tag, just as the regex used to replace the tag in `target`:

https://github.com/gravitational/webapps/blob/6308951f54871a41a3d8516dad1855608a6182c9/packages/build/devserver/modifyResponse.js#L67-L74