### PR TITLE
If running in enterprise version then provide the enterprise download links

### DIFF
--- a/packages/teleport/src/Apps/AddApp/AddApp.tsx
+++ b/packages/teleport/src/Apps/AddApp/AddApp.tsx
@@ -85,10 +85,11 @@ export function AddApp({
         )}
         {!automatic && (
           <Manually
-            user={user}
-            onClose={onClose}
-            version={version}
             isAuthTypeLocal={isAuthTypeLocal}
+            isEnterprise={isEnterprise}
+            onClose={onClose}
+            user={user}
+            version={version}
           />
         )}
       </Flex>

--- a/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
+++ b/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { Text, Box, ButtonSecondary, Link } from 'design';
 import { DialogContent, DialogFooter } from 'design/Dialog';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
-import * as links from 'teleport/services/links';
+import DownloadLinks from 'teleport/components/DownloadLinks';
 
 export default function Manually({
   user,
@@ -42,17 +42,7 @@ export default function Manually({
             Step 1
           </Text>{' '}
           - Download Teleport package to your computer
-          <Box>
-            <Link href={links.getMacOS(version)} target="_blank" mr="2">
-              MacOS
-            </Link>
-            <Link href={links.getLinux64(version)} target="_blank" mr="2">
-              Linux 64-bit
-            </Link>
-            <Link href={links.getLinux32(version)} target="_blank">
-              Linux 32-bit
-            </Link>
-          </Box>
+          <DownloadLinks version={version} />
         </Box>
         <Box mb={4}>
           <Text bold as="span">

--- a/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
+++ b/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
@@ -19,6 +19,7 @@ import { Text, Box, ButtonSecondary, Link } from 'design';
 import { DialogContent, DialogFooter } from 'design/Dialog';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import DownloadLinks from 'teleport/components/DownloadLinks';
+import useTeleport from 'teleport/useTeleport';
 
 export default function Manually({
   user,
@@ -29,6 +30,9 @@ export default function Manually({
   const { hostname, port } = window.document.location;
   const host = `${hostname}:${port || '443'}`;
   let tshLoginCmd = `tsh login --proxy=${host}`;
+
+  const ctx = useTeleport();
+  const isEnterprise = ctx.isEnterprise;
 
   if (isAuthTypeLocal) {
     tshLoginCmd = `${tshLoginCmd} --auth=local --user=${user}`;
@@ -42,7 +46,7 @@ export default function Manually({
             Step 1
           </Text>{' '}
           - Download Teleport package to your computer
-          <DownloadLinks version={version} />
+          <DownloadLinks isEnterprise={isEnterprise} version={version} />
         </Box>
         <Box mb={4}>
           <Text bold as="span">

--- a/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
+++ b/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
@@ -19,9 +19,9 @@ import { Text, Box, ButtonSecondary, Link } from 'design';
 import { DialogContent, DialogFooter } from 'design/Dialog';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import DownloadLinks from 'teleport/components/DownloadLinks';
-import useTeleport from 'teleport/useTeleport';
 
 export default function Manually({
+  isEnterprise,
   user,
   version,
   onClose,
@@ -30,9 +30,6 @@ export default function Manually({
   const { hostname, port } = window.document.location;
   const host = `${hostname}:${port || '443'}`;
   let tshLoginCmd = `tsh login --proxy=${host}`;
-
-  const ctx = useTeleport();
-  const isEnterprise = ctx.isEnterprise;
 
   if (isAuthTypeLocal) {
     tshLoginCmd = `${tshLoginCmd} --auth=local --user=${user}`;
@@ -93,6 +90,7 @@ export default function Manually({
 
 type Props = {
   onClose(): void;
+  isEnterprise: boolean;
   version: string;
   user: string;
   isAuthTypeLocal: boolean;

--- a/packages/teleport/src/Databases/AddDatabase/AddDatabase.story.tsx
+++ b/packages/teleport/src/Databases/AddDatabase/AddDatabase.story.tsx
@@ -23,6 +23,7 @@ export default {
 
 export const Add = () => (
   <Component
+    isEnterprise={false}
     username="yassine"
     version="6.1.3"
     onClose={() => null}

--- a/packages/teleport/src/Databases/AddDatabase/AddDatabase.test.tsx
+++ b/packages/teleport/src/Databases/AddDatabase/AddDatabase.test.tsx
@@ -65,6 +65,7 @@ test('render instructions dialog for adding database', () => {
 });
 
 const props: Props = {
+  isEnterprise: false,
   username: 'yassine',
   version: '6.1.3',
   onClose: () => null,

--- a/packages/teleport/src/Databases/AddDatabase/AddDatabase.tsx
+++ b/packages/teleport/src/Databases/AddDatabase/AddDatabase.tsx
@@ -23,7 +23,6 @@ import Dialog, {
 } from 'design/Dialog';
 import { Text, Box, ButtonSecondary, Link } from 'design';
 import Select, { Option } from 'shared/components/Select';
-import * as links from 'teleport/services/links';
 import { AuthType } from 'teleport/services/user';
 import { DbType, DbProtocol } from 'teleport/services/databases';
 import {
@@ -31,6 +30,7 @@ import {
   DatabaseInfo,
 } from 'teleport/services/databases/makeDatabase';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
+import DownloadLinks from 'teleport/components/DownloadLinks';
 
 export default function AddDatabase({
   username,
@@ -78,17 +78,7 @@ export default function AddDatabase({
             Step 1
           </Text>
           {' - Download Teleport package to your computer '}
-          <Box>
-            <Link href={links.getMacOS(version)} target="_blank" mr="2">
-              MacOS
-            </Link>
-            <Link href={links.getLinux64(version)} target="_blank" mr="2">
-              Linux 64-bit
-            </Link>
-            <Link href={links.getLinux32(version)} target="_blank">
-              Linux 32-bit
-            </Link>
-          </Box>
+          <DownloadLinks version={version} />
         </Box>
         <Box mb={4}>
           <Text bold as="span">

--- a/packages/teleport/src/Databases/AddDatabase/AddDatabase.tsx
+++ b/packages/teleport/src/Databases/AddDatabase/AddDatabase.tsx
@@ -31,6 +31,7 @@ import {
 } from 'teleport/services/databases/makeDatabase';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import DownloadLinks from 'teleport/components/DownloadLinks';
+import useTeleport from 'teleport/useTeleport';
 
 export default function AddDatabase({
   username,
@@ -40,6 +41,9 @@ export default function AddDatabase({
 }: Props) {
   const { hostname, port } = window.document.location;
   const host = `${hostname}:${port || '443'}`;
+
+  const ctx = useTeleport();
+  const isEnterprise = ctx.isEnterprise;
 
   const [dbOptions] = useState<Option<DatabaseInfo>[]>(() =>
     options.map(dbOption => {
@@ -78,7 +82,7 @@ export default function AddDatabase({
             Step 1
           </Text>
           {' - Download Teleport package to your computer '}
-          <DownloadLinks version={version} />
+          <DownloadLinks isEnterprise={isEnterprise} version={version} />
         </Box>
         <Box mb={4}>
           <Text bold as="span">

--- a/packages/teleport/src/Databases/AddDatabase/AddDatabase.tsx
+++ b/packages/teleport/src/Databases/AddDatabase/AddDatabase.tsx
@@ -31,9 +31,9 @@ import {
 } from 'teleport/services/databases/makeDatabase';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import DownloadLinks from 'teleport/components/DownloadLinks';
-import useTeleport from 'teleport/useTeleport';
 
 export default function AddDatabase({
+  isEnterprise,
   username,
   version,
   authType,
@@ -41,9 +41,6 @@ export default function AddDatabase({
 }: Props) {
   const { hostname, port } = window.document.location;
   const host = `${hostname}:${port || '443'}`;
-
-  const ctx = useTeleport();
-  const isEnterprise = ctx.isEnterprise;
 
   const [dbOptions] = useState<Option<DatabaseInfo>[]>(() =>
     options.map(dbOption => {
@@ -178,6 +175,7 @@ const options: DatabaseInfo[] = [
 ];
 
 export type Props = {
+  isEnterprise: boolean;
   onClose(): void;
   username: string;
   version: string;

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -27,7 +27,7 @@ import Empty, { EmptyStateInfo } from 'teleport/components/Empty';
 import DatabaseList from './DatabaseList';
 import useDatabases, { State } from './useDatabases';
 import ButtonAdd from './ButtonAdd';
-import AddDialog from './AddDatabase';
+import AddDatabase from './AddDatabase';
 
 export default function Container() {
   const ctx = useTeleport();
@@ -44,6 +44,7 @@ export function Databases(props: State) {
     showAddDialog,
     hideAddDialog,
     isAddDialogVisible,
+    isEnterprise,
     username,
     version,
     clusterId,
@@ -88,7 +89,8 @@ export function Databases(props: State) {
         />
       )}
       {isAddDialogVisible && (
-        <AddDialog
+        <AddDatabase
+          isEnterprise={isEnterprise}
           username={username}
           version={version}
           authType={authType}

--- a/packages/teleport/src/Nodes/AddNode/AddNode.tsx
+++ b/packages/teleport/src/Nodes/AddNode/AddNode.tsx
@@ -35,6 +35,7 @@ export default function Container(props: Props) {
 }
 
 export function AddNode({
+  isEnterprise,
   user,
   onClose,
   script,
@@ -85,6 +86,7 @@ export function AddNode({
           )}
           {!automatic && (
             <Manually
+              isEnterprise={isEnterprise}
               user={user}
               version={version}
               isAuthTypeLocal={isAuthTypeLocal}

--- a/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
+++ b/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
@@ -18,15 +18,16 @@ import React from 'react';
 import { Text, Box } from 'design';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import DownloadLinks from 'teleport/components/DownloadLinks';
-import useTeleport from 'teleport/useTeleport';
 
-export default function Manually({ user, version, isAuthTypeLocal }: Props) {
+export default function Manually({
+  isEnterprise,
+  user,
+  version,
+  isAuthTypeLocal,
+}: Props) {
   const { hostname, port } = window.document.location;
   const host = `${hostname}:${port || '443'}`;
   let tshLoginCmd = `tsh login --proxy=${host}`;
-
-  const ctx = useTeleport();
-  const isEnterprise = ctx.isEnterprise;
 
   if (isAuthTypeLocal) {
     tshLoginCmd = `${tshLoginCmd} --auth=local --user=${user}`;
@@ -70,6 +71,7 @@ export default function Manually({ user, version, isAuthTypeLocal }: Props) {
 }
 
 type Props = {
+  isEnterprise: boolean;
   user: string;
   version: string;
   isAuthTypeLocal: boolean;

--- a/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
+++ b/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
@@ -15,9 +15,9 @@
  */
 
 import React from 'react';
-import { Text, Box, Link } from 'design';
+import { Text, Box } from 'design';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
-import * as links from 'teleport/services/links';
+import DownloadLinks from 'teleport/components/DownloadLinks';
 
 export default function Manually({ user, version, isAuthTypeLocal }: Props) {
   const { hostname, port } = window.document.location;
@@ -35,17 +35,7 @@ export default function Manually({ user, version, isAuthTypeLocal }: Props) {
           Step 1
         </Text>{' '}
         - Download Teleport package to your computer
-        <Box>
-          <Link href={links.getMacOS(version)} target="_blank" mr="2">
-            MacOS
-          </Link>
-          <Link href={links.getLinux64(version)} target="_blank" mr="2">
-            Linux 64-bit
-          </Link>
-          <Link href={links.getLinux32(version)} target="_blank">
-            Linux 32-bit
-          </Link>
-        </Box>
+        <DownloadLinks version={version} />
       </Box>
       <Box mb={4}>
         <Text bold as="span">

--- a/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
+++ b/packages/teleport/src/Nodes/AddNode/Manually/Manually.tsx
@@ -18,11 +18,15 @@ import React from 'react';
 import { Text, Box } from 'design';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import DownloadLinks from 'teleport/components/DownloadLinks';
+import useTeleport from 'teleport/useTeleport';
 
 export default function Manually({ user, version, isAuthTypeLocal }: Props) {
   const { hostname, port } = window.document.location;
   const host = `${hostname}:${port || '443'}`;
   let tshLoginCmd = `tsh login --proxy=${host}`;
+
+  const ctx = useTeleport();
+  const isEnterprise = ctx.isEnterprise;
 
   if (isAuthTypeLocal) {
     tshLoginCmd = `${tshLoginCmd} --auth=local --user=${user}`;
@@ -35,7 +39,7 @@ export default function Manually({ user, version, isAuthTypeLocal }: Props) {
           Step 1
         </Text>{' '}
         - Download Teleport package to your computer
-        <DownloadLinks version={version} />
+        <DownloadLinks isEnterprise={isEnterprise} version={version} />
       </Box>
       <Box mb={4}>
         <Text bold as="span">

--- a/packages/teleport/src/Nodes/AddNode/__snapshots__/AddNode.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/AddNode/__snapshots__/AddNode.story.test.tsx.snap
@@ -991,7 +991,7 @@ exports[`render manual tab with local user 1`] = `
             >
               <a
                 class="c14"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-darwin-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-darwin-amd64-bin.tar.gz"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -999,7 +999,7 @@ exports[`render manual tab with local user 1`] = `
               </a>
               <a
                 class="c14"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-linux-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-linux-amd64-bin.tar.gz"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -1007,7 +1007,7 @@ exports[`render manual tab with local user 1`] = `
               </a>
               <a
                 class="c15"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-linux-386-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-linux-386-bin.tar.gz"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -1468,7 +1468,7 @@ exports[`render manual tab with sso user 1`] = `
             >
               <a
                 class="c14"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-darwin-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-darwin-amd64-bin.tar.gz"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -1476,7 +1476,7 @@ exports[`render manual tab with sso user 1`] = `
               </a>
               <a
                 class="c14"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-linux-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-linux-amd64-bin.tar.gz"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -1484,7 +1484,7 @@ exports[`render manual tab with sso user 1`] = `
               </a>
               <a
                 class="c15"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-linux-386-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-linux-386-bin.tar.gz"
                 rel="noreferrer"
                 target="_blank"
               >

--- a/packages/teleport/src/Nodes/AddNode/useAddNode.ts
+++ b/packages/teleport/src/Nodes/AddNode/useAddNode.ts
@@ -21,6 +21,7 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 export default function useAddNode(ctx: TeleportContext) {
   const { attempt, run } = useAttempt('processing');
   const canCreateToken = ctx.storeUser.getTokenAccess().create;
+  const isEnterprise = ctx.isEnterprise;
   const version = ctx.storeUser.state.cluster.authVersion;
   const user = ctx.storeUser.state.username;
   const isAuthTypeLocal = !ctx.storeUser.isSso();
@@ -42,6 +43,7 @@ export default function useAddNode(ctx: TeleportContext) {
   }
 
   return {
+    isEnterprise,
     canCreateToken,
     createJoinToken,
     automatic,

--- a/packages/teleport/src/components/DownloadLinks/DownloadLinks.tsx
+++ b/packages/teleport/src/components/DownloadLinks/DownloadLinks.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Link } from 'design';
+import getDownloadLink from 'teleport/services/links';
+import useTeleport from 'teleport/useTeleport';
+
+export default function DownloadLinks({ version }: Props) {
+  const ctx = useTeleport();
+  const isEnterprise = ctx.isEnterprise;
+
+  return (
+    <Box>
+      <Link
+        href={getDownloadLink('mac', version, isEnterprise)}
+        target="_blank"
+        mr="2"
+      >
+        MacOS
+      </Link>
+      <Link
+        href={getDownloadLink('linux64', version, isEnterprise)}
+        target="_blank"
+        mr="2"
+      >
+        Linux 64-bit
+      </Link>
+      <Link
+        href={getDownloadLink('linux32', version, isEnterprise)}
+        target="_blank"
+      >
+        Linux 32-bit
+      </Link>
+    </Box>
+  );
+}
+
+type Props = {
+  version: string;
+};

--- a/packages/teleport/src/components/DownloadLinks/DownloadLinks.tsx
+++ b/packages/teleport/src/components/DownloadLinks/DownloadLinks.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { Box, Link } from 'design';
 import getDownloadLink from 'teleport/services/links';

--- a/packages/teleport/src/components/DownloadLinks/DownloadLinks.tsx
+++ b/packages/teleport/src/components/DownloadLinks/DownloadLinks.tsx
@@ -17,12 +17,8 @@
 import React from 'react';
 import { Box, Link } from 'design';
 import getDownloadLink from 'teleport/services/links';
-import useTeleport from 'teleport/useTeleport';
 
-export default function DownloadLinks({ version }: Props) {
-  const ctx = useTeleport();
-  const isEnterprise = ctx.isEnterprise;
-
+export default function DownloadLinks({ isEnterprise, version }: Props) {
   return (
     <Box>
       <Link
@@ -50,5 +46,6 @@ export default function DownloadLinks({ version }: Props) {
 }
 
 type Props = {
+  isEnterprise: boolean;
   version: string;
 };

--- a/packages/teleport/src/components/DownloadLinks/index.ts
+++ b/packages/teleport/src/components/DownloadLinks/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Gravitational, Inc.
+ * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,5 @@
  * limitations under the License.
  */
 
-const DOWNLOAD_BASE_URL = 'https://get.gravitational.com/';
-
-export default function getDownloadLink(
-  type: Arch,
-  version: string,
-  isEnterprise: boolean
-) {
-  let infix = 'linux-amd64';
-  const enterprise = isEnterprise ? 'ent-' : '';
-  if (type === 'mac') {
-    infix = 'darwin-amd64';
-  } else if (type === 'linux32') {
-    infix = 'linux-386';
-  }
-
-  return `${DOWNLOAD_BASE_URL}teleport-${enterprise}v${version}-${infix}-bin.tar.gz`;
-}
-
-type Arch = 'mac' | 'linux32' | 'linux64';
+import DownloadLinks from './DownloadLinks';
+export default DownloadLinks;

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Applications/Applications.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Applications/Applications.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import styled from 'styled-components';
-import { Label, Flex, Text, ButtonBorder } from 'design';
+import { Flex, Text, ButtonBorder } from 'design';
 import {
   pink,
   teal,

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { useServers, State } from './useServers';
 import * as types from 'teleterm/ui/services/clusters/types';
 import Table, { Cell } from 'design/DataTable';
-import { ButtonBorder, Label } from 'design';
+import { ButtonBorder } from 'design';
 import { renderLabelCell } from '../renderLabelCell';
 
 export default function Container() {


### PR DESCRIPTION
- Change the file download link depending on the enterprise status of the deployment.
- Consolidate the links into a separate component.

Fixes: https://github.com/gravitational/teleport/issues/10341
