### PR TITLE
[v9] Update snapshot

### DIFF
--- a/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
+++ b/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
@@ -1391,7 +1391,7 @@ exports[`unintended disconnect 1`] = `
       class="c12"
       kind="danger"
     >
-      Session disconnected for an unkown reason
+      Session disconnected for an unknown reason
     </div>
     <canvas
       style="display: none; flex: 1;"


### PR DESCRIPTION
It seems we fixed a typo and forgot to update the snapshot, making `yarn test` fail