### PR TITLE
Add `VirtualScroll` component

### DIFF
--- a/packages/teleterm/src/ui/components/VirtualScroll/VirtualScroll.story.tsx
+++ b/packages/teleterm/src/ui/components/VirtualScroll/VirtualScroll.story.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import styled from 'styled-components';
+import { VirtualScroll } from './VirtualScroll';
+import { Text } from 'design';
+import { unique } from 'teleterm/ui/utils/uid';
+
+const items: SimpleItem[] = new Array(10000)
+  .fill(null)
+  .map((_, index) => ({ index }));
+
+export default {
+  title: 'Teleterm/components/VirtualScroll',
+};
+
+interface SimpleItem {
+  index: number;
+}
+
+export function SimpleList() {
+  return (
+    <>
+      <h2>Rendering {items.length} items</h2>
+      <Container>
+        <VirtualScroll<SimpleItem>
+          keyProp="index"
+          rowHeight={24}
+          items={items}
+          Node={({ item }) => <Text>This is item with {item.index} index</Text>}
+        />
+      </Container>
+    </>
+  );
+}
+
+interface TreeItem {
+  children?: TreeItem[];
+  id: string;
+}
+
+export function TreeList() {
+  const deepLevels = 6;
+  const childrenPerLevel = 6;
+
+  function createTree(currentLevel = 0): TreeItem {
+    const item = {
+      children: [],
+      id: unique(),
+    };
+
+    if (currentLevel === deepLevels) {
+      return item;
+    }
+
+    for (let i = 0; i < childrenPerLevel; i++) {
+      item.children.push(createTree(currentLevel + 1));
+    }
+
+    return item;
+  }
+
+  return (
+    <>
+      <h2>Rendering up to {Math.pow(deepLevels, childrenPerLevel)} items</h2>
+      <Container>
+        <VirtualScroll<TreeItem>
+          keyProp="id"
+          childrenProp="children"
+          rowHeight={24}
+          items={[createTree()]}
+          Node={({ item, isLeaf, onToggle, isExpanded, deepLevel }) => {
+            const marginLeft = deepLevel * 15 + 'px';
+            return (
+              <Text>
+                <ClickableItem
+                  onClick={onToggle}
+                  ml={marginLeft}
+                  hidden={isLeaf}
+                >
+                  {isExpanded ? '-' : '+'}{' '}
+                </ClickableItem>
+                <span>This is item with {item.id} id</span>
+              </Text>
+            );
+          }}
+        />
+      </Container>
+    </>
+  );
+}
+
+const ClickableItem = styled.span`
+  visibility: ${props => (props.hidden ? 'hidden' : 'visible')};
+  margin-left: ${props => props.ml};
+  font-weight: bold;
+  cursor: pointer;
+  display: inline-block;
+  width: 10px;
+  margin-right: 5px;
+
+  &:hover {
+    transform: scale(1.5);
+  }
+`;
+
+const Container = styled.div`
+  height: 500px;
+`;

--- a/packages/teleterm/src/ui/components/VirtualScroll/VirtualScroll.story.tsx
+++ b/packages/teleterm/src/ui/components/VirtualScroll/VirtualScroll.story.tsx
@@ -38,7 +38,7 @@ interface TreeItem {
 }
 
 export function TreeList() {
-  const deepLevels = 6;
+  const depth = 6;
   const childrenPerLevel = 6;
 
   function createTree(currentLevel = 0): TreeItem {
@@ -47,7 +47,7 @@ export function TreeList() {
       id: unique(),
     };
 
-    if (currentLevel === deepLevels) {
+    if (currentLevel === depth) {
       return item;
     }
 
@@ -60,15 +60,15 @@ export function TreeList() {
 
   return (
     <>
-      <h2>Rendering up to {Math.pow(deepLevels, childrenPerLevel)} items</h2>
+      <h2>Rendering up to {Math.pow(depth, childrenPerLevel)} items</h2>
       <Container>
         <VirtualScroll<TreeItem>
           keyProp="id"
           childrenProp="children"
           rowHeight={24}
           items={[createTree()]}
-          Node={({ item, isLeaf, onToggle, isExpanded, deepLevel }) => {
-            const marginLeft = deepLevel * 15 + 'px';
+          Node={({ item, isLeaf, onToggle, isExpanded, depth }) => {
+            const marginLeft = depth * 15 + 'px';
             return (
               <Text>
                 <ClickableItem

--- a/packages/teleterm/src/ui/components/VirtualScroll/VirtualScroll.tsx
+++ b/packages/teleterm/src/ui/components/VirtualScroll/VirtualScroll.tsx
@@ -4,6 +4,8 @@ import { useVirtualScrollNodes } from './useVirtualScrollNodes';
 import { VirtualScrollProps } from './types';
 
 export function VirtualScroll<T>(props: VirtualScrollProps<T>) {
+  // consider using `content-visibility: auto` https://github.com/gravitational/webapps/pull/595#pullrequestreview-880424544
+
   const scrollableRef = useRef<HTMLDivElement>();
   const {
     setScrollTop,

--- a/packages/teleterm/src/ui/components/VirtualScroll/VirtualScroll.tsx
+++ b/packages/teleterm/src/ui/components/VirtualScroll/VirtualScroll.tsx
@@ -1,0 +1,55 @@
+import React, { useRef, useEffect } from 'react';
+import styled from 'styled-components';
+import { useVirtualScrollNodes } from './useVirtualScrollNodes';
+import { VirtualScrollProps } from './types';
+
+export function VirtualScroll<T>(props: VirtualScrollProps<T>) {
+  const scrollableRef = useRef<HTMLDivElement>();
+  const {
+    setScrollTop,
+    updateRenderedNodesCount,
+    visibleNodes,
+    offset,
+    totalHeight,
+  } = useVirtualScrollNodes(props);
+
+  function handleScroll(e: React.UIEvent<HTMLDivElement>): void {
+    setScrollTop(e.currentTarget.scrollTop);
+  }
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(entries => {
+      updateRenderedNodesCount(entries[0].contentRect.height);
+    });
+
+    resizeObserver.observe(scrollableRef.current);
+
+    return () => {
+      resizeObserver.unobserve(scrollableRef.current);
+      updateRenderedNodesCount.cancel();
+    };
+  }, []);
+
+  return (
+    <Scrollable ref={scrollableRef} onScroll={handleScroll}>
+      <TotalHeight height={totalHeight}>
+        <Offset moveBy={offset}>{visibleNodes}</Offset>
+      </TotalHeight>
+    </Scrollable>
+  );
+}
+
+const TotalHeight = styled.div`
+  height: ${props => props.height + 'px'};
+`;
+
+const Offset = styled.div.attrs(props => ({
+  style: {
+    transform: `translateY(${props.moveBy + 'px'})`,
+  },
+}))``;
+
+const Scrollable = styled.div`
+  height: 100%;
+  overflow-y: auto;
+`;

--- a/packages/teleterm/src/ui/components/VirtualScroll/index.ts
+++ b/packages/teleterm/src/ui/components/VirtualScroll/index.ts
@@ -1,0 +1,2 @@
+export * from './VirtualScroll';
+export * from './types';

--- a/packages/teleterm/src/ui/components/VirtualScroll/prepareVirtualScrollItems.ts
+++ b/packages/teleterm/src/ui/components/VirtualScroll/prepareVirtualScrollItems.ts
@@ -1,0 +1,36 @@
+import { VirtualScrollItem, VirtualScrollProps } from './types';
+
+export function prepareVirtualScrollItems<T>(
+  options: Pick<VirtualScrollProps<T>, 'items' | 'keyProp' | 'childrenProp'> & {
+    expandedKeys: Set<unknown>;
+  }
+) {
+  function getFlattenedItems(
+    items: T[],
+    parentKeys: string[] = []
+  ): VirtualScrollItem<T>[] {
+    return items.reduce<VirtualScrollItem<T>[]>((flattenedItems, item) => {
+      const hasChildren = item =>
+        Array.isArray(item[options.childrenProp]) &&
+        item[options.childrenProp]?.length;
+      const isLeaf = !hasChildren(item);
+      const deepLevel = parentKeys.length;
+      const virtualScrollItem = { item, deepLevel, parentKeys, isLeaf };
+
+      if (isLeaf || !options.expandedKeys.has(item[options.keyProp])) {
+        return [...flattenedItems, virtualScrollItem];
+      }
+
+      return [
+        ...flattenedItems,
+        virtualScrollItem,
+        ...getFlattenedItems(item[options.childrenProp] as unknown as T[], [
+          ...parentKeys,
+          item[options.keyProp] as unknown as string,
+        ]),
+      ];
+    }, []);
+  }
+
+  return getFlattenedItems(options.items);
+}

--- a/packages/teleterm/src/ui/components/VirtualScroll/types.ts
+++ b/packages/teleterm/src/ui/components/VirtualScroll/types.ts
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+
+export interface VirtualScrollProps<T> {
+  rowHeight: number;
+  keyProp: keyof T;
+  childrenProp?: keyof T;
+  items: T[];
+  Node(props: {
+    item: T;
+    deepLevel: number;
+    isExpanded: boolean;
+    isLeaf: boolean;
+    onToggle(): void;
+  }): ReactNode;
+}
+
+export interface VirtualScrollItem<T> {
+  item: T;
+  deepLevel: number;
+  parentKeys: string[];
+  isLeaf: boolean;
+}

--- a/packages/teleterm/src/ui/components/VirtualScroll/types.ts
+++ b/packages/teleterm/src/ui/components/VirtualScroll/types.ts
@@ -7,16 +7,9 @@ export interface VirtualScrollProps<T> {
   items: T[];
   Node(props: {
     item: T;
-    deepLevel: number;
+    depth: number;
     isExpanded: boolean;
     isLeaf: boolean;
     onToggle(): void;
   }): ReactNode;
-}
-
-export interface VirtualScrollItem<T> {
-  item: T;
-  deepLevel: number;
-  parentKeys: string[];
-  isLeaf: boolean;
 }

--- a/packages/teleterm/src/ui/components/VirtualScroll/useVirtualScrollNodes.tsx
+++ b/packages/teleterm/src/ui/components/VirtualScroll/useVirtualScrollNodes.tsx
@@ -1,0 +1,103 @@
+import React, { Fragment, useMemo, useState } from 'react';
+import { debounce } from 'lodash';
+import styled from 'styled-components';
+import { prepareVirtualScrollItems } from './prepareVirtualScrollItems';
+import { VirtualScrollProps } from './types';
+
+export function useVirtualScrollNodes<T>(props: VirtualScrollProps<T>) {
+  const renderedNodesMultiplier = 2;
+  const [expandedKeys, setExpandedKeys] = useState(new Set<unknown>());
+  const [renderedNodesLength, setRenderedNodesLength] = useState<number>();
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const items = useMemo(
+    () =>
+      prepareVirtualScrollItems<T>({
+        expandedKeys,
+        items: props.items,
+        childrenProp: props.childrenProp,
+        keyProp: props.keyProp,
+      }),
+    [expandedKeys, props.items, props.childrenProp, props.keyProp]
+  );
+
+  // these items are needed to be pre-rendered above visible items
+  const topPrereneredItems = useMemo(() => {
+    function getTopItemsCount() {
+      const value = Math.floor(
+        renderedNodesLength / renderedNodesMultiplier / 2
+      );
+      if (Number.isNaN(value)) {
+        return 0;
+      }
+      return value;
+    }
+
+    return Array.from(new Array(getTopItemsCount()))
+      .fill(0)
+      .map(() => undefined);
+  }, [renderedNodesLength, renderedNodesMultiplier]);
+
+  const firstIndexToRender = Math.floor(scrollTop / props.rowHeight);
+
+  const visibleNodes = [...topPrereneredItems, ...items]
+    .slice(firstIndexToRender, firstIndexToRender + renderedNodesLength)
+    .map((i, index) => {
+      if (i === undefined) {
+        return (
+          <EmptyNode key={`_empty_node_${index}`} height={props.rowHeight} />
+        );
+      }
+
+      const itemKey = i.item[props.keyProp];
+      return (
+        <Fragment key={itemKey.toString()}>
+          {props.Node({
+            item: i.item,
+            isExpanded: expandedKeys.has(itemKey),
+            isLeaf: i.isLeaf,
+            deepLevel: i.deepLevel,
+            onToggle: () => {
+              setExpandedKeys(prevExpandedKeys => {
+                const newExpandedKeys = new Set(prevExpandedKeys);
+                if (!newExpandedKeys.has(itemKey)) {
+                  newExpandedKeys.add(itemKey);
+                } else {
+                  newExpandedKeys.delete(itemKey);
+                }
+                return newExpandedKeys;
+              });
+            },
+          })}
+        </Fragment>
+      );
+    });
+
+  const totalHeight = props.rowHeight * items.length;
+  const offset =
+    (firstIndexToRender - topPrereneredItems.length) * props.rowHeight;
+
+  const updateRenderedNodesCount = useMemo(
+    () =>
+      debounce((viewportHeight: number) => {
+        const visibleItemsLength = Math.ceil(
+          (viewportHeight / props.rowHeight) * renderedNodesMultiplier
+        );
+        setRenderedNodesLength(visibleItemsLength);
+      }, 10),
+    [setRenderedNodesLength, renderedNodesMultiplier, props.rowHeight]
+  );
+
+  return {
+    totalHeight,
+    offset,
+    visibleNodes,
+    setScrollTop,
+    updateRenderedNodesCount,
+  };
+}
+
+const EmptyNode = styled.div`
+  width: 100%;
+  height: ${props => props.height + 'px'};
+`;

--- a/packages/teleterm/src/ui/components/VirtualScroll/useVirtualScrollNodes.tsx
+++ b/packages/teleterm/src/ui/components/VirtualScroll/useVirtualScrollNodes.tsx
@@ -56,7 +56,7 @@ export function useVirtualScrollNodes<T>(props: VirtualScrollProps<T>) {
             item: i.item,
             isExpanded: expandedKeys.has(itemKey),
             isLeaf: i.isLeaf,
-            deepLevel: i.deepLevel,
+            depth: i.depth,
             onToggle: () => {
               setExpandedKeys(prevExpandedKeys => {
                 const newExpandedKeys = new Set(prevExpandedKeys);


### PR DESCRIPTION
The `VirtualScroll` component can render both simple lists and trees.
It doesn't provide any styling, everything should be configured using props and `Node` rendering function. 

Currently it's not used anywhere in `teleterm` due to design changes. 