### PR TITLE
Add chrome as unsupported for U2F checks

### DIFF
--- a/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -104,7 +104,7 @@ export default function LoginForm(props: Props) {
       {({ validator }) => (
         <CardLogin title={title}>
           {isFailed && (
-            <Alerts.Danger m={5} mb={0}>
+            <Alerts.Danger m={5} mb={0} style={{ wordBreak: 'break-word' }}>
               {message}
             </Alerts.Danger>
           )}

--- a/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
+++ b/packages/teleport/src/components/FormLogin/__snapshots__/FormLogin.story.test.tsx.snap
@@ -2544,6 +2544,7 @@ exports[`server error rendering 1`] = `
   <div
     class="c2"
     kind="danger"
+    style="word-break: break-word;"
   >
     invalid credentials with looooooooooooooooooooooooooooooooong text
   </div>

--- a/packages/teleport/src/components/FormNewCredentials/FormNewCredentials.tsx
+++ b/packages/teleport/src/components/FormNewCredentials/FormNewCredentials.tsx
@@ -210,11 +210,11 @@ export type Props = {
 
 function ErrorMessage({ message = '' }) {
   // quick fix: check if error text has U2F substring
-  const browserSupported = !message.includes('does not support U2F');
-  const showU2fErrorLink = browserSupported && message.includes('U2F');
+  const notSupportedErr = !message.includes('is not supported');
+  const showU2fErrorLink = notSupportedErr && message.includes('U2F');
 
   return (
-    <Alerts.Danger>
+    <Alerts.Danger style={{ wordBreak: 'break-word' }}>
       <div>
         {message}
         {showU2fErrorLink && (

--- a/packages/teleport/src/components/FormNewCredentials/__snapshots__/FormNewCredentials.story.test.tsx.snap
+++ b/packages/teleport/src/components/FormNewCredentials/__snapshots__/FormNewCredentials.story.test.tsx.snap
@@ -766,6 +766,7 @@ exports[`story.OtpError 1`] = `
       <div
         class="c4"
         kind="danger"
+        style="word-break: break-word;"
       >
         <div>
           Server error with a long teeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeext
@@ -2013,6 +2014,7 @@ exports[`story.Webauthn Error 1`] = `
       <div
         class="c4"
         kind="danger"
+        style="word-break: break-word;"
       >
         <div>
           Message with has [U2F] word

--- a/packages/teleport/src/services/auth/auth.test.js
+++ b/packages/teleport/src/services/auth/auth.test.js
@@ -46,11 +46,11 @@ describe('services/auth', () => {
     expect.assertions(2);
 
     await auth.loginWithU2f(email, password).catch(err => {
-      expect(err.message).toContain('does not support U2F');
+      expect(err.message).toContain('is not supported');
     });
 
     await auth.resetPasswordWithU2f('any', password).catch(err => {
-      expect(err.message).toContain('does not support U2F');
+      expect(err.message).toContain('is not supported');
     });
   });
 
@@ -132,9 +132,7 @@ describe('services/auth', () => {
     };
 
     await auth.resetPasswordWithU2f('tokenId', password);
-    expect(
-      api.post
-    ).toHaveBeenCalledWith(
+    expect(api.post).toHaveBeenCalledWith(
       cfg.getMfaCreateRegistrationChallengeUrl('tokenId'),
       { deviceType: 'u2f' }
     );

--- a/packages/teleport/src/services/auth/auth.ts
+++ b/packages/teleport/src/services/auth/auth.ts
@@ -35,7 +35,7 @@ const auth = {
         'The U2F API for hardware keys is not supported by your browser. \
         Please notify your system administrator to update cluster settings \
         to use WebAuthn as the second factor protocol. In the meantime, \
-        you can use Firefox to log in.'
+        you can use Firefox to use this hardware key.'
       );
     }
   },

--- a/packages/teleport/src/services/auth/auth.ts
+++ b/packages/teleport/src/services/auth/auth.ts
@@ -30,13 +30,14 @@ import { DeviceType } from './types';
 
 const auth = {
   u2fBrowserSupported() {
-    if (window['u2f']) {
-      return null;
+    if (!window['u2f'] || navigator.userAgent.includes('Chrome')) {
+      return new Error(
+        'The U2F API for hardware keys is not supported by your browser. \
+        Please notify your system administrator to update cluster settings \
+        to use WebAuthn as the second factor protocol. In the meantime, \
+        you can use Firefox to log in.'
+      );
     }
-
-    return new Error(
-      'this browser does not support U2F required for hardware tokens, please try Chrome or Firefox instead'
-    );
   },
 
   checkWebauthnSupport() {
@@ -102,7 +103,7 @@ const auth = {
     return auth.mfaLoginBegin(name, password).then(data => {
       const promise = new Promise((resolve, reject) => {
         const { appId, challenge, registeredKeys } = data.u2f;
-        window['u2f'].sign(appId, challenge, registeredKeys, function(res) {
+        window['u2f'].sign(appId, challenge, registeredKeys, function (res) {
           if (res.errorCode) {
             const err = auth._getU2fErr(res.errorCode);
             reject(err);
@@ -208,7 +209,7 @@ const auth = {
     return auth.mfaChangePasswordBegin(oldPass).then(data => {
       return new Promise((resolve, reject) => {
         const { appId, challenge, registeredKeys } = data.u2f;
-        window['u2f'].sign(appId, challenge, registeredKeys, function(res) {
+        window['u2f'].sign(appId, challenge, registeredKeys, function (res) {
           if (res.errorCode) {
             const err = auth._getU2fErr(res.errorCode);
             reject(err);
@@ -330,14 +331,19 @@ const auth = {
     return auth.createMfaRegistrationChallenge(tokenId, 'u2f').then(data => {
       const challenge = data.u2fRegisterRequest;
       return new Promise((resolve, reject) => {
-        window['u2f'].register(challenge.appId, [challenge], [], function(res) {
-          if (res.errorCode) {
-            const err = auth._getU2fErr(res.errorCode);
-            reject(err);
-            return;
+        window['u2f'].register(
+          challenge.appId,
+          [challenge],
+          [],
+          function (res) {
+            if (res.errorCode) {
+              const err = auth._getU2fErr(res.errorCode);
+              reject(err);
+              return;
+            }
+            resolve(res);
           }
-          resolve(res);
-        });
+        );
       });
     });
   },
@@ -359,7 +365,7 @@ const auth = {
 
 function base64EncodeUnicode(str: string) {
   return window.btoa(
-    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
       const hexadecimalStr = '0x' + p1;
       return String.fromCharCode(Number(hexadecimalStr));
     })


### PR DESCRIPTION
** requires backporting to `v8`

### Description
u2f api no longer works for chrome ([since this month](https://www.yubico.com/blog/google-chrome-u2f-api-decommission-what-the-change-means-for-your-users-and-how-to-prepare/)), and when users try to log in or 'create account', the error is obscure or hidden (shows up in console log) so it appears to do nothing. Firefox still supports u2f (could not find when they are ending it). 

This PR checks if users are on chrome, to give a better error message. Same error message is shown to safari users.

![image](https://user-images.githubusercontent.com/43280172/154753714-77358dcb-5f1f-4a69-8ce1-0c8751b2fd47.png)
