### PR TITLE
Fix failing test in useAddNode.test in v8

### DIFF
--- a/packages/teleport/src/Nodes/AddNode/useAddNode.test.ts
+++ b/packages/teleport/src/Nodes/AddNode/useAddNode.test.ts
@@ -6,7 +6,7 @@ describe('correct node bash command', () => {
 
   test.each`
     token            | hours  | expires      | cmd
-    ${'some-token'}  | ${1.1} | ${'1 hour'}  | ${'sudo bash -c "$(curl -fsSL http://localhost/scripts/some-token/install-node.sh)"'}
+    ${'some-token'}  | ${1.1} | ${'an hour'} | ${'sudo bash -c "$(curl -fsSL http://localhost/scripts/some-token/install-node.sh)"'}
     ${'other-token'} | ${2.1} | ${'2 hours'} | ${'sudo bash -c "$(curl -fsSL http://localhost/scripts/other-token/install-node.sh)"'}
     ${'some-token'}  | ${25}  | ${'a day'}   | ${'sudo bash -c "$(curl -fsSL http://localhost/scripts/some-token/install-node.sh)"'}
   `(


### PR DESCRIPTION
The test got backported from master that used new date-fns library.
But in v8, we are using moment, which resulted in a slightly diff
test result.