### PR TITLE
[v7 backport] Add public tunnel address

### DIFF
--- a/packages/teleport/src/Support/Support.story.tsx
+++ b/packages/teleport/src/Support/Support.story.tsx
@@ -27,6 +27,10 @@ export const SupportEnterprise = () => (
   <Support {...props} isEnterprise={true} />
 );
 
+export const SupportWithTunnelAddress = () => (
+  <Support {...props} tunnelPublicAddress="localhost:11005"></Support>
+);
+
 const props = {
   clusterId: 'test',
   authVersion: '4.4.0-dev',

--- a/packages/teleport/src/Support/Support.tsx
+++ b/packages/teleport/src/Support/Support.tsx
@@ -26,7 +26,13 @@ export default function Container() {
   const ctx = useTeleport();
   const cluster = ctx.storeUser.state.cluster;
 
-  return <Support {...cluster} isEnterprise={cfg.isEnterprise} />;
+  return (
+    <Support
+      {...cluster}
+      isEnterprise={cfg.isEnterprise}
+      tunnelPublicAddress={cfg.tunnelPublicAddress}
+    />
+  );
 }
 
 export const Support = ({
@@ -34,6 +40,7 @@ export const Support = ({
   authVersion,
   publicURL,
   isEnterprise,
+  tunnelPublicAddress,
 }: Props) => {
   const docs = getDocUrls(authVersion, isEnterprise);
 
@@ -120,6 +127,9 @@ export const Support = ({
         <ClusterData title="Cluster Name" data={clusterId} />
         <ClusterData title="Teleport Version" data={authVersion} />
         <ClusterData title="Public Address" data={publicURL} />
+        {tunnelPublicAddress && (
+          <ClusterData title="Public SSH Tunnel" data={tunnelPublicAddress} />
+        )}
       </Box>
     </FeatureBox>
   );
@@ -209,4 +219,5 @@ type Props = {
   authVersion: string;
   publicURL: string;
   isEnterprise: boolean;
+  tunnelPublicAddress?: string;
 };

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -20,6 +20,7 @@ import { AuthProvider, Auth2faType } from 'shared/services';
 
 const cfg = {
   isEnterprise: false,
+  tunnelPublicAddress: '',
 
   baseUrl: window.location.origin,
 


### PR DESCRIPTION
Backport of https://github.com/gravitational/webapps/pull/580

teleport v7 backport: gravitational/teleport#10549
___

## Purpose
Show the reverse tunnel address on Help & Support screen.

On cloud instances, we use a custom reverse tunnel port for each tenant. In the UI, there is no way to know your reverse tunnel address, which is necessary when adding a trusted cluster.
This PR adds a new field under cluster information Public SSH Tunnel.

Screenshot: 
![Screenshot from 2022-02-03 16-34-15](https://user-images.githubusercontent.com/8400114/152523742-1edd5f61-8d89-45c3-8e78-ca93a084ae1f.png)
(new field `Public SSH Tunnel` at the bottom of **Cluster Information**)
