### PR TITLE
Update command for generating gRPC files for Teleterm

### DIFF
--- a/packages/teleterm/README.md
+++ b/packages/teleterm/README.md
@@ -119,7 +119,7 @@ For quick restarts, that restarts all processes and `tsh` daemon, press `F6`.
 
 ```sh
 $ cd teleport
-$ make grpc
+$ make grpc-teleterm
 ```
 
 Resulting files both `nodejs` and `golang` can be found in `/teleport/lib/teleterm/api/protogen/` directory.


### PR DESCRIPTION
Just a single line change, I extracted the gRPC stuff in the Teleport repo (gravitational/teleport@a220e2d).