### PR TITLE
Edit api response for getXXX (resources)

### DIFF
--- a/packages/teleport/src/Apps/Apps.story.test.tsx
+++ b/packages/teleport/src/Apps/Apps.story.test.tsx
@@ -40,7 +40,7 @@ test('useApps hook returns expected props', async () => {
   const acl = makeAcl(sample.acl);
   ctx.isEnterprise = true;
   ctx.storeUser.setState({ acl });
-  ctx.appService.fetchApps = () => Promise.resolve(apps);
+  ctx.appService.fetchApps = () => Promise.resolve({ apps });
 
   let hook;
 

--- a/packages/teleport/src/Apps/useApps.ts
+++ b/packages/teleport/src/Apps/useApps.ts
@@ -31,7 +31,7 @@ export default function useApps(ctx: Ctx) {
   function refresh() {
     return ctx.appService
       .fetchApps(clusterId)
-      .then(setApps)
+      .then(res => setApps(res.apps))
       .catch((err: Error) =>
         setAttempt({ status: 'failed', statusText: err.message })
       );
@@ -47,7 +47,9 @@ export default function useApps(ctx: Ctx) {
   };
 
   useEffect(() => {
-    run(() => ctx.appService.fetchApps(clusterId).then(setApps));
+    run(() =>
+      ctx.appService.fetchApps(clusterId).then(res => setApps(res.apps))
+    );
   }, [clusterId]);
 
   return {

--- a/packages/teleport/src/Console/consoleContext.tsx
+++ b/packages/teleport/src/Console/consoleContext.tsx
@@ -146,10 +146,10 @@ export default class ConsoleContext {
       serviceUser.fetchUserContext(),
       serviceNodes.fetchNodes(clusterId),
     ]).then(values => {
-      const [user, nodes] = values;
+      const [user, nodesRes] = values;
       return {
         logins: user.acl.sshLogins,
-        nodes,
+        nodes: nodesRes.nodes,
       };
     });
   }

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -33,13 +33,17 @@ export default function useDatabases(ctx: Ctx) {
   const [isAddDialogVisible, setIsAddDialogVisible] = useState(false);
 
   useEffect(() => {
-    run(() => ctx.databaseService.fetchDatabases(clusterId).then(setDatabases));
+    run(() =>
+      ctx.databaseService
+        .fetchDatabases(clusterId)
+        .then(res => setDatabases(res.databases))
+    );
   }, [clusterId]);
 
   const fetchDatabases = () => {
     return ctx.databaseService
       .fetchDatabases(clusterId)
-      .then(setDatabases)
+      .then(res => setDatabases(res.databases))
       .catch((err: Error) =>
         setAttempt({ status: 'failed', statusText: err.message })
       );

--- a/packages/teleport/src/Desktops/useDesktops.ts
+++ b/packages/teleport/src/Desktops/useDesktops.ts
@@ -34,7 +34,11 @@ export default function useDesktops(ctx: Ctx) {
     makeOptions(clusterId, desktopName, windowsLogins);
 
   useEffect(() => {
-    run(() => ctx.desktopService.fetchDesktops(clusterId).then(setDesktops));
+    run(() =>
+      ctx.desktopService
+        .fetchDesktops(clusterId)
+        .then(res => setDesktops(res.desktops))
+    );
   }, [clusterId]);
 
   const openRemoteDesktopTab = (username: string, desktopName: string) => {

--- a/packages/teleport/src/Kubes/useKubes.ts
+++ b/packages/teleport/src/Kubes/useKubes.ts
@@ -28,7 +28,11 @@ export default function useKubes(ctx: TeleportContext) {
   const [kubes, setKubes] = useState([] as Kube[]);
 
   useEffect(() => {
-    run(() => ctx.kubeService.fetchKubernetes(clusterId).then(setKubes));
+    run(() =>
+      ctx.kubeService
+        .fetchKubernetes(clusterId)
+        .then(res => setKubes(res.kubes))
+    );
   }, [clusterId]);
 
   return {

--- a/packages/teleport/src/Main/Main.story.tsx
+++ b/packages/teleport/src/Main/Main.story.tsx
@@ -64,12 +64,12 @@ function useMainStory() {
     ctx.auditService.fetchEvents = () =>
       Promise.resolve({ events, startKey: '' });
     ctx.clusterService.fetchClusters = () => Promise.resolve(clusters);
-    ctx.nodeService.fetchNodes = () => Promise.resolve(nodes);
+    ctx.nodeService.fetchNodes = () => Promise.resolve({ nodes });
     ctx.sshService.fetchSessions = () => Promise.resolve(sessions);
-    ctx.appService.fetchApps = () => Promise.resolve(apps);
-    ctx.kubeService.fetchKubernetes = () => Promise.resolve(kubes);
-    ctx.databaseService.fetchDatabases = () => Promise.resolve(databases);
-    ctx.desktopService.fetchDesktops = () => Promise.resolve(desktops);
+    ctx.appService.fetchApps = () => Promise.resolve({ apps });
+    ctx.kubeService.fetchKubernetes = () => Promise.resolve({ kubes });
+    ctx.databaseService.fetchDatabases = () => Promise.resolve({ databases });
+    ctx.desktopService.fetchDesktops = () => Promise.resolve({ desktops });
     ctx.storeUser.setState(userContext);
     getFeatures().forEach(f => f.register(ctx));
     return ctx;

--- a/packages/teleport/src/Nodes/useNodes.ts
+++ b/packages/teleport/src/Nodes/useNodes.ts
@@ -31,7 +31,9 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
   const logins = ctx.storeUser.getSshLogins();
 
   useEffect(() => {
-    run(() => ctx.nodeService.fetchNodes(clusterId).then(setNodes));
+    run(() =>
+      ctx.nodeService.fetchNodes(clusterId).then(res => setNodes(res.nodes))
+    );
   }, [clusterId]);
 
   const getNodeLoginOptions = (serverId: string) =>
@@ -50,7 +52,7 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
   const fetchNodes = () => {
     return ctx.nodeService
       .fetchNodes(clusterId)
-      .then(setNodes)
+      .then(res => setNodes(res.nodes))
       .catch((err: Error) =>
         setAttempt({ status: 'failed', statusText: err.message })
       );

--- a/packages/teleport/src/services/apps/apps.test.ts
+++ b/packages/teleport/src/services/apps/apps.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import api from 'teleport/services/api';
+import apps from 'teleport/services/apps';
+
+test('correct formatting of apps fetch response', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue(mockResponse);
+  const response = await apps.fetchApps('does-not-matter');
+
+  expect(response).toEqual({
+    apps: [
+      {
+        id: 'cluster-id-app-name-app-name.example.com',
+        name: 'app-name',
+        description: 'some description',
+        uri: 'http://localhost:3001',
+        publicAddr: 'app-name.example.com',
+        tags: ['env: dev'],
+        clusterId: 'cluster-id',
+        fqdn: 'app-name.example.com',
+        launchUrl:
+          '/web/launch/app-name.example.com/cluster-id/app-name.example.com',
+        awsRoles: [],
+        awsConsole: false,
+      },
+    ],
+    startKey: mockResponse.startKey,
+    totalCount: mockResponse.totalCount,
+  });
+});
+
+test('null response from apps fetch', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue(null);
+
+  const response = await apps.fetchApps('does-not-matter');
+
+  expect(response).toEqual({
+    apps: [],
+    startKey: undefined,
+    totalCount: undefined,
+  });
+});
+
+test('null labels field in apps fetch response', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue({ items: [{ labels: null }] });
+  const response = await apps.fetchApps('does-not-matter');
+
+  expect(response.apps[0].tags).toEqual([]);
+});
+
+const mockResponse = {
+  items: [
+    {
+      awsConsole: false,
+      clusterId: 'cluster-id',
+      description: 'some description',
+      fqdn: 'app-name.example.com',
+      labels: [{ name: 'env', value: 'dev' }],
+      name: 'app-name',
+      publicAddr: 'app-name.example.com',
+      uri: 'http://localhost:3001',
+    },
+  ],
+  startKey: 'mockKey',
+  totalCount: 100,
+};

--- a/packages/teleport/src/services/apps/apps.ts
+++ b/packages/teleport/src/services/apps/apps.ts
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
-import { map } from 'lodash';
 import api from 'teleport/services/api';
 import cfg, { UrlAppParams } from 'teleport/config';
 import makeApp from './makeApps';
+import { AppsResponse } from './types';
 
 const service = {
-  fetchApps(clusterId: string) {
-    return api
-      .get(cfg.getApplicationsUrl(clusterId))
-      .then(json => map(json.items, makeApp));
+  fetchApps(clusterId: string): Promise<AppsResponse> {
+    return api.get(cfg.getApplicationsUrl(clusterId)).then(json => {
+      const items = json?.items || [];
+
+      return {
+        apps: items.map(makeApp),
+        startKey: json?.startKey,
+        totalCount: json?.totalCount,
+      };
+    });
   },
 
   createAppSession(params: UrlAppParams) {

--- a/packages/teleport/src/services/apps/makeApps.ts
+++ b/packages/teleport/src/services/apps/makeApps.ts
@@ -29,8 +29,11 @@ export default function makeApp(json: any): App {
     awsConsole = false,
   } = json;
 
+  const canCreateUrl = fqdn && clusterId && publicAddr;
+  const launchUrl = canCreateUrl
+    ? cfg.getAppLauncherRoute({ fqdn, clusterId, publicAddr })
+    : '';
   const id = `${clusterId}-${name}-${publicAddr}`;
-  const launchUrl = cfg.getAppLauncherRoute({ fqdn, clusterId, publicAddr });
   const labels = json.labels || [];
   const awsRoles = json.awsRoles || [];
 

--- a/packages/teleport/src/services/apps/types.ts
+++ b/packages/teleport/src/services/apps/types.ts
@@ -28,11 +28,11 @@ export interface App {
   awsConsole: boolean;
 }
 
-export interface AppsResponse {
+export type AppsResponse = {
   apps: App[];
   startKey?: string;
   totalCount?: number;
-}
+};
 
 export type AwsRole = {
   arn: string;

--- a/packages/teleport/src/services/apps/types.ts
+++ b/packages/teleport/src/services/apps/types.ts
@@ -28,6 +28,12 @@ export interface App {
   awsConsole: boolean;
 }
 
+export interface AppsResponse {
+  apps: App[];
+  startKey?: string;
+  totalCount?: number;
+}
+
 export type AwsRole = {
   arn: string;
   display: string;

--- a/packages/teleport/src/services/databases/databases.test.ts
+++ b/packages/teleport/src/services/databases/databases.test.ts
@@ -23,15 +23,19 @@ test('correct formatting of database fetch response', async () => {
   const database = new DatabaseService();
   const response = await database.fetchDatabases('im-a-cluster');
 
-  expect(response).toEqual([
-    {
-      name: 'aurora',
-      desc: 'PostgreSQL 11.6: AWS Aurora',
-      title: 'RDS PostgreSQL',
-      protocol: 'postgres',
-      tags: ['cluster: root', 'env: aws'],
-    },
-  ]);
+  expect(response).toEqual({
+    databases: [
+      {
+        name: 'aurora',
+        desc: 'PostgreSQL 11.6: AWS Aurora',
+        title: 'RDS PostgreSQL',
+        protocol: 'postgres',
+        tags: ['cluster: root', 'env: aws'],
+      },
+    ],
+    startKey: mockResponse.startKey,
+    totalCount: mockResponse.totalCount,
+  });
 });
 
 test('null response from database fetch', async () => {
@@ -40,7 +44,11 @@ test('null response from database fetch', async () => {
   const database = new DatabaseService();
   const response = await database.fetchDatabases('im-a-cluster');
 
-  expect(response).toEqual([]);
+  expect(response).toEqual({
+    databases: [],
+    startKey: undefined,
+    totalCount: undefined,
+  });
 });
 
 describe('correct formatting of all type and protocol combos', () => {
@@ -56,36 +64,39 @@ describe('correct formatting of all type and protocol combos', () => {
   `(
     'should combine type: $type and protocol: $protocol correctly',
     async ({ type, protocol, combined }) => {
-      jest.spyOn(api, 'get').mockResolvedValue([{ type, protocol }]);
+      jest.spyOn(api, 'get').mockResolvedValue({ items: [{ type, protocol }] });
 
       const database = new DatabaseService();
       const response = await database.fetchDatabases('im-a-cluster');
 
-      expect(response[0].title).toBe(combined);
+      expect(response.databases[0].title).toBe(combined);
     }
   );
 });
 
 test('null labels field in database fetch response', async () => {
-  jest.spyOn(api, 'get').mockResolvedValue([{ labels: null }]);
+  jest.spyOn(api, 'get').mockResolvedValue({ items: [{ labels: null }] });
 
   const database = new DatabaseService();
   const response = await database.fetchDatabases('im-a-cluster');
 
-  expect(response[0].tags).toEqual([]);
+  expect(response.databases[0].tags).toEqual([]);
 });
 
-const mockResponse = [
-  {
-    name: 'aurora',
-    desc: 'PostgreSQL 11.6: AWS Aurora',
-    protocol: 'postgres',
-    type: 'rds',
-    uri:
-      'postgres-aurora-instance-1.c1xpjrob56xs.us-west-1.rds.amazonaws.com:5432',
-    labels: [
-      { name: 'cluster', value: 'root' },
-      { name: 'env', value: 'aws' },
-    ],
-  },
-];
+const mockResponse = {
+  items: [
+    {
+      name: 'aurora',
+      desc: 'PostgreSQL 11.6: AWS Aurora',
+      protocol: 'postgres',
+      type: 'rds',
+      uri: 'postgres-aurora-instance-1.c1xpjrob56xs.us-west-1.rds.amazonaws.com:5432',
+      labels: [
+        { name: 'cluster', value: 'root' },
+        { name: 'env', value: 'aws' },
+      ],
+    },
+  ],
+  startKey: 'mockKey',
+  totalCount: 100,
+};

--- a/packages/teleport/src/services/databases/databases.ts
+++ b/packages/teleport/src/services/databases/databases.ts
@@ -14,16 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { map } from 'lodash';
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import makeDatabase from './makeDatabase';
+import { DatabasesResponse } from './types';
 
 class DatabaseService {
-  fetchDatabases(clusterId?: string) {
-    return api
-      .get(cfg.getDatabasesUrl(clusterId))
-      .then(json => map(json, makeDatabase));
+  fetchDatabases(clusterId?: string): Promise<DatabasesResponse> {
+    return api.get(cfg.getDatabasesUrl(clusterId)).then(json => {
+      const items = json?.items || [];
+
+      return {
+        databases: items.map(makeDatabase),
+        startKey: json?.startKey,
+        totalCount: json?.totalCount,
+      };
+    });
   }
 }
 

--- a/packages/teleport/src/services/databases/types.ts
+++ b/packages/teleport/src/services/databases/types.ts
@@ -25,8 +25,8 @@ export interface Database {
 export type DbType = 'redshift' | 'rds' | 'gcp' | 'self-hosted';
 export type DbProtocol = 'postgres' | 'mysql' | 'mongodb';
 
-export interface DatabasesResponse {
+export type DatabasesResponse = {
   databases: Database[];
   startKey?: string;
   totalCount?: number;
-}
+};

--- a/packages/teleport/src/services/databases/types.ts
+++ b/packages/teleport/src/services/databases/types.ts
@@ -24,3 +24,9 @@ export interface Database {
 
 export type DbType = 'redshift' | 'rds' | 'gcp' | 'self-hosted';
 export type DbProtocol = 'postgres' | 'mysql' | 'mongodb';
+
+export interface DatabasesResponse {
+  databases: Database[];
+  startKey?: string;
+  totalCount?: number;
+}

--- a/packages/teleport/src/services/desktops/desktops.test.ts
+++ b/packages/teleport/src/services/desktops/desktops.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import api from 'teleport/services/api';
+import desktops from 'teleport/services/desktops';
+
+test('correct formatting of desktops fetch response', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue(mockResponse);
+  const response = await desktops.fetchDesktops('does-not-matter');
+
+  expect(response).toEqual({
+    desktops: [
+      {
+        os: 'windows',
+        name: 'DC1-teleport-demo',
+        addr: '10.0.0.10',
+        tags: ['env: test'],
+      },
+    ],
+    startKey: mockResponse.startKey,
+    totalCount: mockResponse.totalCount,
+  });
+});
+
+test('null response from desktops fetch', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue(null);
+
+  const response = await desktops.fetchDesktops('does-not-matter');
+
+  expect(response).toEqual({
+    desktops: [],
+    startKey: undefined,
+    totalCount: undefined,
+  });
+});
+
+test('null labels field in desktops fetch response', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue({ items: [{ labels: null }] });
+  const response = await desktops.fetchDesktops('does-not-matter');
+
+  expect(response.desktops[0].tags).toEqual([]);
+});
+
+const mockResponse = {
+  items: [
+    {
+      addr: '10.0.0.10',
+      labels: [{ name: 'env', value: 'test' }],
+      name: 'DC1-teleport-demo',
+      os: 'windows',
+    },
+  ],
+  startKey: 'mockKey',
+  totalCount: 100,
+};

--- a/packages/teleport/src/services/desktops/desktops.ts
+++ b/packages/teleport/src/services/desktops/desktops.ts
@@ -14,16 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { map } from 'lodash';
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import makeDesktop from './makeDesktop';
+import { DesktopsResponse } from './types';
 
 class DesktopService {
-  fetchDesktops(clusterId: string) {
-    return api
-      .get(cfg.getDesktopsUrl(clusterId))
-      .then(json => map(json, makeDesktop));
+  fetchDesktops(clusterId: string): Promise<DesktopsResponse> {
+    return api.get(cfg.getDesktopsUrl(clusterId)).then(json => {
+      const items = json?.items || [];
+
+      return {
+        desktops: items.map(makeDesktop),
+        startKey: json?.startKey,
+        totalCount: json?.totalCount,
+      };
+    });
   }
 
   fetchDesktop(clusterId: string, desktopPath: string) {

--- a/packages/teleport/src/services/desktops/types.ts
+++ b/packages/teleport/src/services/desktops/types.ts
@@ -25,3 +25,9 @@ export type Desktop = {
   // Labels.
   tags: string[];
 };
+
+export interface DesktopsResponse {
+  desktops: Desktop[];
+  startKey?: string;
+  totalCount?: number;
+}

--- a/packages/teleport/src/services/desktops/types.ts
+++ b/packages/teleport/src/services/desktops/types.ts
@@ -26,8 +26,8 @@ export type Desktop = {
   tags: string[];
 };
 
-export interface DesktopsResponse {
+export type DesktopsResponse = {
   desktops: Desktop[];
   startKey?: string;
   totalCount?: number;
-}
+};

--- a/packages/teleport/src/services/kube/kube.test.ts
+++ b/packages/teleport/src/services/kube/kube.test.ts
@@ -23,12 +23,16 @@ test('correct processed fetch response formatting', async () => {
   const kubeService = new KubeService();
   const response = await kubeService.fetchKubernetes('clusterId');
 
-  expect(response).toEqual([
-    {
-      name: 'tele.logicoma.dev-prod',
-      tags: ['kernal: 4.15.0-51-generic', 'env: prod'],
-    },
-  ]);
+  expect(response).toEqual({
+    kubes: [
+      {
+        name: 'tele.logicoma.dev-prod',
+        tags: ['kernal: 4.15.0-51-generic', 'env: prod'],
+      },
+    ],
+    startKey: mockApiResponse.startKey,
+    totalCount: mockApiResponse.totalCount,
+  });
 });
 
 test('handling of null fetch response', async () => {
@@ -37,24 +41,34 @@ test('handling of null fetch response', async () => {
   const kubeService = new KubeService();
   const response = await kubeService.fetchKubernetes('clusterId');
 
-  expect(response).toEqual([]);
+  expect(response).toEqual({
+    kubes: [],
+    startKey: undefined,
+    totalCount: undefined,
+  });
 });
 
 test('handling of null labels', async () => {
-  jest.spyOn(api, 'get').mockResolvedValue([{ name: 'test', labels: null }]);
+  jest
+    .spyOn(api, 'get')
+    .mockResolvedValue({ items: [{ name: 'test', labels: null }] });
 
   const kubeService = new KubeService();
   const response = await kubeService.fetchKubernetes('clusterId');
 
-  expect(response).toEqual([{ name: 'test', tags: [] }]);
+  expect(response.kubes).toEqual([{ name: 'test', tags: [] }]);
 });
 
-const mockApiResponse = [
-  {
-    name: 'tele.logicoma.dev-prod',
-    labels: [
-      { name: 'kernal', value: '4.15.0-51-generic' },
-      { name: 'env', value: 'prod' },
-    ],
-  },
-];
+const mockApiResponse = {
+  items: [
+    {
+      name: 'tele.logicoma.dev-prod',
+      labels: [
+        { name: 'kernal', value: '4.15.0-51-generic' },
+        { name: 'env', value: 'prod' },
+      ],
+    },
+  ],
+  startKey: 'mockKey',
+  totalCount: 100,
+};

--- a/packages/teleport/src/services/kube/kube.ts
+++ b/packages/teleport/src/services/kube/kube.ts
@@ -14,16 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { map } from 'lodash';
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import makeKube from './makeKube';
+import { KubesResponse } from './types';
 
 class KubeService {
-  fetchKubernetes(clusterId) {
-    return api
-      .get(cfg.getKubernetesUrl(clusterId))
-      .then(json => map(json, makeKube));
+  fetchKubernetes(clusterId): Promise<KubesResponse> {
+    return api.get(cfg.getKubernetesUrl(clusterId)).then(json => {
+      const items = json?.items || [];
+
+      return {
+        kubes: items.map(makeKube),
+        startKey: json?.startKey,
+        totalCount: json?.totalCount,
+      };
+    });
   }
 }
 

--- a/packages/teleport/src/services/kube/types.ts
+++ b/packages/teleport/src/services/kube/types.ts
@@ -18,3 +18,9 @@ export interface Kube {
   name: string;
   tags: string[];
 }
+
+export interface KubesResponse {
+  kubes: Kube[];
+  startKey?: string;
+  totalCount?: number;
+}

--- a/packages/teleport/src/services/kube/types.ts
+++ b/packages/teleport/src/services/kube/types.ts
@@ -19,8 +19,8 @@ export interface Kube {
   tags: string[];
 }
 
-export interface KubesResponse {
+export type KubesResponse = {
   kubes: Kube[];
   startKey?: string;
   totalCount?: number;
-}
+};

--- a/packages/teleport/src/services/nodes/makeNode.ts
+++ b/packages/teleport/src/services/nodes/makeNode.ts
@@ -17,11 +17,11 @@ limitations under the License.
 import { Node } from './types';
 
 export default function makeNode(json): Node {
-  const { id, clusterId, hostname, addr, tunnel, tags = [] } = json;
+  const { id, siteId, hostname, addr, tunnel, tags = [] } = json;
 
   return {
     id,
-    clusterId,
+    clusterId: siteId,
     hostname,
     tags: tags.map(tag => `${tag.name}: ${tag.value}`),
     addr,

--- a/packages/teleport/src/services/nodes/nodes.test.ts
+++ b/packages/teleport/src/services/nodes/nodes.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import api from 'teleport/services/api';
+import nodes from 'teleport/services/nodes';
+
+test('correct formatting of nodes fetch response', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue(mockResponse);
+  const response = await nodes.fetchNodes('does-not-matter');
+
+  expect(response).toEqual({
+    nodes: [
+      {
+        id: '00a53f99-993b-40bc-af51-5ba259af4e43',
+        clusterId: 'im-a-cluster-name',
+        hostname: 'im-a-nodename',
+        tags: ['env: dev'],
+        addr: '192.168.86.132:3022',
+        tunnel: false,
+      },
+    ],
+    startKey: mockResponse.startKey,
+    totalCount: mockResponse.totalCount,
+  });
+});
+
+test('null response from nodes fetch', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue(null);
+
+  const response = await nodes.fetchNodes('does-not-matter');
+
+  expect(response).toEqual({
+    nodes: [],
+    startKey: undefined,
+    totalCount: undefined,
+  });
+});
+
+test('null labels field in nodes fetch response', async () => {
+  jest.spyOn(api, 'get').mockResolvedValue({ items: [{ labels: null }] });
+  const response = await nodes.fetchNodes('does-not-matter');
+
+  expect(response.nodes[0].tags).toEqual([]);
+});
+
+const mockResponse = {
+  items: [
+    {
+      addr: '192.168.86.132:3022',
+      hostname: 'im-a-nodename',
+      id: '00a53f99-993b-40bc-af51-5ba259af4e43',
+      siteId: 'im-a-cluster-name',
+      tags: [{ name: 'env', value: 'dev' }],
+      tunnel: false,
+    },
+  ],
+  startKey: 'mockKey',
+  totalCount: 100,
+};

--- a/packages/teleport/src/services/nodes/nodes.ts
+++ b/packages/teleport/src/services/nodes/nodes.ts
@@ -14,19 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { map } from 'lodash';
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import makeNode from './makeNode';
 import makeNodeToken from './makeNodeToken';
 import makeAppBashCmd from './makeAppBashCmd';
 import makeNodeBashCmd from './makeNodeBashCmd';
+import { NodesResponse } from './types';
 
 const service = {
-  fetchNodes(clusterId?: string) {
-    return api
-      .get(cfg.getClusterNodesUrl(clusterId))
-      .then(json => map(json.items, makeNode));
+  fetchNodes(clusterId?: string): Promise<NodesResponse> {
+    return api.get(cfg.getClusterNodesUrl(clusterId)).then(json => {
+      const items = json?.items || [];
+
+      return {
+        nodes: items.map(makeNode),
+        startKey: json?.startKey,
+        totalCount: json?.totalCount,
+      };
+    });
   },
 
   createNodeBashCommand() {

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -32,3 +32,9 @@ export interface BashCommand {
   text: string;
   expires: string;
 }
+
+export interface NodesResponse {
+  nodes: Node[];
+  startKey?: string;
+  totalCount?: number;
+}

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -33,8 +33,8 @@ export interface BashCommand {
   expires: string;
 }
 
-export interface NodesResponse {
+export type NodesResponse = {
   nodes: Node[];
   startKey?: string;
   totalCount?: number;
-}
+};


### PR DESCRIPTION
### Description
Making changes in response to PR https://github.com/gravitational/teleport/pull/10598, where the api responses are different for our resource getters. Adds extra fields (startKey and totalCount) that are currently not used but will be in future work.

### Counterpart PRs
https://github.com/gravitational/webapps.e/pull/122