### PR TITLE
Support the 'unknown' audit event

### DIFF
--- a/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -116,6 +116,7 @@ const EventIconMap: Record<EventCode, React.FC> = {
   [eventCodes.X11_FORWARD]: Icons.Info,
   [eventCodes.X11_FORWARD_FAILURE]: Icons.Info,
   [eventCodes.CERTIFICATE_CREATED]: Icons.Keypair,
+  [eventCodes.UNKNOWN]: Icons.Question,
 };
 
 export default function renderTypeCell(event: Event, clusterId: string) {

--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -3756,12 +3756,12 @@ exports[`loaded audit log screen 1`] = `
           </strong>
            - 
           <strong>
-            4
+            5
           </strong>
            of
            
           <strong>
-            4
+            5
           </strong>
         </div>
       </div>
@@ -3884,6 +3884,43 @@ exports[`loaded audit log screen 1`] = `
           style="min-width: 120px;"
         >
           2020-06-05 16:24:05
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c17"
+            kind="border"
+            width="87px"
+          >
+            Details
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style="vertical-align: inherit;"
+        >
+          <div
+            class="c15"
+          >
+            <span
+              class="c11 c16 icon icon-question-circle c11 c16"
+              color="light"
+              font-size="3"
+            />
+            Unknown Event
+          </div>
+        </td>
+        <td
+          style="word-break: break-word;"
+        >
+          Unknown 'unimplemented.event' event (abc123)
+        </td>
+        <td
+          style="min-width: 120px;"
+        >
+          2019-04-22 19:39:26
         </td>
         <td
           align="right"

--- a/packages/teleport/src/Audit/fixtures/index.ts
+++ b/packages/teleport/src/Audit/fixtures/index.ts
@@ -1063,4 +1063,12 @@ export const eventsSample = [
     return_code: 0,
     time: '2019-04-22T19:39:26.676Z',
   },
+  {
+    code: 'TCC00E',
+    event: 'unknown',
+    unknown_type: 'unimplemented.event',
+    unknown_code: 'abc123',
+    data: '{"some": "json"}',
+    time: '2019-04-22T19:39:26.676Z'
+  },
 ].map(makeEvent);

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -451,19 +451,19 @@ export const formatters: Formatters = {
   [eventCodes.MYSQL_STATEMENT_CLOSE]: {
     type: 'db.session.mysql.statements.close',
     desc: 'MySQL Statement Close',
-    format: ({ user, db_service, db_name, statement_id}) =>
+    format: ({ user, db_service, db_name, statement_id }) =>
       `User [${user}] has closed statement [${statement_id}] in database [${db_name}] on [${db_service}]`,
   },
   [eventCodes.MYSQL_STATEMENT_RESET]: {
     type: 'db.session.mysql.statements.reset',
     desc: 'MySQL Statement Reset',
-    format: ({ user, db_service, db_name, statement_id}) =>
+    format: ({ user, db_service, db_name, statement_id }) =>
       `User [${user}] has reset statement [${statement_id}] in database [${db_name}] on [${db_service}]`,
   },
   [eventCodes.MYSQL_STATEMENT_FETCH]: {
     type: 'db.session.mysql.statements.fetch',
     desc: 'MySQL Statement Fetch',
-    format: ({ user, db_service, db_name, rows_count, statement_id}) =>
+    format: ({ user, db_service, db_name, rows_count, statement_id }) =>
       `User [${user}] has fetched ${rows_count} rows of statement [${statement_id}] in database [${db_name}] on [${db_service}]`,
   },
   [eventCodes.MYSQL_STATEMENT_BULK_EXECUTE]: {
@@ -597,6 +597,11 @@ export const formatters: Formatters = {
       }
       return `Certificate of type [${cert_type}] issued for [${user}]`
     }
+  },
+  [eventCodes.UNKNOWN]: {
+    type: 'unknown',
+    desc: 'Unknown Event',
+    format: ({ unknown_type, unknown_code }) => `Unknown '${unknown_type}' event (${unknown_code})`,
   }
 };
 

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -122,6 +122,7 @@ export const eventCodes = {
   TRUSTED_CLUSTER_CREATED: 'T7000I',
   TRUSTED_CLUSTER_DELETED: 'T7001I',
   TRUSTED_CLUSTER_TOKEN_CREATED: 'T7002I',
+  UNKNOWN: 'TCC00E',
   USER_CREATED: 'T1002I',
   USER_DELETED: 'T1004I',
   USER_LOCAL_LOGIN: 'T1000I',
@@ -615,6 +616,14 @@ export type RawEvents = {
       desktop_addr: string;
       length: number;
       windows_domain: string;
+    }
+  >;
+  [eventCodes.UNKNOWN]: RawEvent<
+    typeof eventCodes.UNKNOWN,
+    {
+      unknown_type: string;
+      unknown_code: string;
+      data: string;
     }
   >;
   [eventCodes.X11_FORWARD]: RawEvent<typeof eventCodes.X11_FORWARD>;


### PR DESCRIPTION
This event is emitted as a fallback if we encounter an event that
Teleport does not know how to interpret.

See: gravitational/teleport#10665