### PR TITLE
[v9] Disable autocomplete on the SSH login input (#605)

### DIFF
--- a/packages/shared/components/MenuSshLogin/MenuSshLogin.tsx
+++ b/packages/shared/components/MenuSshLogin/MenuSshLogin.tsx
@@ -120,6 +120,7 @@ export const LoginItemList = ({ logins, onClick, onKeyPress }) => {
         type="text"
         autoFocus
         placeholder="Enter login name..."
+        autoComplete="off"
       />
       {$menuItems}
     </React.Fragment>


### PR DESCRIPTION
This prevents password managers like 1password from attempting to
autocomplete the SSH login, which is not a standard password field.

Fixes gravitational/teleport#10356

Co-authored-by: Lisa Kim <lisa@goteleport.com>

Backports #605 