### PR TITLE
Maintain aspect ratio on Desktop Playback

### DIFF
--- a/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -1,17 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
 import styled from 'styled-components';
-import { throttle } from 'lodash';
-import { dateToUtc } from 'shared/services/loc';
-import { format } from 'date-fns';
 
 import cfg from 'teleport/config';
-import { PlayerClient, PlayerClientEvent } from 'teleport/lib/tdp';
+import { PlayerClient } from 'teleport/lib/tdp';
 import { PngFrame, ClientScreenSpec } from 'teleport/lib/tdp/codec';
 import { getAccessToken, getHostName } from 'teleport/services/api';
 import TdpClientCanvas from 'teleport/components/TdpClientCanvas';
 
-import ProgressBar from './ProgressBar';
+import { ProgressBarDesktop } from './ProgressBar';
 
 export const DesktopPlayer = ({
   sid,
@@ -30,6 +27,8 @@ export const DesktopPlayer = ({
 
   return (
     <StyledPlayer>
+      {/* NOTE: tdpCliOnClientScreenSpec depends on the order of elements within StyledPlayer.
+      Be sure to update it if the elements within are changed. */}
       <TdpClientCanvas
         tdpCli={playerClient}
         tdpCliOnPngFrame={tdpCliOnPngFrame}
@@ -37,81 +36,13 @@ export const DesktopPlayer = ({
         onContextMenu={() => true}
         // overflow: 'hidden' is needed to prevent the canvas from outgrowing the container due to some weird css flex idiosyncracy.
         // See https://gaurav5430.medium.com/css-flex-positioning-gotchas-child-expands-to-more-than-the-width-allowed-by-the-parent-799c37428dd6.
-        style={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}
+        style={{
+          alignSelf: 'center',
+          overflow: 'hidden',
+        }}
       />
       <ProgressBarDesktop playerClient={playerClient} durationMs={durationMs} />
     </StyledPlayer>
-  );
-};
-
-export const ProgressBarDesktop = (props: {
-  playerClient: PlayerClient;
-  durationMs: number;
-}) => {
-  const { playerClient, durationMs } = props;
-
-  const toHuman = (currentMs: number) => {
-    return format(dateToUtc(new Date(currentMs)), 'mm:ss');
-  };
-
-  const [state, setState] = useState({
-    max: durationMs,
-    min: 0,
-    current: 0, // the recording always starts at 0 ms
-    time: toHuman(0),
-    isPlaying: true, // determines whether play or pause symbol is shown
-  });
-
-  useEffect(() => {
-    playerClient.addListener(PlayerClientEvent.TOGGLE_PLAY_PAUSE, () => {
-      // setState({...state, isPlaying: !state.isPlaying}) doesn't work because
-      // the listener is added when state == initialState, and that initialState
-      // value is effectively hardcoded into its logic.
-      setState(prevState => {
-        return { ...prevState, isPlaying: !prevState.isPlaying };
-      });
-    });
-
-    const throttledUpdateCurrentTime = throttle(
-      currentTimeMs => {
-        setState(prevState => {
-          return {
-            ...prevState,
-            current: currentTimeMs,
-            time: toHuman(currentTimeMs),
-          };
-        });
-      },
-      // Magic number to throttle progress bar updates so that the playback is smoother.
-      50
-    );
-
-    playerClient.addListener(
-      PlayerClientEvent.UPDATE_CURRENT_TIME,
-      currentTimeMs => throttledUpdateCurrentTime(currentTimeMs)
-    );
-
-    playerClient.addListener(PlayerClientEvent.SESSION_END, () => {
-      throttledUpdateCurrentTime.cancel();
-      // TODO(isaiah): Make this smoother
-      // https://github.com/gravitational/webapps/issues/579
-      setState(prevState => {
-        return { ...prevState, current: durationMs };
-      });
-    });
-
-    return () => {
-      throttledUpdateCurrentTime.cancel();
-      playerClient.nuke();
-    };
-  }, [playerClient]);
-
-  return (
-    <ProgressBar
-      {...state}
-      toggle={() => playerClient.togglePlayPause()}
-      move={() => {}}
-    />
   );
 };
 
@@ -141,6 +72,21 @@ const useDesktopPlayer = ({
     canvas: HTMLCanvasElement,
     spec: ClientScreenSpec
   ) => {
+    const styledPlayer = canvas.parentElement;
+    const progressBar = styledPlayer.children.item(1);
+
+    const fullWidth = styledPlayer.clientWidth;
+    const fullHeight = styledPlayer.clientHeight - progressBar.clientHeight;
+    const originalAspectRatio = spec.width / spec.height;
+    const currentAspectRatio = fullWidth / fullHeight;
+
+    if (originalAspectRatio > currentAspectRatio) {
+      // Use the full width of the screen and scale the height.
+      canvas.style.height = `${(fullWidth * spec.height) / spec.width}px`;
+    } else if (originalAspectRatio < currentAspectRatio) {
+      canvas.style.width = `${(fullHeight * spec.width) / spec.height}px`;
+    }
+
     canvas.width = spec.width;
     canvas.height = spec.height;
   };
@@ -155,6 +101,7 @@ const useDesktopPlayer = ({
 const StyledPlayer = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   width: 100%;
   height: 100%;
 `;

--- a/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -34,8 +34,6 @@ export const DesktopPlayer = ({
   return (
     <>
       <StyledPlayer>
-        {/* NOTE: tdpCliOnClientScreenSpec depends on the order of elements within StyledPlayer.
-      Be sure to update it if the elements within are changed. */}
         {!showCanvas && (
           <Box textAlign="center" m={10}>
             <Indicator />
@@ -61,6 +59,7 @@ export const DesktopPlayer = ({
           style={{
             display: showCanvas ? 'flex' : 'none',
           }}
+          id="progressBarDesktop"
         />
       </StyledPlayer>
     </>
@@ -96,7 +95,7 @@ const useDesktopPlayer = ({
     spec: ClientScreenSpec
   ) => {
     const styledPlayer = canvas.parentElement;
-    const progressBar = styledPlayer.children.item(1);
+    const progressBar = styledPlayer.children.namedItem('progressBarDesktop');
 
     const fullWidth = styledPlayer.clientWidth;
     const fullHeight = styledPlayer.clientHeight - progressBar.clientHeight;

--- a/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
+
+import { Indicator, Box } from 'design';
 
 import cfg from 'teleport/config';
 import { PlayerClient } from 'teleport/lib/tdp';
@@ -19,30 +21,49 @@ export const DesktopPlayer = ({
   clusterId: string;
   durationMs: number;
 }) => {
-  const { playerClient, tdpCliOnPngFrame, tdpCliOnClientScreenSpec } =
-    useDesktopPlayer({
-      sid,
-      clusterId,
-    });
+  const {
+    playerClient,
+    tdpCliOnPngFrame,
+    tdpCliOnClientScreenSpec,
+    showCanvas,
+  } = useDesktopPlayer({
+    sid,
+    clusterId,
+  });
 
   return (
-    <StyledPlayer>
-      {/* NOTE: tdpCliOnClientScreenSpec depends on the order of elements within StyledPlayer.
+    <>
+      <StyledPlayer>
+        {/* NOTE: tdpCliOnClientScreenSpec depends on the order of elements within StyledPlayer.
       Be sure to update it if the elements within are changed. */}
-      <TdpClientCanvas
-        tdpCli={playerClient}
-        tdpCliOnPngFrame={tdpCliOnPngFrame}
-        tdpCliOnClientScreenSpec={tdpCliOnClientScreenSpec}
-        onContextMenu={() => true}
-        // overflow: 'hidden' is needed to prevent the canvas from outgrowing the container due to some weird css flex idiosyncracy.
-        // See https://gaurav5430.medium.com/css-flex-positioning-gotchas-child-expands-to-more-than-the-width-allowed-by-the-parent-799c37428dd6.
-        style={{
-          alignSelf: 'center',
-          overflow: 'hidden',
-        }}
-      />
-      <ProgressBarDesktop playerClient={playerClient} durationMs={durationMs} />
-    </StyledPlayer>
+        {!showCanvas && (
+          <Box textAlign="center" m={10}>
+            <Indicator />
+          </Box>
+        )}
+
+        <TdpClientCanvas
+          tdpCli={playerClient}
+          tdpCliOnPngFrame={tdpCliOnPngFrame}
+          tdpCliOnClientScreenSpec={tdpCliOnClientScreenSpec}
+          onContextMenu={() => true}
+          // overflow: 'hidden' is needed to prevent the canvas from outgrowing the container due to some weird css flex idiosyncracy.
+          // See https://gaurav5430.medium.com/css-flex-positioning-gotchas-child-expands-to-more-than-the-width-allowed-by-the-parent-799c37428dd6.
+          style={{
+            alignSelf: 'center',
+            overflow: 'hidden',
+            display: showCanvas ? 'flex' : 'none',
+          }}
+        />
+        <ProgressBarDesktop
+          playerClient={playerClient}
+          durationMs={durationMs}
+          style={{
+            display: showCanvas ? 'flex' : 'none',
+          }}
+        />
+      </StyledPlayer>
+    </>
   );
 };
 
@@ -60,6 +81,8 @@ const useDesktopPlayer = ({
       .replace(':sid', sid)
       .replace(':token', getAccessToken())
   );
+
+  const [showCanvas, setShowCanvas] = useState(false);
 
   const tdpCliOnPngFrame = (
     ctx: CanvasRenderingContext2D,
@@ -84,17 +107,21 @@ const useDesktopPlayer = ({
       // Use the full width of the screen and scale the height.
       canvas.style.height = `${(fullWidth * spec.height) / spec.width}px`;
     } else if (originalAspectRatio < currentAspectRatio) {
+      // Use the full height of the screen and scale the width.
       canvas.style.width = `${(fullHeight * spec.width) / spec.height}px`;
     }
 
     canvas.width = spec.width;
     canvas.height = spec.height;
+
+    setShowCanvas(true);
   };
 
   return {
     playerClient,
     tdpCliOnPngFrame,
     tdpCliOnClientScreenSpec,
+    showCanvas,
   };
 };
 

--- a/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
+++ b/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
@@ -23,7 +23,7 @@ import Slider from './Slider';
 export default function ProgressBar(props: ProgressBarProps) {
   const Icon = props.isPlaying ? Icons.CirclePause : Icons.CirclePlay;
   return (
-    <StyledProgessBar style={props.style}>
+    <StyledProgessBar style={props.style} id={props.id}>
       <ActionButton onClick={props.toggle}>
         <Icon />
       </ActionButton>
@@ -52,6 +52,7 @@ export type ProgressBarProps = {
   move: (value: any) => void;
   toggle: () => void;
   style?: React.CSSProperties;
+  id?: string;
 };
 
 const SliderContainer = styled.div`

--- a/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
+++ b/packages/teleport/src/Player/ProgressBar/ProgressBar.tsx
@@ -23,7 +23,7 @@ import Slider from './Slider';
 export default function ProgressBar(props: ProgressBarProps) {
   const Icon = props.isPlaying ? Icons.CirclePause : Icons.CirclePlay;
   return (
-    <StyledProgessBar>
+    <StyledProgessBar style={props.style}>
       <ActionButton onClick={props.toggle}>
         <Icon />
       </ActionButton>
@@ -51,6 +51,7 @@ export type ProgressBarProps = {
   current: number;
   move: (value: any) => void;
   toggle: () => void;
+  style?: React.CSSProperties;
 };
 
 const SliderContainer = styled.div`

--- a/packages/teleport/src/Player/ProgressBar/ProgressBarDesktop.tsx
+++ b/packages/teleport/src/Player/ProgressBar/ProgressBarDesktop.tsx
@@ -11,8 +11,9 @@ import ProgressBar from './ProgressBar';
 export const ProgressBarDesktop = (props: {
   playerClient: PlayerClient;
   durationMs: number;
+  style?: React.CSSProperties;
 }) => {
-  const { playerClient, durationMs } = props;
+  const { playerClient, durationMs, style } = props;
 
   const toHuman = (currentMs: number) => {
     return format(dateToUtc(new Date(currentMs)), 'mm:ss');
@@ -75,6 +76,7 @@ export const ProgressBarDesktop = (props: {
       {...state}
       toggle={() => playerClient.togglePlayPause()}
       move={() => {}}
+      style={style}
     />
   );
 };

--- a/packages/teleport/src/Player/ProgressBar/ProgressBarDesktop.tsx
+++ b/packages/teleport/src/Player/ProgressBar/ProgressBarDesktop.tsx
@@ -1,0 +1,80 @@
+import React, { useState, useEffect } from 'react';
+
+import { throttle } from 'lodash';
+import { dateToUtc } from 'shared/services/loc';
+import { format } from 'date-fns';
+
+import { PlayerClient, PlayerClientEvent } from 'teleport/lib/tdp';
+
+import ProgressBar from './ProgressBar';
+
+export const ProgressBarDesktop = (props: {
+  playerClient: PlayerClient;
+  durationMs: number;
+}) => {
+  const { playerClient, durationMs } = props;
+
+  const toHuman = (currentMs: number) => {
+    return format(dateToUtc(new Date(currentMs)), 'mm:ss');
+  };
+
+  const [state, setState] = useState({
+    max: durationMs,
+    min: 0,
+    current: 0, // the recording always starts at 0 ms
+    time: toHuman(0),
+    isPlaying: true, // determines whether play or pause symbol is shown
+  });
+
+  useEffect(() => {
+    playerClient.addListener(PlayerClientEvent.TOGGLE_PLAY_PAUSE, () => {
+      // setState({...state, isPlaying: !state.isPlaying}) doesn't work because
+      // the listener is added when state == initialState, and that initialState
+      // value is effectively hardcoded into its logic.
+      setState(prevState => {
+        return { ...prevState, isPlaying: !prevState.isPlaying };
+      });
+    });
+
+    const throttledUpdateCurrentTime = throttle(
+      currentTimeMs => {
+        setState(prevState => {
+          return {
+            ...prevState,
+            current: currentTimeMs,
+            time: toHuman(currentTimeMs),
+          };
+        });
+      },
+      // Magic number to throttle progress bar updates so that the playback is smoother.
+      50
+    );
+
+    playerClient.addListener(
+      PlayerClientEvent.UPDATE_CURRENT_TIME,
+      currentTimeMs => throttledUpdateCurrentTime(currentTimeMs)
+    );
+
+    playerClient.addListener(PlayerClientEvent.SESSION_END, () => {
+      throttledUpdateCurrentTime.cancel();
+      // TODO(isaiah): Make this smoother
+      // https://github.com/gravitational/webapps/issues/579
+      setState(prevState => {
+        return { ...prevState, current: durationMs };
+      });
+    });
+
+    return () => {
+      throttledUpdateCurrentTime.cancel();
+      playerClient.nuke();
+    };
+  }, [playerClient]);
+
+  return (
+    <ProgressBar
+      {...state}
+      toggle={() => playerClient.togglePlayPause()}
+      move={() => {}}
+    />
+  );
+};

--- a/packages/teleport/src/Player/ProgressBar/ProgressBarDesktop.tsx
+++ b/packages/teleport/src/Player/ProgressBar/ProgressBarDesktop.tsx
@@ -12,8 +12,9 @@ export const ProgressBarDesktop = (props: {
   playerClient: PlayerClient;
   durationMs: number;
   style?: React.CSSProperties;
+  id?: string;
 }) => {
-  const { playerClient, durationMs, style } = props;
+  const { playerClient, durationMs } = props;
 
   const toHuman = (currentMs: number) => {
     return format(dateToUtc(new Date(currentMs)), 'mm:ss');
@@ -76,7 +77,8 @@ export const ProgressBarDesktop = (props: {
       {...state}
       toggle={() => playerClient.togglePlayPause()}
       move={() => {}}
-      style={style}
+      style={props.style}
+      id={props.id}
     />
   );
 };

--- a/packages/teleport/src/Player/ProgressBar/index.tsx
+++ b/packages/teleport/src/Player/ProgressBar/index.tsx
@@ -16,6 +16,7 @@ limitations under the License.
 
 import ProgressBar from './ProgressBar';
 import ProgressBarTty from './ProgressBarTty';
+import { ProgressBarDesktop } from './ProgressBarDesktop';
 
 export default ProgressBar;
-export { ProgressBarTty };
+export { ProgressBarTty, ProgressBarDesktop };


### PR DESCRIPTION
Previously, desktop sessions recorded at one aspect ratio and played at another could look insane (see the screenshot in https://github.com/gravitational/webapps/issues/587). These changes maintain the aspect ratio during playback.

#### Playback aspect ratio > recorded aspect ratio
<img width="2015" alt="Screen Shot 2022-02-28 at 20 50 00" src="https://user-images.githubusercontent.com/13578537/156089757-c4971dff-beb6-49cd-84bb-debf50bdc958.png">

#### Playback aspect ratio < recorded aspect ratio
<img width="1547" alt="Screen Shot 2022-02-28 at 20 49 26" src="https://user-images.githubusercontent.com/13578537/156089827-b21f85bc-0019-4a0b-94ba-88693ff3581d.png">

#### RFD
Due to slight differences between the size available to the desktop session during recording, and the size available to the player, a session recorded and then played back in a browser window of precisely the same size may look something like this:

<img width="2560" alt="Screen Shot 2022-02-28 at 20 50 49" src="https://user-images.githubusercontent.com/13578537/156089999-d4e56c8a-5c13-45eb-8513-880f2466386b.png">

Note the black channels up and down the left and right size of the window, which are created by the same logic that creates the desirable, necessary black-space in the `Playback aspect ratio > recorded aspect ratio` screen shot above. I'm not ecstatic about how that looks, but am not sure precisely what to do about it (if anything).

closes https://github.com/gravitational/webapps/issues/587