### PR TITLE
Fix date picker

### DIFF
--- a/packages/teleport/src/components/EventRangePicker/Custom/Custom.jsx
+++ b/packages/teleport/src/components/EventRangePicker/Custom/Custom.jsx
@@ -83,7 +83,7 @@ export default class CustomRange extends React.Component {
         <DayPicker
           className="Selectable"
           numberOfMonths={2}
-          month={subMonths(to, 1)}
+          month={subMonths(to || new Date(), 1)}
           disabledDays={{
             after: new Date(),
           }}


### PR DESCRIPTION
## Purpose

Fixes bug that caused an error if `to` was undefined when using the date picker.

## Implementation

With `momentjs`, if an inputted date was invalid or `undefined`, it would fallback to using the current date. However `date-fns` instead gives `Invalid Date` and this results in an error. This PR returns behaviour to the same way it was prior.