### PR TITLE
switch recordings service endpoint back to `clusterEventsRecordingsPath`

### DIFF
--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -154,6 +154,16 @@ const cfg = {
     });
   },
 
+  getClusterEventsRecordingsUrl(
+    clusterId: string,
+    params: UrlSessionRecordingsParams
+  ) {
+    return generatePath(cfg.api.clusterEventsRecordingsPath, {
+      clusterId,
+      ...params,
+    });
+  },
+
   getAuthProviders() {
     return cfg.auth && cfg.auth.providers ? cfg.auth.providers : [];
   },

--- a/packages/teleport/src/services/recordings/recordings.ts
+++ b/packages/teleport/src/services/recordings/recordings.ts
@@ -1,9 +1,8 @@
 import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 import { RecordingsQuery, RecordingsResponse } from './types';
-import { formatters, eventCodes } from 'teleport/services/audit';
-
 import { makeRecording } from './makeRecording';
+
 export default class RecordingsService {
   maxFetchLimit = 5000;
 
@@ -14,14 +13,11 @@ export default class RecordingsService {
     const start = params.from.toISOString();
     const end = params.to.toISOString();
 
-    const url = cfg.getClusterEventsUrl(clusterId, {
+    const url = cfg.getClusterEventsRecordingsUrl(clusterId, {
       start,
       end,
       limit: this.maxFetchLimit,
       startKey: params.startKey || undefined,
-      include: `${formatters[eventCodes.SESSION_END].type},${
-        formatters[eventCodes.DESKTOP_SESSION_ENDED].type
-      }`,
     });
 
     return api.get(url).then(json => {


### PR DESCRIPTION
`clusterEventsRecordingsPath` respects rbac where clauses, so users won't see desktop sessions they don't have permission to play back in the Recordings table.

Corresponds with https://github.com/gravitational/teleport/pull/10325