### PR TITLE
[backport v8] Support the 'unknown' audit event (#656)

### DIFF
--- a/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -102,6 +102,7 @@ const EventIconMap: Record<EventCode, React.FC> = {
   [eventCodes.X11_FORWARD]: Icons.Info,
   [eventCodes.X11_FORWARD_FAILURE]: Icons.Info,
   [eventCodes.CERTIFICATE_CREATED]: Icons.Keypair,
+  [eventCodes.UNKNOWN]: Icons.Question,
 };
 
 export default function TypeCell(props) {

--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -3210,12 +3210,12 @@ exports[`loaded audit log screen 1`] = `
           </strong>
            - 
           <strong>
-            4
+            5
           </strong>
            
           of 
           <strong>
-            4
+            5
           </strong>
         </div>
       </div>
@@ -3335,6 +3335,43 @@ exports[`loaded audit log screen 1`] = `
             style="min-width: 120px;"
           >
             2020-06-05 16:24:05
+          </td>
+          <td
+            align="right"
+          >
+            <button
+              class="c17"
+              kind="border"
+              width="87px"
+            >
+              Details
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td
+            style="vertical-align: inherit;"
+          >
+            <div
+              class="c15"
+            >
+              <span
+                class="c11 c16 icon icon-question-circle c11 c16"
+                color="light"
+                font-size="3"
+              />
+              Unknown Event
+            </div>
+          </td>
+          <td
+            style="word-break: break-word;"
+          >
+            Unknown 'unimplemented.event' event (abc123)
+          </td>
+          <td
+            style="min-width: 120px;"
+          >
+            2019-04-22 19:39:26
           </td>
           <td
             align="right"

--- a/packages/teleport/src/Audit/fixtures/index.ts
+++ b/packages/teleport/src/Audit/fixtures/index.ts
@@ -849,4 +849,12 @@ export const eventsSample = [
     return_code: 0,
     time: '2019-04-22T19:39:26.676Z',
   },
+  {
+    code: 'TCC00E',
+    event: 'unknown',
+    unknown_type: 'unimplemented.event',
+    unknown_code: 'abc123',
+    data: '{"some": "json"}',
+    time: '2019-04-22T19:39:26.676Z'
+  },
 ].map(makeEvent);

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -39,8 +39,7 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_REQUEST_DELETED]: {
     type: 'access_request.delete',
     desc: 'Access Request Deleted',
-    format: ({ id }) =>
-      `Access request [${id}] has been deleted`,
+    format: ({ id }) => `Access request [${id}] has been deleted`,
   },
   [eventCodes.SESSION_COMMAND]: {
     type: 'session.command',
@@ -495,15 +494,21 @@ export const formatters: Formatters = {
     format: ({ server_addr }) => `Session connected to [${server_addr}]`,
   },
   [eventCodes.CERTIFICATE_CREATED]: {
-    type: "cert.create",
-    desc: "Certificate Issued",
+    type: 'cert.create',
+    desc: 'Certificate Issued',
     format: ({ cert_type, identity: { user } }) => {
       if (cert_type === 'user') {
-        return `User certificate issued for [${user}]`
+        return `User certificate issued for [${user}]`;
       }
-      return `Certificate of type [${cert_type}] issued for [${user}]`
-    }
-  }
+      return `Certificate of type [${cert_type}] issued for [${user}]`;
+    },
+  },
+  [eventCodes.UNKNOWN]: {
+    type: 'unknown',
+    desc: 'Unknown Event',
+    format: ({ unknown_type, unknown_code }) =>
+      `Unknown '${unknown_type}' event (${unknown_code})`,
+  },
 };
 
 const unknownFormatter = {

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -108,6 +108,7 @@ export const eventCodes = {
   TRUSTED_CLUSTER_CREATED: 'T7000I',
   TRUSTED_CLUSTER_DELETED: 'T7001I',
   TRUSTED_CLUSTER_TOKEN_CREATED: 'T7002I',
+  UNKNOWN: 'TCC00E',
   USER_CREATED: 'T1002I',
   USER_DELETED: 'T1004I',
   USER_LOCAL_LOGIN: 'T1000I',
@@ -483,6 +484,14 @@ export type RawEvents = {
       desktop_addr: string;
       windows_user: string;
       windows_domain: string;
+    }
+  >;
+  [eventCodes.UNKNOWN]: RawEvent<
+    typeof eventCodes.UNKNOWN,
+    {
+      unknown_type: string;
+      unknown_code: string;
+      data: string;
     }
   >;
   [eventCodes.X11_FORWARD]: RawEvent<typeof eventCodes.X11_FORWARD>;


### PR DESCRIPTION
Backport #656 to teleport-v8