### PR TITLE
Fix Table Regression Bugs

### DIFF
--- a/packages/design/src/DataTable/types.ts
+++ b/packages/design/src/DataTable/types.ts
@@ -7,6 +7,9 @@ export type TableProps<T> = {
   pagination?: PaginationConfig;
   isSearchable?: boolean;
   searchableProps?: Extract<keyof T, string>[];
+  // customSearchMatchers contains custom functions to run when search matching.
+  // 'targetValue' prop will have to be uppercased for proper matching since
+  // the root matcher will uppercase the searchValue.
   customSearchMatchers?: MatchCallback<T>[];
   initialSort?: InitialSort<T>;
   fetching?: FetchingConfig;

--- a/packages/design/src/DataTable/types.ts
+++ b/packages/design/src/DataTable/types.ts
@@ -1,3 +1,5 @@
+import { MatchCallback } from 'design/utils/match';
+
 export type TableProps<T> = {
   data: T[];
   columns: TableColumn<T>[];
@@ -5,6 +7,7 @@ export type TableProps<T> = {
   pagination?: PaginationConfig;
   isSearchable?: boolean;
   searchableProps?: Extract<keyof T, string>[];
+  customSearchMatchers?: MatchCallback<T>[];
   initialSort?: InitialSort<T>;
   fetching?: FetchingConfig;
   showFirst?: (data: T[]) => T;

--- a/packages/design/src/DataTable/types.ts
+++ b/packages/design/src/DataTable/types.ts
@@ -4,6 +4,7 @@ export type TableProps<T> = {
   emptyText: string;
   pagination?: PaginationConfig;
   isSearchable?: boolean;
+  searchableProps?: Extract<keyof T, string>[];
   initialSort?: InitialSort<T>;
   fetching?: FetchingConfig;
   showFirst?: (data: T[]) => T;

--- a/packages/design/src/DataTable/useTable.ts
+++ b/packages/design/src/DataTable/useTable.ts
@@ -173,39 +173,35 @@ function searchAndFilterCb<T>(
   searchValue: string,
   propName: keyof T & string
 ) {
-  if (propName.toLocaleLowerCase().includes('date')) {
-    return displayDate(targetValue).includes(searchValue);
-  }
-  if (propName.toLocaleLowerCase().includes('time')) {
-    return displayDateTime(targetValue).includes(searchValue);
-  }
-  if (typeof targetValue === 'boolean') {
-    return (
-      propName.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase()) &&
-      targetValue
-    );
+  const propNameLowerCased = propName.toLocaleLowerCase();
+  const searchValueLowerCased = searchValue.toLocaleLowerCase();
+
+  let targetValueArr = targetValue;
+
+  if (!Array.isArray(targetValue)) {
+    targetValueArr = [targetValue];
   }
 
-  // For searching through elements of an array
-  if (Array.isArray(targetValue)) {
-    return targetValue.some(item => {
-      if (typeof item === 'object') {
-        for (const key in item) {
-          if (
-            item[key]
-              .toLocaleLowerCase()
-              .includes(searchValue.toLocaleLowerCase())
-          ) {
-            return true;
-          }
+  return targetValueArr.some(item => {
+    if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+      for (const key in item) {
+        if (item[key].toLocaleLowerCase().includes(searchValueLowerCased)) {
+          return true;
         }
-      } else {
-        return item
-          .toLocaleLowerCase()
-          .includes(searchValue.toLocaleLowerCase());
       }
-    });
-  }
+    } else if (propNameLowerCased.includes('date')) {
+      return displayDate(item).includes(searchValueLowerCased);
+    } else if (propNameLowerCased.includes('time')) {
+      return displayDateTime(item).includes(searchValueLowerCased);
+    } else if (typeof item === 'boolean') {
+      return propNameLowerCased.includes(searchValueLowerCased) && item;
+    } else {
+      return item
+        .toString()
+        .toLocaleLowerCase()
+        .includes(searchValueLowerCased);
+    }
+  });
 }
 
 export type State<T> = Omit<

--- a/packages/design/src/DataTable/useTable.ts
+++ b/packages/design/src/DataTable/useTable.ts
@@ -44,7 +44,8 @@ export default function useTable<T>({
       data,
       searchValue,
       sort,
-      searchableProps || columns.map(column => column.key),
+      searchableProps ||
+        columns.filter(column => column.key).map(column => column.key),
       showFirst
     );
 
@@ -172,11 +173,6 @@ function searchAndFilterCb<T>(
   searchValue: string,
   propName: keyof T & string
 ) {
-  if (propName === 'tags') {
-    return targetValue.some(item => {
-      return item.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase());
-    });
-  }
   if (propName.toLocaleLowerCase().includes('date')) {
     return displayDate(targetValue).includes(searchValue);
   }

--- a/packages/design/src/DataTable/useTable.ts
+++ b/packages/design/src/DataTable/useTable.ts
@@ -40,23 +40,21 @@ export default function useTable<T>({
     };
   });
 
-  const [searchAndFilterCb] = useState<MatchCallback<T>>(() => {
-    return (
-      targetValue: any,
-      searchValue: string,
-      propName: keyof T & string
-    ) => {
-      for (const matcher of customSearchMatchers) {
-        const isMatched = matcher(targetValue, searchValue, propName);
-        if (isMatched) {
-          return true;
-        }
+  function searchAndFilterCb(
+    targetValue: any,
+    searchValue: string,
+    propName: keyof T & string
+  ) {
+    for (const matcher of customSearchMatchers) {
+      const isMatched = matcher(targetValue, searchValue, propName);
+      if (isMatched) {
+        return true;
       }
+    }
 
-      // No match found.
-      return false;
-    };
-  });
+    // No match found.
+    return false;
+  }
 
   const updateData = (sort: typeof state.sort, searchValue: string) => {
     const sortedAndFiltered = sortAndFilter(

--- a/packages/design/src/utils/match/index.ts
+++ b/packages/design/src/utils/match/index.ts
@@ -1,0 +1,6 @@
+import isMatch, { MatchCallback } from './match';
+import { dateMatcher, dateTimeMatcher } from './matchers';
+
+export default isMatch;
+export { dateMatcher, dateTimeMatcher };
+export type { MatchCallback };

--- a/packages/design/src/utils/match/match.ts
+++ b/packages/design/src/utils/match/match.ts
@@ -36,13 +36,15 @@ export default function match<T>(
     searchableProps,
     cb,
   }: {
-    searchableProps: (keyof T)[];
-    cb?(targetValue: any, searchValue: string, propName: keyof T): boolean;
+    searchableProps: (keyof T & string)[];
+    cb?: MatchCallback<T>;
   }
 ) {
   searchValue = searchValue.toLocaleUpperCase();
+
   let propNames =
-    searchableProps || (Object.getOwnPropertyNames(obj) as (keyof T)[]);
+    searchableProps ||
+    (Object.getOwnPropertyNames(obj) as (keyof T & string)[]);
   for (let i = 0; i < propNames.length; i++) {
     let targetValue = obj[propNames[i]];
     if (targetValue) {
@@ -63,3 +65,9 @@ export default function match<T>(
 
   return false;
 }
+
+export type MatchCallback<T> = (
+  targetValue: any,
+  searchValue: string,
+  propName: keyof T & string
+) => boolean;

--- a/packages/design/src/utils/match/match.ts
+++ b/packages/design/src/utils/match/match.ts
@@ -40,6 +40,8 @@ export default function match<T>(
     cb?: MatchCallback<T>;
   }
 ) {
+  searchValue = searchValue.toLocaleLowerCase();
+
   let propNames =
     searchableProps ||
     (Object.getOwnPropertyNames(obj) as (keyof T & string)[]);
@@ -54,10 +56,7 @@ export default function match<T>(
       }
 
       if (
-        targetValue
-          .toString()
-          .toLocaleLowerCase()
-          .indexOf(searchValue.toLocaleLowerCase()) !== -1
+        targetValue.toString().toLocaleLowerCase().indexOf(searchValue) !== -1
       ) {
         return true;
       }

--- a/packages/design/src/utils/match/match.ts
+++ b/packages/design/src/utils/match/match.ts
@@ -40,7 +40,7 @@ export default function match<T>(
     cb?: MatchCallback<T>;
   }
 ) {
-  searchValue = searchValue.toLocaleLowerCase();
+  searchValue = searchValue.toLocaleUpperCase();
 
   let propNames =
     searchableProps ||
@@ -56,7 +56,7 @@ export default function match<T>(
       }
 
       if (
-        targetValue.toString().toLocaleLowerCase().indexOf(searchValue) !== -1
+        targetValue.toString().toLocaleUpperCase().indexOf(searchValue) !== -1
       ) {
         return true;
       }

--- a/packages/design/src/utils/match/match.ts
+++ b/packages/design/src/utils/match/match.ts
@@ -40,8 +40,6 @@ export default function match<T>(
     cb?: MatchCallback<T>;
   }
 ) {
-  searchValue = searchValue.toLocaleUpperCase();
-
   let propNames =
     searchableProps ||
     (Object.getOwnPropertyNames(obj) as (keyof T & string)[]);
@@ -56,7 +54,10 @@ export default function match<T>(
       }
 
       if (
-        targetValue.toString().toLocaleUpperCase().indexOf(searchValue) !== -1
+        targetValue
+          .toString()
+          .toLocaleLowerCase()
+          .indexOf(searchValue.toLocaleLowerCase()) !== -1
       ) {
         return true;
       }

--- a/packages/design/src/utils/match/matchers.ts
+++ b/packages/design/src/utils/match/matchers.ts
@@ -6,7 +6,7 @@ export function dateMatcher<T>(
 ): MatchCallback<T> {
   return (targetValue, searchValue, propName) => {
     if (datePropNames.includes(propName)) {
-      return displayDate(targetValue).toLocaleLowerCase().includes(searchValue);
+      return displayDate(targetValue).toLocaleUpperCase().includes(searchValue);
     }
   };
 }
@@ -17,7 +17,7 @@ export function dateTimeMatcher<T>(
   return (targetValue, searchValue, propName) => {
     if (dateTimePropNames.includes(propName)) {
       return displayDateTime(targetValue)
-        .toLocaleLowerCase()
+        .toLocaleUpperCase()
         .includes(searchValue);
     }
   };

--- a/packages/design/src/utils/match/matchers.ts
+++ b/packages/design/src/utils/match/matchers.ts
@@ -1,20 +1,26 @@
 import { displayDate, displayDateTime } from 'shared/services/loc';
 import { MatchCallback } from './match';
 
-export const dateMatcher =
-  <T>(datePropNames: (keyof T & string)[]): MatchCallback<T> =>
-  (targetValue, searchValue, propName) => {
+export function dateMatcher<T>(
+  datePropNames: (keyof T & string)[]
+): MatchCallback<T> {
+  return (targetValue, searchValue, propName) => {
+    searchValue = searchValue.toLocaleLowerCase();
     if (datePropNames.includes(propName)) {
       return displayDate(targetValue).toLocaleLowerCase().includes(searchValue);
     }
   };
+}
 
-export const dateTimeMatcher =
-  <T>(dateTimePropNames: (keyof T & string)[]): MatchCallback<T> =>
-  (targetValue, searchValue, propName) => {
+export function dateTimeMatcher<T>(
+  dateTimePropNames: (keyof T & string)[]
+): MatchCallback<T> {
+  return (targetValue, searchValue, propName) => {
+    searchValue = searchValue.toLocaleLowerCase();
     if (dateTimePropNames.includes(propName)) {
       return displayDateTime(targetValue)
         .toLocaleLowerCase()
         .includes(searchValue);
     }
   };
+}

--- a/packages/design/src/utils/match/matchers.ts
+++ b/packages/design/src/utils/match/matchers.ts
@@ -1,0 +1,20 @@
+import { displayDate, displayDateTime } from 'shared/services/loc';
+import { MatchCallback } from './match';
+
+export const dateMatcher =
+  <T>(datePropNames: (keyof T & string)[]): MatchCallback<T> =>
+  (targetValue, searchValue, propName) => {
+    if (datePropNames.includes(propName)) {
+      return displayDate(targetValue).toLocaleLowerCase().includes(searchValue);
+    }
+  };
+
+export const dateTimeMatcher =
+  <T>(dateTimePropNames: (keyof T & string)[]): MatchCallback<T> =>
+  (targetValue, searchValue, propName) => {
+    if (dateTimePropNames.includes(propName)) {
+      return displayDateTime(targetValue)
+        .toLocaleLowerCase()
+        .includes(searchValue);
+    }
+  };

--- a/packages/design/src/utils/match/matchers.ts
+++ b/packages/design/src/utils/match/matchers.ts
@@ -5,7 +5,6 @@ export function dateMatcher<T>(
   datePropNames: (keyof T & string)[]
 ): MatchCallback<T> {
   return (targetValue, searchValue, propName) => {
-    searchValue = searchValue.toLocaleLowerCase();
     if (datePropNames.includes(propName)) {
       return displayDate(targetValue).toLocaleLowerCase().includes(searchValue);
     }
@@ -16,7 +15,6 @@ export function dateTimeMatcher<T>(
   dateTimePropNames: (keyof T & string)[]
 ): MatchCallback<T> {
   return (targetValue, searchValue, propName) => {
-    searchValue = searchValue.toLocaleLowerCase();
     if (dateTimePropNames.includes(propName)) {
       return displayDateTime(targetValue)
         .toLocaleLowerCase()

--- a/packages/teleport/src/Account/ManageDevices/ManageDevices.story.tsx
+++ b/packages/teleport/src/Account/ManageDevices/ManageDevices.story.tsx
@@ -24,7 +24,7 @@ export default {
 
 export const Loaded = () => <ManageDevices {...props} />;
 
-export const LoadedMfaaOff = () => (
+export const LoadedMfaOff = () => (
   <ManageDevices {...props} mfaDisabled={true} />
 );
 

--- a/packages/teleport/src/Audit/EventList/EventList.tsx
+++ b/packages/teleport/src/Audit/EventList/EventList.tsx
@@ -32,7 +32,6 @@ export default function EventList(props: Props) {
     pageSize = 50,
   } = props;
   const [detailsToShow, setDetailsToShow] = useState<Event>();
-
   return (
     <>
       <Table
@@ -62,6 +61,7 @@ export default function EventList(props: Props) {
         ]}
         emptyText={'No Events Found'}
         isSearchable
+        searchableProps={['code', 'codeDesc', 'time', 'user', 'message', 'id']}
         initialSort={{ key: 'time', dir: 'DESC' }}
         pagination={{ pageSize }}
         fetching={{

--- a/packages/teleport/src/Audit/EventList/EventList.tsx
+++ b/packages/teleport/src/Audit/EventList/EventList.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React, { useState } from 'react';
 import { ButtonBorder } from 'design';
 import Table, { Cell } from 'design/DataTable';
+import { dateTimeMatcher } from 'design/utils/match';
 import { displayDateTime } from 'shared/services/loc';
 import { Event } from 'teleport/services/audit';
 import { State } from '../useAuditEvents';
@@ -62,6 +63,7 @@ export default function EventList(props: Props) {
         emptyText={'No Events Found'}
         isSearchable
         searchableProps={['code', 'codeDesc', 'time', 'user', 'message', 'id']}
+        customSearchMatchers={[dateTimeMatcher(['time'])]}
         initialSort={{ key: 'time', dir: 'DESC' }}
         pagination={{ pageSize }}
         fetching={{

--- a/packages/teleport/src/Recordings/RecordingsList.tsx
+++ b/packages/teleport/src/Recordings/RecordingsList.tsx
@@ -86,6 +86,15 @@ export default function RecordingsList(props: Props) {
         dir: 'DESC',
       }}
       isSearchable
+      searchableProps={[
+        'recordingType',
+        'hostname',
+        'description',
+        'createdDate',
+        'sid',
+        'users',
+        'durationText',
+      ]}
     />
   );
 }

--- a/packages/teleport/src/Recordings/RecordingsList.tsx
+++ b/packages/teleport/src/Recordings/RecordingsList.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React from 'react';
 import { ButtonBorder } from 'design';
 import Table, { Cell, TextCell } from 'design/DataTable';
+import { dateTimeMatcher } from 'design/utils/match';
 import { displayDateTime } from 'shared/services/loc';
 import cfg from 'teleport/config';
 import { Recording, RecordingType } from 'teleport/services/recordings';
@@ -95,6 +96,7 @@ export default function RecordingsList(props: Props) {
         'users',
         'durationText',
       ]}
+      customSearchMatchers={[dateTimeMatcher(['createdDate'])]}
     />
   );
 }

--- a/packages/teleport/src/Sessions/SessionList/SessionList.tsx
+++ b/packages/teleport/src/Sessions/SessionList/SessionList.tsx
@@ -119,11 +119,11 @@ function participantMatcher(
 ) {
   if (propName === 'parties') {
     return targetValue.some((participant: Participant) => {
-      if (participant.remoteAddr.toLocaleLowerCase().includes(searchValue)) {
+      if (participant.remoteAddr.toLocaleUpperCase().includes(searchValue)) {
         return true;
       }
 
-      return participant.user.toLocaleLowerCase().includes(searchValue);
+      return participant.user.toLocaleUpperCase().includes(searchValue);
     });
   }
 }

--- a/packages/teleport/src/Sessions/SessionList/SessionList.tsx
+++ b/packages/teleport/src/Sessions/SessionList/SessionList.tsx
@@ -117,7 +117,6 @@ function participantMatcher(
   searchValue: string,
   propName: keyof Session & string
 ) {
-  searchValue = searchValue.toLocaleLowerCase();
   if (propName === 'parties') {
     return targetValue.some((participant: Participant) => {
       if (participant.remoteAddr.toLocaleLowerCase().includes(searchValue)) {

--- a/packages/teleport/src/Sessions/SessionList/SessionList.tsx
+++ b/packages/teleport/src/Sessions/SessionList/SessionList.tsx
@@ -117,15 +117,14 @@ function participantMatcher(
   searchValue: string,
   propName: keyof Session & string
 ) {
+  searchValue = searchValue.toLocaleLowerCase();
   if (propName === 'parties') {
     return targetValue.some((participant: Participant) => {
-      if (participant.remoteAddr.toLocaleUpperCase().includes(searchValue)) {
+      if (participant.remoteAddr.toLocaleLowerCase().includes(searchValue)) {
         return true;
       }
 
-      return participant.user.toLocaleUpperCase().includes(searchValue);
+      return participant.user.toLocaleLowerCase().includes(searchValue);
     });
   }
-  // No match.
-  return false;
 }

--- a/packages/teleport/src/Sessions/SessionList/SessionList.tsx
+++ b/packages/teleport/src/Sessions/SessionList/SessionList.tsx
@@ -59,6 +59,18 @@ export default function SessionList(props: Props) {
       emptyText="No Active Sessions Found"
       pagination={{ pageSize }}
       isSearchable
+      searchableProps={[
+        'addr',
+        'sid',
+        'clusterId',
+        'serverId',
+        'hostname',
+        'parties',
+        'durationText',
+        'login',
+        'created',
+        'parties',
+      ]}
     />
   );
 }

--- a/packages/teleport/src/Sessions/SessionList/SessionList.tsx
+++ b/packages/teleport/src/Sessions/SessionList/SessionList.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import Table, { Cell } from 'design/DataTable';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 import cfg from 'teleport/config';
-import { Session } from 'teleport/services/ssh';
+import { Session, Participant } from 'teleport/services/ssh';
 import renderDescCell from './DescCell';
 
 export default function SessionList(props: Props) {
@@ -58,6 +58,7 @@ export default function SessionList(props: Props) {
       ]}
       emptyText="No Active Sessions Found"
       pagination={{ pageSize }}
+      customSearchMatchers={[participantMatcher]}
       isSearchable
       searchableProps={[
         'addr',
@@ -110,3 +111,21 @@ type Props = {
   sessions: Session[];
   pageSize?: number;
 };
+
+function participantMatcher(
+  targetValue: any,
+  searchValue: string,
+  propName: keyof Session & string
+) {
+  if (propName === 'parties') {
+    return targetValue.some((participant: Participant) => {
+      if (participant.remoteAddr.toLocaleUpperCase().includes(searchValue)) {
+        return true;
+      }
+
+      return participant.user.toLocaleUpperCase().includes(searchValue);
+    });
+  }
+  // No match.
+  return false;
+}

--- a/packages/teleport/src/Support/Support.tsx
+++ b/packages/teleport/src/Support/Support.tsx
@@ -87,15 +87,7 @@ export const Support = ({
           <Box>
             <Header title="Troubleshooting" icon={<Icons.Graph />} />
             <SupportLink
-              title="Monitoring Teleport"
-              url={docs.troubleshooting}
-            />
-            <SupportLink
-              title="Collecting Debug Data"
-              url={docs.troubleshooting}
-            />
-            <SupportLink
-              title="Troubleshooting FAQ"
+              title="Monitoring & Debugging"
               url={docs.troubleshooting}
             />
           </Box>
@@ -159,7 +151,7 @@ const getDocUrls = (version = '', isEnterprise: boolean) => {
     userManual: withUTM('https://goteleport.com/teleport/docs/user-manual'),
     adminGuide: withUTM('https://goteleport.com/teleport/docs/admin-guide'),
     troubleshooting: withUTM(
-      'https://goteleport.com/teleport/docs/admin-guide',
+      'https://goteleport.com/teleport/docs/setup/admin/troubleshooting',
       '#troubleshooting'
     ),
     faq: withUTM('https://goteleport.com/teleport/docs/faq'),

--- a/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
+++ b/packages/teleport/src/Support/__snapshots__/Support.story.test.tsx.snap
@@ -279,24 +279,10 @@ exports[`support Enterprise 1`] = `
         </div>
         <a
           class="c8"
-          href="https://goteleport.com/teleport/docs/admin-guide?product=teleport&version=e_4.4.0-dev#troubleshooting"
+          href="https://goteleport.com/teleport/docs/setup/admin/troubleshooting?product=teleport&version=e_4.4.0-dev#troubleshooting"
           rel="noreferrer"
         >
-          Monitoring Teleport
-        </a>
-        <a
-          class="c8"
-          href="https://goteleport.com/teleport/docs/admin-guide?product=teleport&version=e_4.4.0-dev#troubleshooting"
-          rel="noreferrer"
-        >
-          Collecting Debug Data
-        </a>
-        <a
-          class="c8"
-          href="https://goteleport.com/teleport/docs/admin-guide?product=teleport&version=e_4.4.0-dev#troubleshooting"
-          rel="noreferrer"
-        >
-          Troubleshooting FAQ
+          Monitoring & Debugging
         </a>
       </div>
       <div
@@ -671,24 +657,10 @@ exports[`support OSS 1`] = `
         </div>
         <a
           class="c8"
-          href="https://goteleport.com/teleport/docs/admin-guide?product=teleport&version=oss_4.4.0-dev#troubleshooting"
+          href="https://goteleport.com/teleport/docs/setup/admin/troubleshooting?product=teleport&version=oss_4.4.0-dev#troubleshooting"
           rel="noreferrer"
         >
-          Monitoring Teleport
-        </a>
-        <a
-          class="c8"
-          href="https://goteleport.com/teleport/docs/admin-guide?product=teleport&version=oss_4.4.0-dev#troubleshooting"
-          rel="noreferrer"
-        >
-          Collecting Debug Data
-        </a>
-        <a
-          class="c8"
-          href="https://goteleport.com/teleport/docs/admin-guide?product=teleport&version=oss_4.4.0-dev#troubleshooting"
-          rel="noreferrer"
-        >
-          Troubleshooting FAQ
+          Monitoring & Debugging
         </a>
       </div>
       <div

--- a/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
+++ b/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
@@ -160,7 +160,7 @@ const Empty = (props: EmptyProps) => {
         <Info pr={4} mb={6} />
         <ButtonPrimary
           disabled={props.disabled}
-          title={props.disabled && 'You do not have access to add a trusted cluster'}
+          title={props.disabled ? 'You do not have access to add a trusted cluster' : ''}
           onClick={props.onCreate}
           mb="2"
           mx="auto"

--- a/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
+++ b/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
@@ -160,6 +160,7 @@ const Empty = (props: EmptyProps) => {
         <Info pr={4} mb={6} />
         <ButtonPrimary
           disabled={props.disabled}
+          title={props.disabled && 'You do not have access to add a trusted cluster'}
           onClick={props.onCreate}
           mb="2"
           mx="auto"

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -97,7 +97,7 @@ const renderRemoveCell = (
   mfaDisabled: boolean
 ) => {
   if (id === mostRecentDevice?.id) {
-    return null;
+    return <Cell align="right"></Cell>;
   }
 
   return (

--- a/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { ButtonBorder, Text } from 'design';
 import Table, { Cell } from 'design/DataTable';
+import { dateMatcher } from 'design/utils/match';
 import { displayDate } from 'shared/services/loc';
 import { MfaDevice } from 'teleport/services/mfa/types';
 
@@ -71,6 +72,7 @@ export default function MfaDeviceList({
         key: 'registeredDate',
         dir: 'DESC',
       }}
+      customSearchMatchers={[dateMatcher(['registeredDate', 'lastUsedDate'])]}
     />
   );
 }

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -61,6 +61,7 @@ function NodeList(props: Props) {
         'tags',
         'clusterId',
       ]}
+      customSearchMatchers={[tunnelMatcher]}
     />
   );
 }
@@ -103,6 +104,23 @@ const renderLoginCell = (
 export const renderAddressCell = ({ addr, tunnel }: Node) => (
   <Cell>{tunnel ? renderTunnel() : addr}</Cell>
 );
+
+function tunnelMatcher(
+  targetValue: any,
+  searchValue: string,
+  propName: keyof Node & string
+) {
+  if (
+    propName === 'tunnel' &&
+    targetValue &&
+    propName.includes(searchValue.toLocaleLowerCase())
+  ) {
+    console.log('reached here');
+    return true;
+  }
+
+  return false;
+}
 
 function renderTunnel() {
   return (

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -110,16 +110,8 @@ function tunnelMatcher(
   searchValue: string,
   propName: keyof Node & string
 ) {
-  if (
-    propName === 'tunnel' &&
-    targetValue &&
-    propName.includes(searchValue.toLocaleLowerCase())
-  ) {
-    console.log('reached here');
-    return true;
-  }
-
-  return false;
+  searchValue = searchValue.toLocaleLowerCase();
+  return propName === 'tunnel' && targetValue && propName.includes(searchValue);
 }
 
 function renderTunnel() {

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -110,7 +110,6 @@ function tunnelMatcher(
   searchValue: string,
   propName: keyof Node & string
 ) {
-  searchValue = searchValue.toLocaleLowerCase();
   return propName === 'tunnel' && targetValue && propName.includes(searchValue);
 }
 

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -110,7 +110,11 @@ function tunnelMatcher(
   searchValue: string,
   propName: keyof Node & string
 ) {
-  return propName === 'tunnel' && targetValue && propName.includes(searchValue);
+  return (
+    propName === 'tunnel' &&
+    targetValue &&
+    propName.includes(searchValue.toLocaleLowerCase())
+  );
 }
 
 function renderTunnel() {

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -53,6 +53,14 @@ function NodeList(props: Props) {
         pageSize,
       }}
       isSearchable
+      searchableProps={[
+        'addr',
+        'hostname',
+        'id',
+        'tunnel',
+        'tags',
+        'clusterId',
+      ]}
     />
   );
 }


### PR DESCRIPTION
## Purpose

This PR resolves #629 

Fixes some table regressions and other improvements

## Implementation

- Added `searchableProps` to Table config to allow searching through the pieces of data that are part of the object but that aren't indexed by the table columns. 

- Added search functionality to arrays of objects and arrays of strings, this is useful in the case of searching through Active Sessions because you are now able to search by participants. 

- Added search functionality for booleans, eg. you can now search `tunnel` and get rows that have `tunnel: true`. 

## Demo

### Searching through Active Sessions by duration and by users
![searchingsessions2](https://user-images.githubusercontent.com/56373201/156635958-bf866b41-cad4-4b4e-9b84-e94f10d23d99.gif)