### PR TITLE
Implement new version of command bar

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -29,7 +29,7 @@
     "@storybook/react": "^6.4.0",
     "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/react": "^12.1.2",
-    "@types/jest": "^27.0.3",
+    "@types/jest": "^27.3.1",
     "@types/lodash": "4.14.149",
     "@types/node": "^16.11.10",
     "@types/react": "^16.8.19",

--- a/packages/teleterm/src/services/pty/ptyProcess.ts
+++ b/packages/teleterm/src/services/pty/ptyProcess.ts
@@ -55,6 +55,10 @@ class PtyProcess extends EventEmitter {
 
     this._process.onData(data => this._handleData(data));
     this._process.onExit(ev => this._handleExit(ev));
+
+    if (this.options.initCommand) {
+      this._process.write(this.options.initCommand + '\r');
+    }
   }
 
   send(data: string) {

--- a/packages/teleterm/src/services/pty/ptyService.ts
+++ b/packages/teleterm/src/services/pty/ptyService.ts
@@ -94,13 +94,13 @@ function buildOptions(settings: RuntimeSettings, cmd: PtyCommand): PtyOptions {
         env['TELEPORT_CLUSTER'] = cmd.leafClusterId;
       }
 
+      const loginHost = cmd.login
+        ? `${cmd.login}@${cmd.serverId}`
+        : cmd.serverId;
+
       return {
         path: settings.tshd.binaryPath,
-        args: [
-          `--proxy=${cmd.rootClusterId}`,
-          'ssh',
-          `${cmd.login}@${cmd.serverId}`,
-        ],
+        args: [`--proxy=${cmd.rootClusterId}`, 'ssh', loginHost],
         env,
       };
     default:

--- a/packages/teleterm/src/services/pty/ptyService.ts
+++ b/packages/teleterm/src/services/pty/ptyService.ts
@@ -67,6 +67,7 @@ function buildOptions(settings: RuntimeSettings, cmd: PtyCommand): PtyOptions {
         args: [],
         cwd: cmd.cwd,
         env,
+        initCommand: cmd.initCommand,
       };
 
     case 'pty.tsh-kube-login':

--- a/packages/teleterm/src/services/pty/types.ts
+++ b/packages/teleterm/src/services/pty/types.ts
@@ -3,6 +3,7 @@ export type PtyOptions = {
   path: string;
   args: string[] | string;
   cwd?: string;
+  initCommand?: string;
 };
 
 export type PtyProcess = {
@@ -24,6 +25,7 @@ export type PtyServiceClient = {
 export type ShellCommand = {
   kind: 'pty.shell';
   cwd?: string;
+  initCommand?: string;
 };
 
 export type TshLoginCommand = {

--- a/packages/teleterm/src/services/pty/types.ts
+++ b/packages/teleterm/src/services/pty/types.ts
@@ -30,7 +30,7 @@ export type ShellCommand = {
 
 export type TshLoginCommand = {
   kind: 'pty.tsh-login';
-  login: string;
+  login?: string;
   serverId: string;
   rootClusterId: string;
   leafClusterId?: string;

--- a/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
+++ b/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
@@ -58,9 +58,19 @@ async function initState(
     docsService.update(doc.uri, { cwd, title: cwd });
   };
 
+  const removeInitCommand = () => {
+    if (doc.kind !== 'doc.terminal_shell') {
+      return;
+    }
+    // The initCommand has to be launched only once, not every time we recreate the document from
+    // the state.
+    docsService.update(doc.uri, { initCommand: undefined });
+  };
+
   ptyProcess.onOpen(() => {
     docsService.update(doc.uri, { status: 'connected' });
     refreshTitle();
+    removeInitCommand();
   });
 
   ptyProcess.onExit(() => {
@@ -92,6 +102,7 @@ function createCmd(doc: Doc): PtyCommand {
   return {
     kind: 'pty.shell',
     cwd: doc.cwd,
+    initCommand: doc.initCommand,
   };
 }
 

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
@@ -28,7 +28,7 @@ export default function Container() {
 }
 
 export function QuickInput(props: State) {
-  const { visible, activeSuggestion, autocompleteResult } = props;
+  const { visible, activeSuggestion, autocompleteResult, inputValue } = props;
   const hasSuggestions =
     autocompleteResult.kind === 'autocomplete.partial-match';
   const refInput = useRef<HTMLInputElement>();
@@ -40,6 +40,14 @@ export function QuickInput(props: State) {
       props.onInputChange(refInput.current.value);
     }, 100);
   }, []);
+
+  // Update input value if it changed outside of this component. This happens when the user pick an
+  // autocomplete suggestion.
+  useEffect(() => {
+    if (refInput.current.value !== inputValue) {
+      refInput.current.value = inputValue;
+    }
+  }, [inputValue]);
 
   function handleOnFocus(e: React.SyntheticEvent) {
     // trigger a callback when focus is coming from external element
@@ -82,19 +90,10 @@ export function QuickInput(props: State) {
     const keyCode = e.which;
     switch (keyCode) {
       case KeyEnum.RETURN:
-        // TODO: even if the list is empty, it should call onPick from the given picker.
-        // Some pickers will choose from a list, some will just submit the command.
-        if (!hasSuggestions) {
-          return;
-        }
-        const { suggestions } = autocompleteResult;
-        if (suggestions.length > 0) {
-          e.stopPropagation();
-          e.preventDefault();
+        e.stopPropagation();
+        e.preventDefault();
 
-          refInput.current.value = '';
-          props.onPickSuggestion(activeSuggestion);
-        }
+        props.onPickSuggestion(activeSuggestion);
         return;
       case KeyEnum.ESC:
         props.onBack();

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
@@ -90,10 +90,9 @@ export function QuickInput(props: State) {
         if (listItems.length > 0) {
           e.stopPropagation();
           e.preventDefault();
-          if (listItems[activeItem].kind !== 'item.empty') {
-            refInput.current.value = '';
-            props.onPickItem(activeItem);
-          }
+
+          refInput.current.value = '';
+          props.onPickItem(activeItem);
         }
         return;
       case KeyEnum.ESC:

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
@@ -28,8 +28,9 @@ export default function Container() {
 }
 
 export function QuickInput(props: State) {
-  const { visible, activeItem, autocompleteResult } = props;
-  const hasListItems = autocompleteResult.kind === 'autocomplete.partial-match';
+  const { visible, activeSuggestion, autocompleteResult } = props;
+  const hasSuggestions =
+    autocompleteResult.kind === 'autocomplete.partial-match';
   const refInput = useRef<HTMLInputElement>();
   const refList = useRef<HTMLElement>();
   const refContainer = useRef<HTMLElement>();
@@ -67,14 +68,14 @@ export function QuickInput(props: State) {
 
   const handleArrowKey = (e: React.KeyboardEvent, nudge = 0) => {
     e.stopPropagation();
-    if (!hasListItems) {
+    if (!hasSuggestions) {
       return;
     }
     const next = getNext(
-      activeItem + nudge,
-      autocompleteResult.listItems.length
+      activeSuggestion + nudge,
+      autocompleteResult.suggestions.length
     );
-    props.onActiveItem(next);
+    props.onActiveSuggestion(next);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -83,16 +84,16 @@ export function QuickInput(props: State) {
       case KeyEnum.RETURN:
         // TODO: even if the list is empty, it should call onPick from the given picker.
         // Some pickers will choose from a list, some will just submit the command.
-        if (!hasListItems) {
+        if (!hasSuggestions) {
           return;
         }
-        const { listItems } = autocompleteResult;
-        if (listItems.length > 0) {
+        const { suggestions } = autocompleteResult;
+        if (suggestions.length > 0) {
           e.stopPropagation();
           e.preventDefault();
 
           refInput.current.value = '';
-          props.onPickItem(activeItem);
+          props.onPickSuggestion(activeSuggestion);
         }
         return;
       case KeyEnum.ESC:
@@ -139,12 +140,12 @@ export function QuickInput(props: State) {
           onKeyDown={handleKeyDown}
         />
       </Box>
-      {visible && hasListItems && (
+      {visible && hasSuggestions && (
         <QuickInputList
           ref={refList}
-          items={autocompleteResult.listItems}
-          activeItem={activeItem}
-          onPick={props.onPickItem}
+          items={autocompleteResult.suggestions}
+          activeItem={activeSuggestion}
+          onPick={props.onPickSuggestion}
         />
       )}
     </Flex>

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
@@ -93,7 +93,7 @@ export function QuickInput(props: State) {
         e.stopPropagation();
         e.preventDefault();
 
-        props.onPickSuggestion(activeSuggestion);
+        props.onEnter(activeSuggestion);
         return;
       case KeyEnum.ESC:
         props.onBack();
@@ -144,7 +144,7 @@ export function QuickInput(props: State) {
           ref={refList}
           items={autocompleteResult.suggestions}
           activeItem={activeSuggestion}
-          onPick={props.onPickSuggestion}
+          onPick={props.onEnter}
         />
       )}
     </Flex>

--- a/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React from 'react';
 import styled from 'styled-components';
 import { Label, Box, Text, Flex } from 'design';
+import { makeLabelTag } from 'teleport/components/formatters';
 import * as types from 'teleterm/ui/services/quickInput/types';
 
 const QuickInputList = React.forwardRef<HTMLElement, Props>((props, ref) => {
@@ -77,6 +78,25 @@ function SshLoginItem(props: { item: types.SuggestionSshLogin }) {
   );
 }
 
+function ServerItem(props: { item: types.SuggestionServer }) {
+  const { hostname, uri, labelsList } = props.item.data;
+  const $labels = labelsList.map((label, index) => (
+    <Label mr="1" key={index} kind="secondary">
+      {makeLabelTag(label)}
+    </Label>
+  ));
+
+  return (
+    <div>
+      <Flex alignItems="center">
+        <Box mr={2}>{hostname}</Box>
+        <Box color="text.placeholder">{uri}</Box>
+      </Flex>
+      {$labels}
+    </div>
+  );
+}
+
 function UnknownItem(props: { item: types.Suggestion }) {
   const { kind } = props.item;
   return <div>unknown kind: {kind} </div>;
@@ -124,6 +144,7 @@ const ComponentMap: Record<
 > = {
   ['suggestion.cmd']: CmdItem,
   ['suggestion.ssh-login']: SshLoginItem,
+  ['suggestion.server']: ServerItem,
 };
 
 type Props = {

--- a/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
@@ -130,10 +130,6 @@ function UnknownItem(props: { item: types.Item }) {
   return <div>unknown kind: {kind} </div>;
 }
 
-function EmptyItem(props: { item: types.ItemEmpty }) {
-  return <div>{props.item.data.message || 'Empty'}</div>;
-}
-
 function NewClusterItem(props: { item: types.ItemNewCluster }) {
   return (
     <Flex alignItems="center">
@@ -189,7 +185,6 @@ const ComponentMap: Record<
   ['item.cluster-new']: NewClusterItem,
   ['item.cmd']: CmdItem,
   ['item.ssh-login']: SshLoginItem,
-  ['item.empty']: EmptyItem,
 };
 
 type Props = {

--- a/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
@@ -72,7 +72,7 @@ function CmdItem(props: { item: types.SuggestionCmd }) {
 function SshLoginItem(props: { item: types.SuggestionSshLogin }) {
   return (
     <Flex alignItems="center">
-      <Box mr={2}>{props.item.token}</Box>
+      <Box mr={2}>{props.item.data}</Box>
     </Flex>
   );
 }

--- a/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
@@ -60,47 +60,7 @@ const QuickInputList = React.forwardRef<HTMLElement, Props>((props, ref) => {
 
 export default QuickInputList;
 
-function ServerItem(props: { item: types.ItemServer }) {
-  const { hostname, uri, labelsList } = props.item.data;
-  const $labels = labelsList.map((label, index) => (
-    <Label mr="1" key={index} kind="secondary">
-      {label.name}: {label.value}
-    </Label>
-  ));
-
-  return (
-    <div>
-      <Flex alignItems="center">
-        <Box mr={2}>{hostname}</Box>
-        <Box color="text.placeholder">{uri}</Box>
-      </Flex>
-      {$labels}
-    </div>
-  );
-}
-
-function DbItem(props: { item: types.ItemDb }) {
-  const db = props.item.data;
-  const $labels = db.labelsList.map((label, index) => (
-    <Label mr="1" key={index} kind="secondary">
-      {label.name}: {label.value}
-    </Label>
-  ));
-  return (
-    <div>
-      <Flex alignItems="center">
-        <Box mr={2}>{db.name}</Box>
-        <Box color="text.placeholder">{db.uri}</Box>
-        <Text ml="auto" typography="body2" fontSize={0}>
-          {db.type}/{db.protocol}
-        </Text>
-      </Flex>
-      {$labels}
-    </div>
-  );
-}
-
-function CmdItem(props: { item: types.ItemCmd }) {
+function CmdItem(props: { item: types.SuggestionCmd }) {
   return (
     <Flex alignItems="center">
       <Box mr={2}>{props.item.data.displayName}</Box>
@@ -109,34 +69,17 @@ function CmdItem(props: { item: types.ItemCmd }) {
   );
 }
 
-function ClusterItem(props: { item: types.ItemCluster }) {
+function SshLoginItem(props: { item: types.SuggestionSshLogin }) {
   return (
     <Flex alignItems="center">
-      <Box mr={2}>{props.item.data.name}</Box>
+      <Box mr={2}>{props.item.token}</Box>
     </Flex>
   );
 }
 
-function SshLoginItem(props: { item: types.ItemSshLogin }) {
-  return (
-    <Flex alignItems="center">
-      <Box mr={2}>{props.item.data}</Box>
-    </Flex>
-  );
-}
-
-function UnknownItem(props: { item: types.Item }) {
+function UnknownItem(props: { item: types.Suggestion }) {
   const { kind } = props.item;
   return <div>unknown kind: {kind} </div>;
-}
-
-function NewClusterItem(props: { item: types.ItemNewCluster }) {
-  return (
-    <Flex alignItems="center">
-      <Box mr={2}>{props.item.data.displayName}</Box>
-      <Box color="text.placeholder">{props.item.data.description}</Box>
-    </Flex>
-  );
 }
 
 const StyledItem = styled.div(({ theme, $active }) => {
@@ -176,19 +119,15 @@ const StyledGlobalSearchResults = styled.div(({ theme }) => {
 });
 
 const ComponentMap: Record<
-  types.Item['kind'],
-  React.FC<{ item: types.Item }>
+  types.Suggestion['kind'],
+  React.FC<{ item: types.Suggestion }>
 > = {
-  ['item.db']: DbItem,
-  ['item.server']: ServerItem,
-  ['item.cluster']: ClusterItem,
-  ['item.cluster-new']: NewClusterItem,
-  ['item.cmd']: CmdItem,
-  ['item.ssh-login']: SshLoginItem,
+  ['suggestion.cmd']: CmdItem,
+  ['suggestion.ssh-login']: SshLoginItem,
 };
 
 type Props = {
-  items: types.Item[];
+  items: types.Suggestion[];
   activeItem: number;
   onPick(index: number): void;
 };

--- a/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInputList/QuickInputList.tsx
@@ -117,6 +117,14 @@ function ClusterItem(props: { item: types.ItemCluster }) {
   );
 }
 
+function SshLoginItem(props: { item: types.ItemSshLogin }) {
+  return (
+    <Flex alignItems="center">
+      <Box mr={2}>{props.item.data}</Box>
+    </Flex>
+  );
+}
+
 function UnknownItem(props: { item: types.Item }) {
   const { kind } = props.item;
   return <div>unknown kind: {kind} </div>;
@@ -180,6 +188,7 @@ const ComponentMap: Record<
   ['item.cluster']: ClusterItem,
   ['item.cluster-new']: NewClusterItem,
   ['item.cmd']: CmdItem,
+  ['item.ssh-login']: SshLoginItem,
   ['item.empty']: EmptyItem,
 };
 

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -19,15 +19,14 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useKeyboardShortcuts } from 'teleterm/ui/services/keyboardShortcuts';
 
 export default function useQuickInput() {
-  const { quickInputService: serviceQuickInput, workspacesService } =
-    useAppContext();
+  const { quickInputService, workspacesService } = useAppContext();
   workspacesService.useState();
   const documentsService =
     workspacesService.getActiveWorkspaceDocumentService();
-  const { visible, inputValue } = serviceQuickInput.useState();
+  const { visible, inputValue } = quickInputService.useState();
   const [activeSuggestion, setActiveSuggestion] = React.useState(0);
   const autocompleteResult = React.useMemo(
-    () => serviceQuickInput.getAutocompleteResult(inputValue),
+    () => quickInputService.getAutocompleteResult(inputValue),
     [inputValue]
   );
   const hasSuggestions =
@@ -35,7 +34,7 @@ export default function useQuickInput() {
 
   const onFocus = (e: any) => {
     if (e.relatedTarget) {
-      serviceQuickInput.lastFocused = new WeakRef(e.relatedTarget);
+      quickInputService.lastFocused = new WeakRef(e.relatedTarget);
     }
   };
 
@@ -55,7 +54,7 @@ export default function useQuickInput() {
     const suggestion = autocompleteResult.suggestions[index];
 
     setActiveSuggestion(index);
-    serviceQuickInput.pickSuggestion(
+    quickInputService.pickSuggestion(
       autocompleteResult.targetToken,
       suggestion
     );
@@ -67,15 +66,15 @@ export default function useQuickInput() {
     // If there are suggestions to show, the first onBack call should always just close the
     // suggestions and the second call should actually go back.
     if (visible && hasSuggestions) {
-      serviceQuickInput.hide();
+      quickInputService.hide();
     } else {
-      serviceQuickInput.goBack();
+      quickInputService.goBack();
     }
   };
 
   useKeyboardShortcuts({
     'focus-global-search': () => {
-      serviceQuickInput.show();
+      quickInputService.show();
     },
   });
 
@@ -100,9 +99,9 @@ export default function useQuickInput() {
     onBack,
     onEnter,
     onActiveSuggestion,
-    onInputChange: serviceQuickInput.setInputValue,
-    onHide: serviceQuickInput.hide,
-    onShow: serviceQuickInput.show,
+    onInputChange: quickInputService.setInputValue,
+    onHide: quickInputService.hide,
+    onShow: quickInputService.show,
   };
 }
 

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -28,7 +28,6 @@ export default function useQuickInput() {
   );
   const hasSuggestions =
     autocompleteResult.kind === 'autocomplete.partial-match';
-  const picker = autocompleteResult.picker;
 
   const onFocus = (e: any) => {
     if (e.relatedTarget) {
@@ -47,8 +46,14 @@ export default function useQuickInput() {
     if (!hasSuggestions) {
       return;
     }
+
+    const suggestion = autocompleteResult.suggestions[index];
+
     setActiveSuggestion(index);
-    picker.onPick(autocompleteResult.suggestions[index]);
+    serviceQuickInput.pickSuggestion(
+      autocompleteResult.targetToken,
+      suggestion
+    );
   };
 
   const onBack = () => {
@@ -62,9 +67,17 @@ export default function useQuickInput() {
     },
   });
 
+  // Reset active suggestion when the suggestion list changes.
+  // We extract just the tokens and stringify the list to avoid stringifying big objects.
+  // See https://github.com/facebook/react/issues/14476#issuecomment-471199055
   useEffect(() => {
     setActiveSuggestion(0);
-  }, [picker]);
+  }, [
+    hasSuggestions &&
+      JSON.stringify(
+        autocompleteResult.suggestions.map(suggestion => suggestion.token)
+      ),
+  ]);
 
   return {
     visible,

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -20,12 +20,14 @@ import { useKeyboardShortcuts } from 'teleterm/ui/services/keyboardShortcuts';
 
 export default function useQuickInput() {
   const { quickInputService: serviceQuickInput } = useAppContext();
-  const { picker, visible, inputValue } = serviceQuickInput.useState();
+  const { visible, inputValue } = serviceQuickInput.useState();
   const [activeItem, setActiveItem] = React.useState(0);
-  const listItems = React.useMemo(
-    () => picker.onFilter(inputValue),
-    [inputValue, picker]
+  const autocompleteResult = React.useMemo(
+    () => serviceQuickInput.getAutocompleteResult(inputValue),
+    [inputValue]
   );
+  const hasListItems = autocompleteResult.kind === 'autocomplete.partial-match';
+  const picker = autocompleteResult.picker;
 
   const onFocus = (e: any) => {
     if (e.relatedTarget) {
@@ -34,12 +36,18 @@ export default function useQuickInput() {
   };
 
   const onActiveItem = (index: number) => {
+    if (!hasListItems) {
+      return;
+    }
     setActiveItem(index);
   };
 
   const onPickItem = (index: number) => {
+    if (!hasListItems) {
+      return;
+    }
     setActiveItem(index);
-    picker.onPick(listItems[index]);
+    picker.onPick(autocompleteResult.listItems[index]);
   };
 
   const onBack = () => {
@@ -59,9 +67,9 @@ export default function useQuickInput() {
 
   return {
     visible,
+    autocompleteResult,
     activeItem,
     inputValue,
-    listItems,
     onFocus,
     onBack,
     onPickItem,

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -46,8 +46,8 @@ export default function useQuickInput() {
     setActiveSuggestion(index);
   };
 
-  const onPickSuggestion = (index: number) => {
-    if (!hasSuggestions) {
+  const onEnter = (index?: number) => {
+    if (!hasSuggestions || !visible) {
       documentsService.openNewTerminal(inputValue);
       return;
     }
@@ -62,8 +62,15 @@ export default function useQuickInput() {
   };
 
   const onBack = () => {
-    serviceQuickInput.goBack();
     setActiveSuggestion(0);
+
+    // If there are suggestions to show, the first onBack call should always just close the
+    // suggestions and the second call should actually go back.
+    if (visible && hasSuggestions) {
+      serviceQuickInput.hide();
+    } else {
+      serviceQuickInput.goBack();
+    }
   };
 
   useKeyboardShortcuts({
@@ -91,7 +98,7 @@ export default function useQuickInput() {
     inputValue,
     onFocus,
     onBack,
-    onPickSuggestion,
+    onEnter,
     onActiveSuggestion,
     onInputChange: serviceQuickInput.setInputValue,
     onHide: serviceQuickInput.hide,

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -21,12 +21,13 @@ import { useKeyboardShortcuts } from 'teleterm/ui/services/keyboardShortcuts';
 export default function useQuickInput() {
   const { quickInputService: serviceQuickInput } = useAppContext();
   const { visible, inputValue } = serviceQuickInput.useState();
-  const [activeItem, setActiveItem] = React.useState(0);
+  const [activeSuggestion, setActiveSuggestion] = React.useState(0);
   const autocompleteResult = React.useMemo(
     () => serviceQuickInput.getAutocompleteResult(inputValue),
     [inputValue]
   );
-  const hasListItems = autocompleteResult.kind === 'autocomplete.partial-match';
+  const hasSuggestions =
+    autocompleteResult.kind === 'autocomplete.partial-match';
   const picker = autocompleteResult.picker;
 
   const onFocus = (e: any) => {
@@ -35,24 +36,24 @@ export default function useQuickInput() {
     }
   };
 
-  const onActiveItem = (index: number) => {
-    if (!hasListItems) {
+  const onActiveSuggestion = (index: number) => {
+    if (!hasSuggestions) {
       return;
     }
-    setActiveItem(index);
+    setActiveSuggestion(index);
   };
 
-  const onPickItem = (index: number) => {
-    if (!hasListItems) {
+  const onPickSuggestion = (index: number) => {
+    if (!hasSuggestions) {
       return;
     }
-    setActiveItem(index);
-    picker.onPick(autocompleteResult.listItems[index]);
+    setActiveSuggestion(index);
+    picker.onPick(autocompleteResult.suggestions[index]);
   };
 
   const onBack = () => {
     serviceQuickInput.goBack();
-    setActiveItem(0);
+    setActiveSuggestion(0);
   };
 
   useKeyboardShortcuts({
@@ -62,18 +63,18 @@ export default function useQuickInput() {
   });
 
   useEffect(() => {
-    setActiveItem(0);
+    setActiveSuggestion(0);
   }, [picker]);
 
   return {
     visible,
     autocompleteResult,
-    activeItem,
+    activeSuggestion,
     inputValue,
     onFocus,
     onBack,
-    onPickItem,
-    onActiveItem,
+    onPickSuggestion,
+    onActiveSuggestion,
     onInputChange: serviceQuickInput.setInputValue,
     onHide: serviceQuickInput.hide,
     onShow: serviceQuickInput.show,

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -19,7 +19,11 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useKeyboardShortcuts } from 'teleterm/ui/services/keyboardShortcuts';
 
 export default function useQuickInput() {
-  const { quickInputService: serviceQuickInput } = useAppContext();
+  const { quickInputService: serviceQuickInput, workspacesService } =
+    useAppContext();
+  workspacesService.useState();
+  const documentsService =
+    workspacesService.getActiveWorkspaceDocumentService();
   const { visible, inputValue } = serviceQuickInput.useState();
   const [activeSuggestion, setActiveSuggestion] = React.useState(0);
   const autocompleteResult = React.useMemo(
@@ -44,6 +48,7 @@ export default function useQuickInput() {
 
   const onPickSuggestion = (index: number) => {
     if (!hasSuggestions) {
+      documentsService.openNewTerminal(inputValue);
       return;
     }
 

--- a/packages/teleterm/src/ui/appContext.ts
+++ b/packages/teleterm/src/ui/appContext.ts
@@ -61,7 +61,8 @@ export default class AppContext {
 
     this.quickInputService = new QuickInputService(
       this.commandLauncher,
-      this.clustersService
+      this.clustersService,
+      this.workspacesService
     );
 
     this.connectionTracker = new ConnectionTrackerService(

--- a/packages/teleterm/src/ui/commandLauncher.ts
+++ b/packages/teleterm/src/ui/commandLauncher.ts
@@ -117,6 +117,18 @@ const commands = {
       }
     },
   },
+
+  'autocomplete.tsh-ssh': {
+    displayName: 'tsh ssh',
+    description: 'Run shell or execute a command on a remote SSH node',
+    run() {},
+  },
+  'autocomplete.tsh-proxy-db': {
+    displayName: 'tsh proxy db',
+    description:
+      'Start local TLS proxy for database connections when using Teleport',
+    run() {},
+  },
 };
 
 export class CommandLauncher {
@@ -128,6 +140,12 @@ export class CommandLauncher {
 
   executeCommand<T extends CommandName>(name: T, args: CommandArgs<T>) {
     commands[name].run(this.appContext, args as any);
+  }
+
+  getAutocompleteCommands() {
+    return Object.entries(commands)
+      .filter(([key]) => key.startsWith('autocomplete.'))
+      .map(([key, value]) => ({ name: key, ...value }));
   }
 }
 

--- a/packages/teleterm/src/ui/commandLauncher.ts
+++ b/packages/teleterm/src/ui/commandLauncher.ts
@@ -117,48 +117,6 @@ const commands = {
       }
     },
   },
-
-  'cmd-palette.cluster-login': {
-    displayName: 'login',
-    description: 'Log in to a cluster and retrieve the session',
-    run(appCtx: IAppContext) {
-      appCtx.quickInputService.setState({
-        picker: appCtx.quickInputService.quickLoginPicker,
-        inputValue: '',
-      });
-    },
-  },
-  'cmd-palette.ssh': {
-    displayName: 'ssh',
-    description: 'Run shell or execute a command on a remote SSH node',
-    run(appCtx: IAppContext) {
-      appCtx.quickInputService.setState({
-        picker: appCtx.quickInputService.quickServerPicker,
-        inputValue: '',
-      });
-    },
-  },
-  'cmd-palette.proxy-db': {
-    displayName: 'proxy db',
-    description:
-      'Start local TLS proxy for database connections when using Teleport',
-    run(appCtx: IAppContext) {
-      appCtx.quickInputService.setState({
-        picker: appCtx.quickInputService.quickDbPicker,
-        inputValue: '',
-      });
-    },
-  },
-  'cmd-palette.db-ls': {
-    displayName: 'db ls',
-    description: 'List cluster available databases',
-    run(appCtx: IAppContext) {
-      appCtx.quickInputService.setState({
-        picker: appCtx.quickInputService.quickLoginPicker,
-        inputValue: '',
-      });
-    },
-  },
 };
 
 export class CommandLauncher {
@@ -170,19 +128,6 @@ export class CommandLauncher {
 
   executeCommand<T extends CommandName>(name: T, args: CommandArgs<T>) {
     commands[name].run(this.appContext, args as any);
-  }
-
-  getPaletteCommands() {
-    return Object.entries(commands)
-      .filter(([key]) => {
-        return key.startsWith('cmd-palette');
-      })
-      .map(([key, value]) => {
-        return {
-          name: key,
-          ...value,
-        };
-      });
   }
 }
 

--- a/packages/teleterm/src/ui/commandLauncher.ts
+++ b/packages/teleterm/src/ui/commandLauncher.ts
@@ -36,7 +36,8 @@ const commands = {
       }
     ) {
       const onSuccess = (gatewayUri: string) => {
-        const documentsService = ctx.workspacesService.getActiveWorkspaceDocumentService()
+        const documentsService =
+          ctx.workspacesService.getActiveWorkspaceDocumentService();
         const db = ctx.clustersService.findDb(args.dbUri);
         const gateway = ctx.clustersService.findGateway(gatewayUri);
         const doc = documentsService.createGatewayDocument({
@@ -63,7 +64,8 @@ const commands = {
     displayName: '',
     description: '',
     run(ctx: IAppContext, args: { kubeUri: string }) {
-      const documentsService = ctx.workspacesService.getActiveWorkspaceDocumentService()
+      const documentsService =
+        ctx.workspacesService.getActiveWorkspaceDocumentService();
       const kubeDoc = documentsService.createTshKubeDocument(args.kubeUri);
       documentsService.add(kubeDoc);
       documentsService.open(kubeDoc.uri);
@@ -103,7 +105,8 @@ const commands = {
     description: '',
     run(ctx: IAppContext, args: { clusterUri: string }) {
       const { clusterUri } = args;
-      const documentsService = ctx.workspacesService.getActiveWorkspaceDocumentService()
+      const documentsService =
+        ctx.workspacesService.getActiveWorkspaceDocumentService();
       const doc = documentsService.findClusterDocument(clusterUri);
       if (doc) {
         documentsService.open(doc.uri);

--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -462,11 +462,17 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     );
   }
 
-  searchServers(clusterUri: string, query: SearchQuery) {
+  searchServers(clusterUri: string, query: SearchQueryWithProps<tsh.Server>) {
     const servers = this.findServers(clusterUri);
+    const searchableProps = query.searchableProps || [
+      'hostname',
+      'addr',
+      'labelsList',
+      'tunnel',
+    ];
     return servers.filter(obj =>
       isMatch(obj, query.search, {
-        searchableProps: ['hostname', 'addr', 'labelsList', 'tunnel'],
+        searchableProps: searchableProps,
         cb: (targetValue, searchValue, propName) => {
           if (propName === 'tunnel') {
             return 'TUNNEL'.includes(searchValue);
@@ -492,6 +498,10 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
 
 type SearchQuery = {
   search: string;
+};
+
+type SearchQueryWithProps<T> = SearchQuery & {
+  searchableProps?: (keyof T)[];
 };
 
 const helpers = {

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
@@ -142,7 +142,12 @@ test("getAutocompleteResult doesn't return any suggestions if the only suggestio
       return {
         kind: 'autocomplete.partial-match',
         suggestions: [
-          { kind: 'suggestion.ssh-login', token: 'foobar', data: null },
+          {
+            kind: 'suggestion.ssh-login',
+            token: 'foobar',
+            appendToToken: '@',
+            data: 'foobar',
+          },
         ],
         targetToken: {
           startIndex: 0,
@@ -262,9 +267,33 @@ test('picking an SSH login suggestion replaces target token in input value', () 
   const sshLogin: SuggestionSshLogin = {
     kind: 'suggestion.ssh-login',
     token: 'root',
-    data: null,
+    appendToToken: '@',
+    data: 'root',
   };
   quickInputService.pickSuggestion(targetToken, sshLogin);
 
-  expect(quickInputService.getInputValue()).toBe('tsh ssh root --foo');
+  expect(quickInputService.getInputValue()).toBe('tsh ssh root@ --foo');
+});
+
+test('pickSuggestion appends the appendToToken field to the token', () => {
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+  quickInputService.setState({ inputValue: 'tsh ssh foo' });
+
+  const targetToken = {
+    value: 'foo',
+    startIndex: 8,
+  };
+  const sshLogin: SuggestionSshLogin = {
+    kind: 'suggestion.ssh-login',
+    token: 'foobar',
+    appendToToken: '@barbaz',
+    data: 'foobar',
+  };
+  quickInputService.pickSuggestion(targetToken, sshLogin);
+
+  expect(quickInputService.getInputValue()).toBe('tsh ssh foobar@barbaz');
 });

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
@@ -96,6 +96,22 @@ test('getAutocompleteResult returns correct target token for an SSH login sugges
     CommandLauncherMock,
     onlyTshSshCommand
   );
+  jest
+    .spyOn(pickers.QuickSshLoginPicker.prototype, 'getAutocompleteResult')
+    .mockImplementation((input: string, startIndex: number) => {
+      return {
+        kind: 'autocomplete.partial-match',
+        suggestions: [
+          {
+            kind: 'suggestion.ssh-login',
+            token: 'root',
+            appendToToken: '@',
+            data: 'root',
+          },
+        ],
+        targetToken: { startIndex, value: input },
+      };
+    });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
     new ClustersServiceMock(undefined),
@@ -116,6 +132,22 @@ test('getAutocompleteResult returns correct target token for an SSH login sugges
     CommandLauncherMock,
     onlyTshSshCommand
   );
+  jest
+    .spyOn(pickers.QuickSshLoginPicker.prototype, 'getAutocompleteResult')
+    .mockImplementation((input: string, startIndex: number) => {
+      return {
+        kind: 'autocomplete.partial-match',
+        suggestions: [
+          {
+            kind: 'suggestion.ssh-login',
+            token: 'barfoo',
+            appendToToken: '@',
+            data: 'barfoo',
+          },
+        ],
+        targetToken: { startIndex, value: input },
+      };
+    });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
     new ClustersServiceMock(undefined),
@@ -165,6 +197,33 @@ test("getAutocompleteResult doesn't return any suggestions if the only suggestio
   expect(autocompleteResult.kind).toBe('autocomplete.no-match');
 });
 
+test('getAutocompleteResult returns no match if any of the pickers returns partial match with empty array', () => {
+  jest.mock('./quickPickers');
+  const QuickCommandPickerMock = pickers.QuickCommandPicker as jest.MockedClass<
+    typeof pickers.QuickCommandPicker
+  >;
+  jest
+    .spyOn(QuickCommandPickerMock.prototype, 'getAutocompleteResult')
+    .mockImplementation(() => {
+      return {
+        kind: 'autocomplete.partial-match',
+        suggestions: [],
+        targetToken: {
+          startIndex: 0,
+          value: '',
+        },
+      };
+    });
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult = quickInputService.getAutocompleteResult('');
+  expect(autocompleteResult.kind).toBe('autocomplete.no-match');
+});
+
 test("the SSH login autocomplete isn't shown if there's no space after `tsh ssh`", () => {
   mockCommandLauncherAutocompleteCommands(
     CommandLauncherMock,
@@ -185,6 +244,22 @@ test("the SSH login autocomplete is shown only if there's at least one space aft
     CommandLauncherMock,
     onlyTshSshCommand
   );
+  jest
+    .spyOn(pickers.QuickSshLoginPicker.prototype, 'getAutocompleteResult')
+    .mockImplementation((input: string, startIndex: number) => {
+      return {
+        kind: 'autocomplete.partial-match',
+        suggestions: [
+          {
+            kind: 'suggestion.ssh-login',
+            token: 'barfoo',
+            appendToToken: '@',
+            data: 'barfoo',
+          },
+        ],
+        targetToken: { startIndex, value: input },
+      };
+    });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
     new ClustersServiceMock(undefined),

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
@@ -275,6 +275,75 @@ test("the SSH login autocomplete is shown only if there's at least one space aft
   });
 });
 
+test('getAutocompleteResult returns correct target token for an SSH host suggestion right after user@', () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  jest
+    .spyOn(ClustersServiceMock.prototype, 'searchServers')
+    .mockImplementation(() => {
+      return [
+        {
+          hostname: 'bazbar',
+          name: '',
+          addr: '',
+          uri: '',
+          tunnel: false,
+          labelsList: null,
+        },
+      ];
+    });
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult =
+    quickInputService.getAutocompleteResult('tsh ssh user@');
+  expect(autocompleteResult.kind).toBe('autocomplete.partial-match');
+  expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
+    value: '',
+    startIndex: 13,
+  });
+});
+
+test('getAutocompleteResult returns correct target token for a partial match on an SSH host suggestion', () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  jest
+    .spyOn(ClustersServiceMock.prototype, 'searchServers')
+    .mockImplementation(() => {
+      return [
+        {
+          hostname: 'bazbar',
+          name: '',
+          addr: '',
+          uri: '',
+          tunnel: false,
+          labelsList: null,
+        },
+      ];
+    });
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult = quickInputService.getAutocompleteResult(
+    '   tsh ssh    foo@baz'
+  );
+  expect(autocompleteResult.kind).toBe('autocomplete.partial-match');
+  expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
+    value: 'baz',
+    startIndex: 18,
+  });
+});
+
 test('picking a command suggestion in an empty input autocompletes the command', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
@@ -1,0 +1,270 @@
+import { QuickInputService } from './quickInputService';
+
+import { CommandLauncher } from 'teleterm/ui/commandLauncher';
+import { ClustersService } from 'teleterm/ui/services/clusters';
+import { WorkspacesService } from 'teleterm/ui/services/workspacesService';
+import * as pickers from './quickPickers';
+import {
+  AutocompletePartialMatch,
+  SuggestionCmd,
+  SuggestionSshLogin,
+} from './types';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+jest.mock('teleterm/ui/commandLauncher');
+jest.mock('teleterm/ui/services/clusters');
+jest.mock('teleterm/ui/services/workspacesService');
+
+const CommandLauncherMock = CommandLauncher as jest.MockedClass<
+  typeof CommandLauncher
+>;
+const ClustersServiceMock = ClustersService as jest.MockedClass<
+  typeof ClustersService
+>;
+const WorkspacesServiceMock = WorkspacesService as jest.MockedClass<
+  typeof WorkspacesService
+>;
+
+const onlyTshSshCommand = [
+  {
+    name: 'autocomplete.tsh-ssh',
+    displayName: 'tsh ssh',
+    description: '',
+    run: () => {},
+  },
+];
+
+function mockCommandLauncherAutocompleteCommands(
+  commandLauncherMock: jest.MockedClass<typeof CommandLauncher>,
+  commands: {
+    name: string;
+    displayName: string;
+    description: string;
+    run: () => void;
+  }[]
+) {
+  jest
+    .spyOn(commandLauncherMock.prototype, 'getAutocompleteCommands')
+    .mockImplementation(() => {
+      return commands;
+    });
+}
+
+test('getAutocompleteResult returns correct target token for a command suggestion with empty input', () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult = quickInputService.getAutocompleteResult('');
+  expect(autocompleteResult.kind).toBe('autocomplete.partial-match');
+  expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
+    value: '',
+    startIndex: 0,
+  });
+});
+
+test('getAutocompleteResult returns correct target token for a command suggestion', () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult = quickInputService.getAutocompleteResult('ts');
+  expect(autocompleteResult.kind).toBe('autocomplete.partial-match');
+  expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
+    value: 'ts',
+    startIndex: 0,
+  });
+});
+
+test('getAutocompleteResult returns correct target token for an SSH login suggestion', () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult =
+    quickInputService.getAutocompleteResult('tsh ssh roo');
+  expect(autocompleteResult.kind).toBe('autocomplete.partial-match');
+  expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
+    value: 'roo',
+    startIndex: 8,
+  });
+});
+
+test('getAutocompleteResult returns correct target token for an SSH login suggestion with spaces between arguments', () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult =
+    quickInputService.getAutocompleteResult('   tsh ssh    bar');
+  expect(autocompleteResult.kind).toBe('autocomplete.partial-match');
+  expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
+    value: 'bar',
+    startIndex: 14,
+  });
+});
+
+test("getAutocompleteResult doesn't return any suggestions if the only suggestion completely matches the target token", () => {
+  jest.mock('./quickPickers');
+  const QuickCommandPickerMock = pickers.QuickCommandPicker as jest.MockedClass<
+    typeof pickers.QuickCommandPicker
+  >;
+  jest
+    .spyOn(QuickCommandPickerMock.prototype, 'getAutocompleteResult')
+    .mockImplementation(() => {
+      return {
+        kind: 'autocomplete.partial-match',
+        suggestions: [
+          { kind: 'suggestion.ssh-login', token: 'foobar', data: null },
+        ],
+        targetToken: {
+          startIndex: 0,
+          value: 'foobar',
+        },
+      };
+    });
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult = quickInputService.getAutocompleteResult('foobar');
+  expect(autocompleteResult.kind).toBe('autocomplete.no-match');
+});
+
+test("the SSH login autocomplete isn't shown if there's no space after `tsh ssh`", () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult = quickInputService.getAutocompleteResult('tsh ssh');
+  expect(autocompleteResult.kind).toBe('autocomplete.no-match');
+});
+
+test("the SSH login autocomplete is shown only if there's at least one space after `tsh ssh`", () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult =
+    quickInputService.getAutocompleteResult('tsh ssh ');
+  expect(autocompleteResult.kind).toBe('autocomplete.partial-match');
+  expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
+    value: '',
+    startIndex: 8,
+  });
+});
+
+test('picking a command suggestion in an empty input autocompletes the command', () => {
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+  quickInputService.setState({ inputValue: '' });
+
+  const targetToken = {
+    startIndex: 0,
+    value: '',
+  };
+  const cmd: SuggestionCmd = {
+    kind: 'suggestion.cmd',
+    token: 'tsh ssh',
+    data: {
+      name: 'autocomplete.tsh-ssh',
+      displayName: 'tsh ssh',
+      description: '',
+    },
+  };
+  quickInputService.pickSuggestion(targetToken, cmd);
+
+  expect(quickInputService.getInputValue()).toBe('tsh ssh');
+});
+
+test('picking a command suggestion in an input with a single space preserves the space', () => {
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+  quickInputService.setState({ inputValue: ' ' });
+
+  const targetToken = {
+    startIndex: 1,
+    value: '',
+  };
+  const cmd: SuggestionCmd = {
+    kind: 'suggestion.cmd',
+    token: 'tsh ssh',
+    data: {
+      name: 'autocomplete.tsh-ssh',
+      displayName: 'tsh ssh',
+      description: '',
+    },
+  };
+  quickInputService.pickSuggestion(targetToken, cmd);
+
+  expect(quickInputService.getInputValue()).toBe(' tsh ssh');
+});
+
+test('picking an SSH login suggestion replaces target token in input value', () => {
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+  quickInputService.setState({ inputValue: 'tsh ssh roo --foo' });
+
+  const targetToken = {
+    value: 'roo',
+    startIndex: 8,
+  };
+  const sshLogin: SuggestionSshLogin = {
+    kind: 'suggestion.ssh-login',
+    token: 'root',
+    data: null,
+  };
+  quickInputService.pickSuggestion(targetToken, sshLogin);
+
+  expect(quickInputService.getInputValue()).toBe('tsh ssh root --foo');
+});

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
@@ -53,7 +53,7 @@ function mockCommandLauncherAutocompleteCommands(
     });
 }
 
-test('getAutocompleteResult returns correct target token for a command suggestion with empty input', () => {
+test('getAutocompleteResult returns correct result for a command suggestion with empty input', () => {
   mockCommandLauncherAutocompleteCommands(
     CommandLauncherMock,
     onlyTshSshCommand
@@ -70,9 +70,10 @@ test('getAutocompleteResult returns correct target token for a command suggestio
     value: '',
     startIndex: 0,
   });
+  expect(autocompleteResult.command).toEqual({ kind: 'command.unknown' });
 });
 
-test('getAutocompleteResult returns correct target token for a command suggestion', () => {
+test('getAutocompleteResult returns correct result for a command suggestion', () => {
   mockCommandLauncherAutocompleteCommands(
     CommandLauncherMock,
     onlyTshSshCommand
@@ -89,9 +90,10 @@ test('getAutocompleteResult returns correct target token for a command suggestio
     value: 'ts',
     startIndex: 0,
   });
+  expect(autocompleteResult.command).toEqual({ kind: 'command.unknown' });
 });
 
-test('getAutocompleteResult returns correct target token for an SSH login suggestion', () => {
+test('getAutocompleteResult returns correct result for an SSH login suggestion', () => {
   mockCommandLauncherAutocompleteCommands(
     CommandLauncherMock,
     onlyTshSshCommand
@@ -110,6 +112,7 @@ test('getAutocompleteResult returns correct target token for an SSH login sugges
           },
         ],
         targetToken: { startIndex, value: input },
+        command: { kind: 'command.unknown' },
       };
     });
   const quickInputService = new QuickInputService(
@@ -125,9 +128,13 @@ test('getAutocompleteResult returns correct target token for an SSH login sugges
     value: 'roo',
     startIndex: 8,
   });
+  expect(autocompleteResult.command).toEqual({
+    kind: 'command.tsh-ssh',
+    loginHost: 'roo',
+  });
 });
 
-test('getAutocompleteResult returns correct target token for an SSH login suggestion with spaces between arguments', () => {
+test('getAutocompleteResult returns correct result for an SSH login suggestion with spaces between arguments', () => {
   mockCommandLauncherAutocompleteCommands(
     CommandLauncherMock,
     onlyTshSshCommand
@@ -146,6 +153,7 @@ test('getAutocompleteResult returns correct target token for an SSH login sugges
           },
         ],
         targetToken: { startIndex, value: input },
+        command: { kind: 'command.unknown' },
       };
     });
   const quickInputService = new QuickInputService(
@@ -160,6 +168,10 @@ test('getAutocompleteResult returns correct target token for an SSH login sugges
   expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
     value: 'bar',
     startIndex: 14,
+  });
+  expect(autocompleteResult.command).toEqual({
+    kind: 'command.tsh-ssh',
+    loginHost: 'bar',
   });
 });
 
@@ -185,6 +197,7 @@ test("getAutocompleteResult doesn't return any suggestions if the only suggestio
           startIndex: 0,
           value: 'foobar',
         },
+        command: { kind: 'command.unknown' },
       };
     });
   const quickInputService = new QuickInputService(
@@ -195,6 +208,7 @@ test("getAutocompleteResult doesn't return any suggestions if the only suggestio
 
   const autocompleteResult = quickInputService.getAutocompleteResult('foobar');
   expect(autocompleteResult.kind).toBe('autocomplete.no-match');
+  expect(autocompleteResult.command).toEqual({ kind: 'command.unknown' });
 });
 
 test('getAutocompleteResult returns no match if any of the pickers returns partial match with empty array', () => {
@@ -212,6 +226,7 @@ test('getAutocompleteResult returns no match if any of the pickers returns parti
           startIndex: 0,
           value: '',
         },
+        command: { kind: 'command.unknown' },
       };
     });
   const quickInputService = new QuickInputService(
@@ -222,6 +237,7 @@ test('getAutocompleteResult returns no match if any of the pickers returns parti
 
   const autocompleteResult = quickInputService.getAutocompleteResult('');
   expect(autocompleteResult.kind).toBe('autocomplete.no-match');
+  expect(autocompleteResult.command).toEqual({ kind: 'command.unknown' });
 });
 
 test("the SSH login autocomplete isn't shown if there's no space after `tsh ssh`", () => {
@@ -237,6 +253,10 @@ test("the SSH login autocomplete isn't shown if there's no space after `tsh ssh`
 
   const autocompleteResult = quickInputService.getAutocompleteResult('tsh ssh');
   expect(autocompleteResult.kind).toBe('autocomplete.no-match');
+  expect(autocompleteResult.command).toEqual({
+    kind: 'command.tsh-ssh',
+    loginHost: '',
+  });
 });
 
 test("the SSH login autocomplete is shown only if there's at least one space after `tsh ssh`", () => {
@@ -258,6 +278,7 @@ test("the SSH login autocomplete is shown only if there's at least one space aft
           },
         ],
         targetToken: { startIndex, value: input },
+        command: { kind: 'command.unknown' },
       };
     });
   const quickInputService = new QuickInputService(
@@ -273,9 +294,13 @@ test("the SSH login autocomplete is shown only if there's at least one space aft
     value: '',
     startIndex: 8,
   });
+  expect(autocompleteResult.command).toEqual({
+    kind: 'command.tsh-ssh',
+    loginHost: '',
+  });
 });
 
-test('getAutocompleteResult returns correct target token for an SSH host suggestion right after user@', () => {
+test('getAutocompleteResult returns correct result for an SSH host suggestion right after user@', () => {
   mockCommandLauncherAutocompleteCommands(
     CommandLauncherMock,
     onlyTshSshCommand
@@ -307,9 +332,13 @@ test('getAutocompleteResult returns correct target token for an SSH host suggest
     value: '',
     startIndex: 13,
   });
+  expect(autocompleteResult.command).toEqual({
+    kind: 'command.tsh-ssh',
+    loginHost: 'user@',
+  });
 });
 
-test('getAutocompleteResult returns correct target token for a partial match on an SSH host suggestion', () => {
+test('getAutocompleteResult returns correct result for a partial match on an SSH host suggestion', () => {
   mockCommandLauncherAutocompleteCommands(
     CommandLauncherMock,
     onlyTshSshCommand
@@ -341,6 +370,51 @@ test('getAutocompleteResult returns correct target token for a partial match on 
   expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
     value: 'baz',
     startIndex: 18,
+  });
+  expect(autocompleteResult.command).toEqual({
+    kind: 'command.tsh-ssh',
+    loginHost: 'foo@baz',
+  });
+});
+
+test("getAutocompleteResult returns the first argument as loginHost when there's no @ sign", () => {
+  mockCommandLauncherAutocompleteCommands(
+    CommandLauncherMock,
+    onlyTshSshCommand
+  );
+  jest
+    .spyOn(pickers.QuickSshLoginPicker.prototype, 'getAutocompleteResult')
+    .mockImplementation((input: string, startIndex: number) => {
+      return {
+        kind: 'autocomplete.partial-match',
+        suggestions: [
+          {
+            kind: 'suggestion.ssh-login',
+            token: 'barfoo',
+            appendToToken: '@',
+            data: 'barfoo',
+          },
+        ],
+        targetToken: { startIndex, value: input },
+        command: { kind: 'command.unknown' },
+      };
+    });
+  const quickInputService = new QuickInputService(
+    new CommandLauncherMock(undefined),
+    new ClustersServiceMock(undefined),
+    new WorkspacesServiceMock(undefined, undefined, undefined)
+  );
+
+  const autocompleteResult =
+    quickInputService.getAutocompleteResult('tsh ssh bar');
+  expect(autocompleteResult.kind).toBe('autocomplete.partial-match');
+  expect((autocompleteResult as AutocompletePartialMatch).targetToken).toEqual({
+    value: 'bar',
+    startIndex: 8,
+  });
+  expect(autocompleteResult.command).toEqual({
+    kind: 'command.tsh-ssh',
+    loginHost: 'bar',
   });
 });
 

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -43,14 +43,17 @@ export class QuickInputService extends Store<State> {
     });
 
     const sshLoginPicker = new pickers.QuickSshLoginPicker(
-      this,
+      workspacesService,
+      clustersService
+    );
+    const serverPicker = new pickers.QuickServerPicker(
       workspacesService,
       clustersService
     );
 
     this.quickCommandPicker.registerPickerForCommand(
       'tsh ssh',
-      new pickers.QuickTshSshPicker(launcher, sshLoginPicker)
+      new pickers.QuickTshSshPicker(launcher, sshLoginPicker, serverPicker)
     );
     this.quickCommandPicker.registerPickerForCommand(
       'tsh proxy db',

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -120,9 +120,10 @@ export class QuickInputService extends Store<State> {
   // support cursor index. So `tsh ssh roo --cluster=bar` becomes `tsh ssh root --cluster=bar`.
   pickSuggestion(targetToken: AutocompleteToken, suggestion: Suggestion) {
     const { inputValue } = this.state;
+    const insertedToken = suggestion.token + (suggestion.appendToToken || '');
     const newInputValue =
       inputValue.substring(0, targetToken.startIndex) +
-      suggestion.token +
+      insertedToken +
       inputValue.substring(targetToken.startIndex + targetToken.value.length);
 
     this.setState({

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -19,7 +19,7 @@ import { CommandLauncher } from 'teleterm/ui/commandLauncher';
 import { ClustersService } from 'teleterm/ui/services/clusters';
 import { WorkspacesService } from 'teleterm/ui/services/workspacesService';
 import * as pickers from './quickPickers';
-import { AutocompleteResult } from './types';
+import { AutocompleteResult, AutocompleteToken, Suggestion } from './types';
 
 type State = {
   inputValue: string;
@@ -27,7 +27,7 @@ type State = {
 };
 
 export class QuickInputService extends Store<State> {
-  quickCommandPicker: pickers.QuickCommandPicker;
+  private quickCommandPicker: pickers.QuickCommandPicker;
   lastFocused: WeakRef<HTMLElement>;
 
   constructor(
@@ -37,12 +37,13 @@ export class QuickInputService extends Store<State> {
   ) {
     super();
     this.lastFocused = new WeakRef(document.createElement('div'));
-    this.quickCommandPicker = new pickers.QuickCommandPicker(launcher);
+    this.quickCommandPicker = new pickers.QuickCommandPicker(this, launcher);
     this.setState({
       inputValue: '',
     });
 
     const sshLoginPicker = new pickers.QuickSshLoginPicker(
+      this,
       workspacesService,
       clustersService
     );
@@ -86,11 +87,52 @@ export class QuickInputService extends Store<State> {
     });
   };
 
+  // Parses the input string and returns AutocompleteResult which includes information about which
+  // token we currently show the autocomplete for and what are the autocomplete suggestions (items)
+  // to show.
+  //
   // TODO(ravicious): This function needs to take cursor index into account instead of assuming that
   // you want to complete only what's at the end of the input string.
   getAutocompleteResult(input: string): AutocompleteResult {
-    return this.quickCommandPicker.getAutocompleteResult(input);
+    const autocompleteResult =
+      this.quickCommandPicker.getAutocompleteResult(input);
+
+    // Don't show suggestions if the only suggestion completely matches the target token.
+    if (autocompleteResult.kind === 'autocomplete.partial-match') {
+      const { targetToken, suggestions } = autocompleteResult;
+      const hasSingleCompleteMatch =
+        suggestions.length === 1 && suggestions[0].token === targetToken.value;
+
+      if (hasSingleCompleteMatch) {
+        return {
+          kind: 'autocomplete.no-match',
+        };
+      }
+    }
+
+    return autocompleteResult;
   }
+
+  // Replaces the token that is being autocompleted with the token from the suggestion.
+  // `tsh ssh roo` becomes `tsh ssh root`
+  //
+  // However, we also preserve anything after the token so that in the future we might effortlessly
+  // support cursor index. So `tsh ssh roo --cluster=bar` becomes `tsh ssh root --cluster=bar`.
+  pickSuggestion(targetToken: AutocompleteToken, suggestion: Suggestion) {
+    const { inputValue } = this.state;
+    const newInputValue =
+      inputValue.substring(0, targetToken.startIndex) +
+      suggestion.token +
+      inputValue.substring(targetToken.startIndex + targetToken.value.length);
+
+    this.setState({
+      inputValue: newInputValue,
+    });
+  }
+
+  getInputValue = () => {
+    return this.state.inputValue;
+  };
 
   setInputValue = (value: string) => {
     this.setState({

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -112,6 +112,7 @@ export class QuickInputService extends Store<State> {
       if (isEmpty || hasSingleCompleteMatch) {
         return {
           kind: 'autocomplete.no-match',
+          command: autocompleteResult.command,
         };
       }
     }

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -97,13 +97,16 @@ export class QuickInputService extends Store<State> {
     const autocompleteResult =
       this.quickCommandPicker.getAutocompleteResult(input);
 
-    // Don't show suggestions if the only suggestion completely matches the target token.
+    // Automatically handle some universal edge cases so that each individual picker doesn't have to
+    // care about them.
     if (autocompleteResult.kind === 'autocomplete.partial-match') {
       const { targetToken, suggestions } = autocompleteResult;
+      const isEmpty = suggestions.length === 0;
+      // Don't show suggestions if the only suggestion completely matches the target token.
       const hasSingleCompleteMatch =
         suggestions.length === 1 && suggestions[0].token === targetToken.value;
 
-      if (hasSingleCompleteMatch) {
+      if (isEmpty || hasSingleCompleteMatch) {
         return {
           kind: 'autocomplete.no-match',
         };

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -27,10 +27,10 @@ type State = {
 };
 
 export class QuickInputService extends Store<State> {
-  quickCmdPicker: pickers.QuickCmdPicker;
   quickLoginPicker: pickers.QuickLoginPicker;
   quickDbPicker: pickers.QuickDbPicker;
   quickServerPicker: pickers.QuickServerPicker;
+  quickCommandPicker: pickers.QuickCommandPicker;
   lastFocused: WeakRef<HTMLElement>;
 
   constructor(launcher: CommandLauncher, serviceClusters: ClustersService) {
@@ -41,13 +41,13 @@ export class QuickInputService extends Store<State> {
       launcher,
       serviceClusters
     );
-    this.quickCmdPicker = new pickers.QuickCmdPicker(launcher);
     this.quickLoginPicker = new pickers.QuickLoginPicker(
       launcher,
       serviceClusters
     );
+    this.quickCommandPicker = new pickers.QuickCommandPicker();
     this.setState({
-      picker: this.quickCmdPicker,
+      picker: this.quickCommandPicker,
       inputValue: '',
     });
   }
@@ -59,9 +59,9 @@ export class QuickInputService extends Store<State> {
   };
 
   goBack = () => {
-    if (this.state.picker !== this.quickCmdPicker) {
+    if (this.state.picker !== this.quickCommandPicker) {
       this.setState({
-        picker: this.quickCmdPicker,
+        picker: this.quickCommandPicker,
         inputValue: '',
       });
       return;
@@ -78,7 +78,7 @@ export class QuickInputService extends Store<State> {
 
   show = () => {
     this.setState({
-      picker: this.quickCmdPicker,
+      picker: this.quickCommandPicker,
       visible: true,
     });
   };

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -171,6 +171,13 @@ export class QuickInputService extends Store<State> {
     });
   };
 
+  clearInputValueAndHide = () => {
+    this.setState({
+      inputValue: '',
+      visible: false,
+    });
+  };
+
   useState() {
     return useStore<QuickInputService>(this).state;
   }

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -27,9 +27,6 @@ type State = {
 };
 
 export class QuickInputService extends Store<State> {
-  quickLoginPicker: pickers.QuickLoginPicker;
-  quickDbPicker: pickers.QuickDbPicker;
-  quickServerPicker: pickers.QuickServerPicker;
   quickCommandPicker: pickers.QuickCommandPicker;
   lastFocused: WeakRef<HTMLElement>;
 
@@ -40,15 +37,6 @@ export class QuickInputService extends Store<State> {
   ) {
     super();
     this.lastFocused = new WeakRef(document.createElement('div'));
-    this.quickDbPicker = new pickers.QuickDbPicker(launcher, clustersService);
-    this.quickServerPicker = new pickers.QuickServerPicker(
-      launcher,
-      clustersService
-    );
-    this.quickLoginPicker = new pickers.QuickLoginPicker(
-      launcher,
-      clustersService
-    );
     this.quickCommandPicker = new pickers.QuickCommandPicker(launcher);
     this.setState({
       inputValue: '',

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -132,8 +132,28 @@ export class QuickInputService extends Store<State> {
       insertedToken +
       inputValue.substring(targetToken.startIndex + targetToken.value.length);
 
+    // Keep the autocomplete visible if something was appended to the token. If nothing was appended
+    // to the token then we know that we don't have any further suggestions to show.
+    //
+    // Consider these situations:
+    //
+    // 1. You type "tsh s" and choose "tsh ssh" from suggestions. The input becomes "tsh ssh " and
+    // you see the autocomplete for the SSH login.
+    //
+    // 2. You type "tsh ssh roo" and choose "root" from suggestions. The input becomes "tsh ssh
+    // root@" and you see the autocomplete for the SSH host.
+    //
+    // 3. You type "tsh ssh root@foo" and choose "foobar" from suggestions. The input becomes "tsh
+    // ssh root@foobar". You don't see any further suggestions.
+    //
+    // In situation 3, it's crucial that we hide the autocomplete, as there might be other servers
+    // that match "foobar", but the user already made a conscious choice of picking a specific
+    // server.
+    const shouldRemainVisible = !!suggestion.appendToToken;
+
     this.setState({
       inputValue: newInputValue,
+      visible: shouldRemainVisible,
     });
   }
 
@@ -144,6 +164,9 @@ export class QuickInputService extends Store<State> {
   setInputValue = (value: string) => {
     this.setState({
       inputValue: value,
+      // Changing the input through the UI should always make the autocomplete box visible in case
+      // there are any suggestions.
+      visible: true,
     });
   };
 

--- a/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
@@ -236,7 +236,9 @@ export class QuickSshLoginPicker implements QuickInputPicker {
     return matchingLogins.map(login => ({
       kind: 'suggestion.ssh-login' as const,
       token: login,
-      data: null,
+      // This allows the user to immediately begin typing the hostname.
+      appendToToken: '@',
+      data: login,
     }));
   }
 

--- a/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
@@ -69,9 +69,9 @@ export class QuickCommandPicker implements QuickInputPicker {
     const matchingAutocompleteCommands = this.launcher
       .getAutocompleteCommands()
       .filter(cmd => {
-        const completeMatchRegex = new RegExp(`^${cmd.displayName}\\b`);
+        const completeMatchRegex = new RegExp(`^${cmd.displayName}\\b`, 'i');
         return (
-          cmd.displayName.startsWith(input) ||
+          cmd.displayName.startsWith(input.toLowerCase()) ||
           // `completeMatchRegex` handles situations where the `input` akin to "tsh ssh foo".
           // In that case, "tsh ssh" is the matching command, even though
           // `cmd.displayName` ("tsh ssh") doesn't start with `input` ("tsh ssh foo").
@@ -99,7 +99,7 @@ export class QuickCommandPicker implements QuickInputPicker {
     // Handles a complete match, for example the input is `tsh ssh`.
     const soleMatch = matchingAutocompleteCommands[0];
     const commandToken = soleMatch.displayName;
-    const completeMatchRegex = new RegExp(`^${commandToken}\\b`);
+    const completeMatchRegex = new RegExp(`^${commandToken}\\b`, 'i');
     const isCompleteMatch = completeMatchRegex.test(input);
 
     if (isCompleteMatch) {
@@ -213,12 +213,11 @@ export class QuickTshProxyDbPicker implements QuickInputPicker {
 
 export class QuickSshLoginPicker implements QuickInputPicker {
   constructor(
-    private quickInputService: QuickInputService,
     private workspacesService: WorkspacesService,
     private clustersService: ClustersService
   ) {}
 
-  filterSshLogins(input: string): SuggestionSshLogin[] {
+  private filterSshLogins(input: string): SuggestionSshLogin[] {
     // TODO(ravicious): Use local cluster URI.
     // TODO(ravicious): Handle the `--cluster` tsh ssh flag.
     const rootClusterUri = this.workspacesService.getRootClusterUri();
@@ -229,7 +228,9 @@ export class QuickSshLoginPicker implements QuickInputPicker {
     if (!input) {
       matchingLogins = allLogins;
     } else {
-      matchingLogins = allLogins.filter(login => login.startsWith(input));
+      matchingLogins = allLogins.filter(login =>
+        login.startsWith(input.toLowerCase())
+      );
     }
 
     return matchingLogins.map(login => ({

--- a/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
@@ -60,6 +60,7 @@ export class QuickCommandPicker implements QuickInputPicker {
       return {
         kind: 'autocomplete.partial-match',
         targetToken,
+        command: { kind: 'command.unknown' },
         suggestions:
           this.mapAutocompleteCommandsToSuggestions(autocompleteCommands),
       };
@@ -79,13 +80,17 @@ export class QuickCommandPicker implements QuickInputPicker {
       });
 
     if (matchingAutocompleteCommands.length === 0) {
-      return { kind: 'autocomplete.no-match' };
+      return {
+        kind: 'autocomplete.no-match',
+        command: { kind: 'command.unknown' },
+      };
     }
 
     if (matchingAutocompleteCommands.length > 1) {
       return {
         kind: 'autocomplete.partial-match',
         targetToken,
+        command: { kind: 'command.unknown' },
         suggestions: this.mapAutocompleteCommandsToSuggestions(
           matchingAutocompleteCommands
         ),
@@ -119,6 +124,7 @@ export class QuickCommandPicker implements QuickInputPicker {
     return {
       kind: 'autocomplete.partial-match',
       targetToken,
+      command: { kind: 'command.unknown' },
       suggestions: this.mapAutocompleteCommandsToSuggestions(
         matchingAutocompleteCommands
       ),
@@ -186,31 +192,50 @@ export class QuickTshSshPicker implements QuickInputPicker {
 
     // Show autocomplete only after at least one space after `tsh ssh`.
     if (rawInput !== '' && input === '') {
-      return this.sshLoginPicker.getAutocompleteResult('', startIndex);
+      const command = {
+        kind: 'command.tsh-ssh' as const,
+        loginHost: '',
+      };
+      return {
+        ...this.sshLoginPicker.getAutocompleteResult('', startIndex),
+        command,
+      };
     }
 
     const hostMatch = input.match(this.totalSshLoginAndHostRegex);
 
     if (hostMatch) {
+      const command = {
+        kind: 'command.tsh-ssh' as const,
+        loginHost: hostMatch[0],
+      };
       const hostStartIndex = startIndex + hostMatch.groups.loginPart.length;
 
-      return this.serverPicker.getAutocompleteResult(
-        hostMatch.groups.hostPart,
-        hostStartIndex
-      );
+      return {
+        ...this.serverPicker.getAutocompleteResult(
+          hostMatch.groups.hostPart,
+          hostStartIndex
+        ),
+        command,
+      };
     }
 
     const loginMatch = input.match(this.totalSshLoginRegex);
 
     if (loginMatch) {
-      return this.sshLoginPicker.getAutocompleteResult(
-        loginMatch[0],
-        startIndex
-      );
+      const command = {
+        kind: 'command.tsh-ssh' as const,
+        loginHost: loginMatch[0],
+      };
+      return {
+        ...this.sshLoginPicker.getAutocompleteResult(loginMatch[0], startIndex),
+        command,
+      };
     }
 
     return {
       kind: 'autocomplete.no-match',
+      command: { kind: 'command.tsh-ssh', loginHost: '' },
     };
   }
 }
@@ -231,6 +256,7 @@ export class QuickTshProxyDbPicker implements QuickInputPicker {
   getAutocompleteResult(input: string): AutocompleteResult {
     return {
       kind: 'autocomplete.no-match',
+      command: { kind: 'command.unknown' },
     };
   }
 }
@@ -273,6 +299,7 @@ export class QuickSshLoginPicker implements QuickInputPicker {
     return {
       kind: 'autocomplete.partial-match',
       suggestions,
+      command: { kind: 'command.unknown' },
       targetToken: {
         startIndex,
         value: input,
@@ -309,6 +336,7 @@ export class QuickServerPicker implements QuickInputPicker {
     return {
       kind: 'autocomplete.partial-match',
       suggestions,
+      command: { kind: 'command.unknown' },
       targetToken: {
         startIndex,
         value: input,

--- a/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
@@ -133,6 +133,8 @@ export class QuickCommandPicker implements QuickInputPicker {
     return commands.map(cmd => ({
       kind: 'suggestion.cmd' as const,
       token: cmd.displayName,
+      // This allows us to immediately show autocomplete for the first argument of the command.
+      appendToToken: ' ',
       data: cmd,
     }));
   }

--- a/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
@@ -52,7 +52,7 @@ export abstract class ClusterPicker implements QuickInputPicker {
         };
       });
 
-    return ensureEmptyPlaceholder(items);
+    return items;
   }
 
   protected searchServers(value: string): Item[] {
@@ -67,7 +67,7 @@ export abstract class ClusterPicker implements QuickInputPicker {
         });
       }
     }
-    return ensureEmptyPlaceholder(items);
+    return items;
   }
 
   protected searchDbs(value: string): Item[] {
@@ -82,7 +82,7 @@ export abstract class ClusterPicker implements QuickInputPicker {
         });
       }
     }
-    return ensureEmptyPlaceholder(items);
+    return items;
   }
 }
 
@@ -337,12 +337,4 @@ export class QuickSshLoginPicker implements QuickInputPicker {
       listItems,
     };
   }
-}
-
-function ensureEmptyPlaceholder(items: Item[]): Item[] {
-  if (items.length === 0) {
-    items.push({ kind: 'item.empty', data: { message: 'not found' } });
-  }
-
-  return items;
 }

--- a/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
@@ -42,9 +42,7 @@ export class QuickCommandPicker implements QuickInputPicker {
 
   // TODO(ravicious): Handle env vars.
   // TODO(ravicious): Take cursor position into account.
-  onPick(suggestion: SuggestionCmd) {
-    this.quickInputService.setInputValue(suggestion.token);
-  }
+  onPick(suggestion: SuggestionCmd) {}
 
   // TODO(ravicious): Handle env vars.
   getAutocompleteResult(rawInput: string): AutocompleteResult {

--- a/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickPickers.ts
@@ -132,35 +132,12 @@ export class QuickServerPicker extends ClusterPicker {
   }
 }
 
-export class QuickCmdPicker implements QuickInputPicker {
-  launcher: CommandLauncher;
-
-  constructor(launcher: CommandLauncher) {
-    this.launcher = launcher;
+export class QuickCommandPicker implements QuickInputPicker {
+  onFilter() {
+    return [];
   }
 
-  onFilter(value = '') {
-    const items = this.launcher
-      .getPaletteCommands()
-      .filter(cmd => {
-        return [cmd.description, cmd.displayName]
-          .join('')
-          .toLocaleLowerCase()
-          .includes(value);
-      })
-      .map(cmd => {
-        return {
-          kind: 'item.cmd' as const,
-          data: cmd,
-        };
-      });
-
-    return ensureEmptyPlaceholder(items);
-  }
-
-  onPick(item: ItemCmd) {
-    this.launcher.executeCommand(item.data.name as any, null);
-  }
+  onPick() {}
 }
 
 function ensureEmptyPlaceholder(items: Item[]): Item[] {

--- a/packages/teleterm/src/ui/services/quickInput/types.ts
+++ b/packages/teleterm/src/ui/services/quickInput/types.ts
@@ -1,6 +1,7 @@
 type SuggestionBase<T, R> = {
   kind: T;
   token: string;
+  appendToToken?: string;
   data: R;
 };
 
@@ -9,7 +10,10 @@ export type SuggestionCmd = SuggestionBase<
   { name: string; displayName: string; description: string }
 >;
 
-export type SuggestionSshLogin = SuggestionBase<'suggestion.ssh-login', null>;
+export type SuggestionSshLogin = SuggestionBase<
+  'suggestion.ssh-login',
+  string
+> & { appendToToken: string };
 
 export type QuickInputPicker = {
   onPick(suggestion: Suggestion): void;

--- a/packages/teleterm/src/ui/services/quickInput/types.ts
+++ b/packages/teleterm/src/ui/services/quickInput/types.ts
@@ -31,16 +31,35 @@ export type AutocompleteToken = {
   startIndex: number;
 };
 
-type AutocompleteBase<T> = {
+type AutocompleteResultBase<T> = {
   kind: T;
+  // Command includes the result of parsing whatever was parsed so far.
+  // This means that in case of `tsh ssh roo`, the command will say that we want to launch `tsh ssh`
+  // with `roo` as `loginHost`.
+  command: AutocompleteCommand;
 };
 
 export type AutocompletePartialMatch =
-  AutocompleteBase<'autocomplete.partial-match'> & {
+  AutocompleteResultBase<'autocomplete.partial-match'> & {
     suggestions: Suggestion[];
     targetToken: AutocompleteToken;
   };
 
-export type AutocompleteNoMatch = AutocompleteBase<'autocomplete.no-match'>;
+export type AutocompleteNoMatch =
+  AutocompleteResultBase<'autocomplete.no-match'>;
 
 export type AutocompleteResult = AutocompletePartialMatch | AutocompleteNoMatch;
+
+type CommandBase<T> = {
+  kind: T;
+};
+
+export type AutocompleteUnknownCommand = CommandBase<'command.unknown'>;
+
+export type AutocompleteTshSshCommand = CommandBase<'command.tsh-ssh'> & {
+  loginHost: string;
+};
+
+export type AutocompleteCommand =
+  | AutocompleteUnknownCommand
+  | AutocompleteTshSshCommand;

--- a/packages/teleterm/src/ui/services/quickInput/types.ts
+++ b/packages/teleterm/src/ui/services/quickInput/types.ts
@@ -23,9 +23,11 @@ export type ItemNewCluster = Base<
   { displayName: string; uri?: string; description: string }
 >;
 
+export type ItemSshLogin = Base<'item.ssh-login', string>;
+
 export type QuickInputPicker = {
-  onFilter(value: string): Item[];
   onPick(item: Item): void;
+  getAutocompleteResult(input: string): AutocompleteResult;
 };
 
 export type Item =
@@ -34,4 +36,17 @@ export type Item =
   | ItemDb
   | ItemCluster
   | ItemCmd
+  | ItemSshLogin
   | ItemEmpty;
+
+type AutocompleteBase<T> = {
+  kind: T;
+  picker: QuickInputPicker;
+};
+
+export type AutocompletePartialMatch =
+  AutocompleteBase<'autocomplete.partial-match'> & { listItems: Item[] };
+
+export type AutocompleteNoMatch = AutocompleteBase<'autocomplete.no-match'>;
+
+export type AutocompleteResult = AutocompletePartialMatch | AutocompleteNoMatch;

--- a/packages/teleterm/src/ui/services/quickInput/types.ts
+++ b/packages/teleterm/src/ui/services/quickInput/types.ts
@@ -1,3 +1,5 @@
+import { tsh } from 'teleterm/ui/services/clusters/types';
+
 type SuggestionBase<T, R> = {
   kind: T;
   token: string;
@@ -15,12 +17,14 @@ export type SuggestionSshLogin = SuggestionBase<
   string
 > & { appendToToken: string };
 
+export type SuggestionServer = SuggestionBase<'suggestion.server', tsh.Server>;
+
+export type Suggestion = SuggestionCmd | SuggestionSshLogin | SuggestionServer;
+
 export type QuickInputPicker = {
   onPick(suggestion: Suggestion): void;
   getAutocompleteResult(input: string, startIndex: number): AutocompleteResult;
 };
-
-export type Suggestion = SuggestionCmd | SuggestionSshLogin;
 
 export type AutocompleteToken = {
   value: string;

--- a/packages/teleterm/src/ui/services/quickInput/types.ts
+++ b/packages/teleterm/src/ui/services/quickInput/types.ts
@@ -1,40 +1,24 @@
 import { tsh } from 'teleterm/ui/services/clusters/types';
 
-type Base<T, R> = {
+type SuggestionBase<T, R> = {
   kind: T;
+  token: string;
   data: R;
 };
 
-export type ItemCluster = Base<'item.cluster', tsh.Cluster>;
-
-export type ItemServer = Base<'item.server', tsh.Server>;
-
-export type ItemDb = Base<'item.db', tsh.Database>;
-
-export type ItemCmd = Base<
-  'item.cmd',
+export type SuggestionCmd = SuggestionBase<
+  'suggestion.cmd',
   { name: string; displayName: string; description: string }
 >;
 
-export type ItemNewCluster = Base<
-  'item.cluster-new',
-  { displayName: string; uri?: string; description: string }
->;
-
-export type ItemSshLogin = Base<'item.ssh-login', string>;
+export type SuggestionSshLogin = SuggestionBase<'suggestion.ssh-login', null>;
 
 export type QuickInputPicker = {
-  onPick(item: Item): void;
+  onPick(suggestion: Suggestion): void;
   getAutocompleteResult(input: string): AutocompleteResult;
 };
 
-export type Item =
-  | ItemNewCluster
-  | ItemServer
-  | ItemDb
-  | ItemCluster
-  | ItemCmd
-  | ItemSshLogin;
+export type Suggestion = SuggestionCmd | SuggestionSshLogin;
 
 type AutocompleteBase<T> = {
   kind: T;
@@ -42,7 +26,9 @@ type AutocompleteBase<T> = {
 };
 
 export type AutocompletePartialMatch =
-  AutocompleteBase<'autocomplete.partial-match'> & { listItems: Item[] };
+  AutocompleteBase<'autocomplete.partial-match'> & {
+    suggestions: Suggestion[];
+  };
 
 export type AutocompleteNoMatch = AutocompleteBase<'autocomplete.no-match'>;
 

--- a/packages/teleterm/src/ui/services/quickInput/types.ts
+++ b/packages/teleterm/src/ui/services/quickInput/types.ts
@@ -1,5 +1,3 @@
-import { tsh } from 'teleterm/ui/services/clusters/types';
-
 type SuggestionBase<T, R> = {
   kind: T;
   token: string;
@@ -15,19 +13,24 @@ export type SuggestionSshLogin = SuggestionBase<'suggestion.ssh-login', null>;
 
 export type QuickInputPicker = {
   onPick(suggestion: Suggestion): void;
-  getAutocompleteResult(input: string): AutocompleteResult;
+  getAutocompleteResult(input: string, startIndex: number): AutocompleteResult;
 };
 
 export type Suggestion = SuggestionCmd | SuggestionSshLogin;
 
+export type AutocompleteToken = {
+  value: string;
+  startIndex: number;
+};
+
 type AutocompleteBase<T> = {
   kind: T;
-  picker: QuickInputPicker;
 };
 
 export type AutocompletePartialMatch =
   AutocompleteBase<'autocomplete.partial-match'> & {
     suggestions: Suggestion[];
+    targetToken: AutocompleteToken;
   };
 
 export type AutocompleteNoMatch = AutocompleteBase<'autocomplete.no-match'>;

--- a/packages/teleterm/src/ui/services/quickInput/types.ts
+++ b/packages/teleterm/src/ui/services/quickInput/types.ts
@@ -5,8 +5,6 @@ type Base<T, R> = {
   data: R;
 };
 
-export type ItemEmpty = Base<'item.empty', { message: string }>;
-
 export type ItemCluster = Base<'item.cluster', tsh.Cluster>;
 
 export type ItemServer = Base<'item.server', tsh.Server>;
@@ -36,8 +34,7 @@ export type Item =
   | ItemDb
   | ItemCluster
   | ItemCmd
-  | ItemSshLogin
-  | ItemEmpty;
+  | ItemSshLogin;
 
 type AutocompleteBase<T> = {
   kind: T;

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -105,20 +105,20 @@ export class DocumentsService {
   openNewTerminal(initCommand?: string) {
     const doc = ((): Document => {
       const activeDocument = this.getActive();
-      switch (activeDocument.kind) {
-        case 'doc.terminal_shell':
-          return {
-            ...activeDocument,
-            uri: routing.getDocUri({ docId: unique() }),
-            initCommand,
-          };
-        default:
-          return {
-            uri: routing.getDocUri({ docId: unique() }),
-            initCommand,
-            title: 'Terminal',
-            kind: 'doc.terminal_shell',
-          };
+
+      if (activeDocument && activeDocument.kind == 'doc.terminal_shell') {
+        return {
+          ...activeDocument,
+          uri: routing.getDocUri({ docId: unique() }),
+          initCommand,
+        };
+      } else {
+        return {
+          uri: routing.getDocUri({ docId: unique() }),
+          initCommand,
+          title: 'Terminal',
+          kind: 'doc.terminal_shell',
+        };
       }
     })();
 

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -31,7 +31,7 @@ export class DocumentsService {
     private getState: () => { documents: Document[]; location: string },
     private setState: (
       draftState: (draft: { documents: Document[]; location: string }) => void
-    ) => void,
+    ) => void
   ) {}
 
   open(docUri: string) {
@@ -102,7 +102,7 @@ export class DocumentsService {
     };
   }
 
-  openNewTerminal() {
+  openNewTerminal(initCommand?: string) {
     const doc = ((): Document => {
       const activeDocument = this.getActive();
       switch (activeDocument.kind) {
@@ -110,10 +110,12 @@ export class DocumentsService {
           return {
             ...activeDocument,
             uri: routing.getDocUri({ docId: unique() }),
+            initCommand,
           };
         default:
           return {
             uri: routing.getDocUri({ docId: unique() }),
+            initCommand,
             title: 'Terminal',
             kind: 'doc.terminal_shell',
           };

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -39,7 +39,7 @@ export interface DocumentTshNode extends DocumentBase {
   serverUri: string;
   rootClusterId: string;
   leafClusterId?: string;
-  login: string;
+  login?: string;
 }
 
 export interface DocumentTshKube extends DocumentBase {

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -67,6 +67,7 @@ export interface DocumentCluster extends DocumentBase {
 export interface DocumentPtySession extends DocumentBase {
   kind: 'doc.terminal_shell';
   cwd?: string;
+  initCommand?: string;
 }
 
 export type DocumentTerminal =

--- a/packages/teleterm/src/ui/uri.ts
+++ b/packages/teleterm/src/ui/uri.ts
@@ -36,6 +36,12 @@ export const routing = {
     return leafMatch || rootMatch;
   },
 
+  // Pass either a root or a leaf cluster URI to get back a root cluster URI.
+  ensureRootClusterUri(uri: string) {
+    const { rootClusterId } = routing.parseClusterUri(uri).params;
+    return routing.getClusterUri({ rootClusterId });
+  },
+
   parseKubeUri(uri: string) {
     return routing.parseUri(uri, paths.kube);
   },
@@ -79,6 +85,10 @@ export const routing = {
     }
 
     return generatePath(paths.rootCluster, params as any);
+  },
+
+  getServerUri(params: Params) {
+    return generatePath(paths.server, params as any);
   },
 
   isClusterServer(clusterUri: string, serverUri: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2624,12 +2624,20 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@*", "@types/jest@^27.0.3":
+"@types/jest@*":
   version "27.0.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.3.tgz#0cf9dfe9009e467f70a342f0f94ead19842a783a"
   integrity sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==
   dependencies:
     jest-diff "^27.0.0"
+    pretty-format "^27.0.0"
+
+"@types/jest@^27.3.1":
+  version "27.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
+  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
+  dependencies:
+    jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
 "@types/jsdom@^16.2.4":
@@ -5650,6 +5658,11 @@ diff-sequences@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
   integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
+
+diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -8688,6 +8701,16 @@ jest-diff@^27.4.1:
     jest-get-type "^27.4.0"
     pretty-format "^27.4.1"
 
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
+
 jest-docblock@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.4.0.tgz#06c78035ca93cbbb84faf8fce64deae79a59f69f"
@@ -8742,6 +8765,11 @@ jest-get-type@^27.4.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5"
   integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
 
+jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
+
 jest-haste-map@^27.4.1:
   version "27.4.1"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.4.1.tgz#70a5ec4a5d5f965c8637f32bc623e9d48f8bb23e"
@@ -8793,6 +8821,16 @@ jest-leak-detector@^27.4.1:
   dependencies:
     jest-get-type "^27.4.0"
     pretty-format "^27.4.1"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-matcher-utils@^27.4.1:
   version "27.4.1"
@@ -11006,6 +11044,15 @@ pretty-format@^27.4.1:
   integrity sha512-JJw4GzG0vP5dHA+D84zryrX3S34B6rZaJj6zsrN/sdNpcUNf1X6aH/7sPSqwtAGNXCxDqMa1wAKX4EH1Tv62aw==
   dependencies:
     "@jest/types" "^27.4.1"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"


### PR DESCRIPTION
# Todo

* [x] Implement picking the suggestions.
* [x] Implement hostname autocomplete for `tsh ssh`.
* [x] Implement launching the commands.
* [ ] Support `--cluster` arg in `tsh ssh` autocomplete.
* [x] Add tests.
* [ ] Remove behavior related to `goBack`.
* [x] Make sure regexes for SSH logins and hosts cover valid characters.
* [ ] Use local cluster URI for SSH login/node autocomplete.
* [ ] Implement autocomplete for `tsh proxy db`.

Possibly for later (not this PR)

* Take cursor index into account.
* Handle env vars before the command.
   * `FOO=bar tsh ssh` should still offer autocomplete work.
   * Perhaps this can be done when we implement a more sophisticated solution.

---

This PR so far implements only showing the suggestions in the UI, not actually picking them. This is what I'm going to work on next.

The biggest change compared to the previous command palette is that it was essentially a multi-stage UI which kept track of the "progress" through `picker` in `QuickInputService` state.

With autocomplete, the only state we need to keep track of is the input value. So I rewrote QuickInputService so that on each input change it just parses the whole input and then returns 

* autocomplete suggestions
* what picker to use
   * This will be important once I actually get to implementing picking the suggestions.

For autocomplete, this feels like a natural approach and this model will allow us to write a more sophisticated version in the next release.

Due to how everything was designed, I was able to reuse lots of code responsible for UI. `QuickInputService` and `quickPickers` are the two things that changed the most.

Best reviewed commit-by-commit.