### PR TITLE
Update default roles template

### DIFF
--- a/packages/teleport/src/Roles/templates/role.yaml
+++ b/packages/teleport/src/Roles/templates/role.yaml
@@ -16,10 +16,20 @@ spec:
     node_labels:
       '*': '*'
 
-    # RBAC rules for various resources within a cluster.
+    # RBAC rules for various resources within a cluster. This
+    # example provides access to the Audit Log and replaying a user's own sessions.
     rules:
-    - resources: ['*']
-      verbs: ['*']
+    - resources:
+      - event
+      verbs:
+      - list
+      - read
+    - resources:
+      - session
+      verbs:
+      - read
+      - list
+      where: contains(session.participants, user.metadata.name)
 
   # The 'deny' section can have settings that override their 'allow' counterparts
   # It uses the same format as the 'allow' section
@@ -30,4 +40,4 @@ spec:
       # Limits user credentials to 8 hours. After the time to live (TTL) expires,
       # users must re-login
       max_session_ttl: 8h0m0s
-version: v3
+version: v5

--- a/packages/teleport/src/Roles/templates/role.yaml
+++ b/packages/teleport/src/Roles/templates/role.yaml
@@ -42,6 +42,7 @@ spec:
       '*': '*'
     # Windows logins a user is allowed to use for desktop sessions.
     windows_desktop_logins:
+    - '{{internal.windows_logins}}'
     - developer
 
     # RBAC rules for various resources within a cluster. This

--- a/packages/teleport/src/Roles/templates/role.yaml
+++ b/packages/teleport/src/Roles/templates/role.yaml
@@ -6,15 +6,40 @@ spec:
   # This example defines an administrative role. It maps to Kubernetes "admin"
   # group and allows SSH to every node.
   allow:
+    # List of Kubernetes cluster users can access the k8s API
+    kubernetes_labels:
+      '*': '*'
     # This role is mapped to Kubernetes 'admin' group.
     kubernetes_groups: [admin]
-
+    
     # List of allowed SSH logins
-    logins: [root]
+    logins: [ubuntu, debian]
 
     # List of node labels that users can SSH into
     node_labels:
       '*': '*'
+      
+    # List of application labels users can access
+    app_labels:    
+      '*': '*'
+      
+    # List of database labels users can access
+    db_labels:
+      '*': '*'
+    # List of databases on the database server users can access
+    db_names:
+     - '*'
+    # List of database users allowed to open database connections
+    db_users:
+    - dba-admin
+    
+    # List of windows desktop access labels that users can open desktop sessions to
+    windows_desktop_labels:
+      '*': '*'
+    # Windows logins a user is allowed to use for desktop sessions.
+    windows_desktop_logins:
+    - '{{internal.windows_logins}}'
+    - Administrator
 
     # RBAC rules for various resources within a cluster. This
     # example provides access to the Audit Log and replaying a user's own sessions.

--- a/packages/teleport/src/Roles/templates/role.yaml
+++ b/packages/teleport/src/Roles/templates/role.yaml
@@ -23,13 +23,13 @@ spec:
     app_labels:    
       '*': '*'
       
-    # List of database labels users can access
+    # List of database labels users can access database servers
     db_labels:
       '*': '*'
     # List of databases on the database server users can access
     db_names:
      - '*'
-    # List of database users allowed to open database connections
+    # List of database users allowed to open database connections with
     db_users:
     - dba-admin
     

--- a/packages/teleport/src/Roles/templates/role.yaml
+++ b/packages/teleport/src/Roles/templates/role.yaml
@@ -13,7 +13,9 @@ spec:
     kubernetes_groups:
     - '{{internal.kubernetes_groups}}'
     - developer
-
+    kubernetes_users:
+    - '{{internal.kubernetes_users}}'
+    - 'dev'
     # List of allowed SSH logins
     logins: [ubuntu, debian]
 

--- a/packages/teleport/src/Roles/templates/role.yaml
+++ b/packages/teleport/src/Roles/templates/role.yaml
@@ -10,7 +10,9 @@ spec:
     kubernetes_labels:
       '*': '*'
     # This role is mapped to Kubernetes 'developer' group.
-    kubernetes_groups: [developer]
+    kubernetes_groups:
+    - '{{internal.kubernetes_groups}}'
+    - developer
 
     # List of allowed SSH logins
     logins: [ubuntu, debian]

--- a/packages/teleport/src/Roles/templates/role.yaml
+++ b/packages/teleport/src/Roles/templates/role.yaml
@@ -17,7 +17,7 @@ spec:
     - '{{internal.kubernetes_users}}'
     - 'dev'
     # List of allowed SSH logins
-    logins: [ubuntu, debian]
+    logins: ['{{internal.logins}}', ubuntu, debian]
 
     # List of node labels that users can SSH into
     node_labels:
@@ -32,9 +32,11 @@ spec:
       '*': '*'
     # List of databases on the database server users can access
     db_names:
-     - '*'
+    - '{{internal.db_names}}'
+    - '*'
     # List of database users allowed to open database connections with
     db_users:
+    - '{{internal.db_users}}'
     - developer
     
     # List of windows desktop access labels that users can open desktop sessions to

--- a/packages/teleport/src/Roles/templates/role.yaml
+++ b/packages/teleport/src/Roles/templates/role.yaml
@@ -3,15 +3,15 @@ metadata:
   # insert the name of your role here:
   name: new_role_name
 spec:
-  # This example defines an administrative role. It maps to Kubernetes "admin"
-  # group and allows SSH to every node.
+  # This example defines a typical role. It allows listing all resources
+  # with typical developer credentials.
   allow:
     # List of Kubernetes cluster users can access the k8s API
     kubernetes_labels:
       '*': '*'
-    # This role is mapped to Kubernetes 'admin' group.
-    kubernetes_groups: [admin]
-    
+    # This role is mapped to Kubernetes 'developer' group.
+    kubernetes_groups: [developer]
+
     # List of allowed SSH logins
     logins: [ubuntu, debian]
 
@@ -31,15 +31,14 @@ spec:
      - '*'
     # List of database users allowed to open database connections with
     db_users:
-    - dba-admin
+    - developer
     
     # List of windows desktop access labels that users can open desktop sessions to
     windows_desktop_labels:
       '*': '*'
     # Windows logins a user is allowed to use for desktop sessions.
     windows_desktop_logins:
-    - '{{internal.windows_logins}}'
-    - Administrator
+    - developer
 
     # RBAC rules for various resources within a cluster. This
     # example provides access to the Audit Log and replaying a user's own sessions.


### PR DESCRIPTION
Set v5 as the default and change the default resource rules to more limited RBAC then everything.  Addresses https://github.com/gravitational/teleport/issues/10807