### PR TITLE
Add clusters picker

### DIFF
--- a/packages/teleterm/src/services/config/providers/keyboardShortcutsConfigProvider.ts
+++ b/packages/teleterm/src/services/config/providers/keyboardShortcutsConfigProvider.ts
@@ -21,7 +21,8 @@ export type KeyboardShortcutType =
   | 'tab-previous'
   | 'tab-next'
   | 'focus-global-search'
-  | 'toggle-connections';
+  | 'toggle-connections'
+  | 'toggle-clusters';
 
 export type KeyboardShortcutsConfig = Record<KeyboardShortcutType, string>;
 
@@ -43,7 +44,8 @@ export const keyboardShortcutsConfigProvider: ConfigServiceProvider<KeyboardShor
         'tab-previous': 'Control-Shift-Tab',
         'tab-next': 'Control-Tab',
         'focus-global-search': 'F1',
-        'toggle-connections': 'Command-O'
+        'toggle-connections': 'Command-O',
+        'toggle-clusters': 'Command-E',
       };
 
       const linuxShortcuts: KeyboardShortcutsConfig = {
@@ -61,7 +63,8 @@ export const keyboardShortcutsConfigProvider: ConfigServiceProvider<KeyboardShor
         'tab-previous': 'Ctrl-PageUp',
         'tab-next': 'Ctrl-PageDown',
         'focus-global-search': 'F1',
-        'toggle-connections': 'Ctrl-O'
+        'toggle-connections': 'Ctrl-O',
+        'toggle-clusters': 'Ctrl-E',
       };
 
       switch (platform) {

--- a/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -80,7 +80,7 @@ function getTestSetup({ documents }: { documents: Document[] }) {
       return {
         documents,
         location: undefined,
-        localClusterUri: undefined,
+        localClusterUri: 'test_uri',
       };
     },
     // @ts-expect-error - using mocks

--- a/packages/teleterm/src/ui/TabHost/TabHost.tsx
+++ b/packages/teleterm/src/ui/TabHost/TabHost.tsx
@@ -22,6 +22,7 @@ import * as types from 'teleterm/ui/services/workspacesService/documentsService/
 import { Tabs } from 'teleterm/ui/Tabs';
 import { useTabShortcuts } from './useTabShortcuts';
 import { DocumentsRenderer } from 'teleterm/ui/Documents';
+import { useNewTabOpener } from './useNewTabOpener';
 
 export function TabHostContainer() {
   const ctx = useAppContext();
@@ -42,6 +43,7 @@ export function TabHost() {
   const documentsService =
     ctx.workspacesService.getActiveWorkspaceDocumentService();
   const activeDocument = documentsService.getActive();
+  const { openClusterTab } = useNewTabOpener();
   ctx.workspacesService.useState();
 
   // enable keyboard shortcuts
@@ -57,12 +59,6 @@ export function TabHost() {
 
   function handleTabMoved(oldIndex: number, newIndex: number) {
     documentsService.swapPosition(oldIndex, newIndex);
-  }
-
-  function handleTabNew() {
-    const doc = documentsService.createClusterDocument();
-    documentsService.add(doc);
-    documentsService.open(doc.uri);
   }
 
   function handleTabContextMenu(doc: types.Document) {
@@ -101,7 +97,7 @@ export function TabHost() {
           activeTab={activeDocument?.uri}
           onMoved={handleTabMoved}
           disableNew={false}
-          onNew={handleTabNew}
+          onNew={openClusterTab}
         />
       </Flex>
       <DocumentsRenderer />

--- a/packages/teleterm/src/ui/TabHost/useNewTabOpener.ts
+++ b/packages/teleterm/src/ui/TabHost/useNewTabOpener.ts
@@ -1,0 +1,25 @@
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { useCallback } from 'react';
+
+export function useNewTabOpener() {
+  const ctx = useAppContext();
+
+  const documentsService =
+    ctx.workspacesService.getActiveWorkspaceDocumentService();
+
+  const localClusterUri =
+    ctx.workspacesService.getActiveWorkspace()?.localClusterUri;
+
+  const openClusterTab = useCallback(() => {
+    if (localClusterUri) {
+      const clusterDocument = documentsService.createClusterDocument({
+        clusterUri: localClusterUri,
+      });
+
+      documentsService.add(clusterDocument);
+      documentsService.open(clusterDocument.uri);
+    }
+  }, [documentsService, localClusterUri]);
+
+  return { openClusterTab };
+}

--- a/packages/teleterm/src/ui/TabHost/useTabShortcuts.ts
+++ b/packages/teleterm/src/ui/TabHost/useTabShortcuts.ts
@@ -21,20 +21,23 @@ import {
 } from 'teleterm/ui/services/keyboardShortcuts';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { DocumentsService } from 'teleterm/ui/services/workspacesService';
+import { useNewTabOpener } from 'teleterm/ui/TabHost/useNewTabOpener';
 
 export function useTabShortcuts() {
   const { workspacesService } = useAppContext();
   workspacesService.useState();
   const documentService = workspacesService.getActiveWorkspaceDocumentService();
+  const { openClusterTab } = useNewTabOpener();
   const tabsShortcuts = useMemo(
-    () => buildTabsShortcuts(documentService),
+    () => buildTabsShortcuts(documentService, openClusterTab),
     [documentService]
   );
   useKeyboardShortcuts(tabsShortcuts);
 }
 
 function buildTabsShortcuts(
-  documentService: DocumentsService
+  documentService: DocumentsService,
+  openClusterTab: () => void
 ): KeyboardShortcutHandlers {
   const handleTabIndex = (index: number) => () => {
     const docs = documentService.getDocuments();
@@ -46,12 +49,6 @@ function buildTabsShortcuts(
   const handleActiveTabClose = () => {
     const { uri } = documentService.getActive();
     documentService.close(uri);
-  };
-
-  const handleNewTabOpen = () => {
-    const doc = documentService.createClusterDocument();
-    documentService.add(doc);
-    documentService.open(doc.uri);
   };
 
   const handleTabSwitch = (direction: 'previous' | 'next') => () => {
@@ -79,6 +76,6 @@ function buildTabsShortcuts(
     'tab-close': handleActiveTabClose,
     'tab-previous': handleTabSwitch('previous'),
     'tab-next': handleTabSwitch('next'),
-    'tab-new': handleNewTabOpen,
+    'tab-new': openClusterTab,
   };
 }

--- a/packages/teleterm/src/ui/TabHost/useTabSortcuts.test.tsx
+++ b/packages/teleterm/src/ui/TabHost/useTabSortcuts.test.tsx
@@ -105,6 +105,13 @@ function getTestSetup({ documents }: { documents: Document[] }) {
     getActiveWorkspaceDocumentService() {
       return docsService;
     },
+    getActiveWorkspace() {
+      return {
+        localClusterUri: 'test_uri',
+        documents: [],
+        location: ''
+      }
+    },
     useState: jest.fn(),
     state: {
       workspaces: {},

--- a/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
+++ b/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import { SortAsc, SortDesc } from 'design/Icon';
 import styled from 'styled-components';
-import { Box, Text } from 'design';
+import { Text } from 'design';
 
 interface ClusterSelectorProps {
   clusterName?: string;
@@ -13,24 +13,26 @@ interface ClusterSelectorProps {
 export const ClusterSelector = forwardRef<HTMLDivElement, ClusterSelectorProps>(
   (props, ref) => {
     const SortIcon = props.isOpened ? SortAsc : SortDesc;
-    const text = props.clusterName || 'Select Resource';
+    const text = props.clusterName || 'Select Cluster';
     return (
-      <StyledButton
+      <Container
         ref={ref}
         onClick={props.onClick}
         isOpened={props.isOpened}
         isClusterSelected={!!props.clusterName}
-        m="auto"
         title={text}
       >
         <Text css={{ whiteSpace: 'nowrap' }}>{text}</Text>
         <SortIcon fontSize={12} ml={3} />
-      </StyledButton>
+      </Container>
     );
   }
 );
 
-const StyledButton = styled(Box)`
+const Container = styled.button`
+  background: inherit;
+  color: inherit;
+  font-family: inherit;
   width: 100%;
   height: 40px;
   border: 0.5px ${props => props.theme.colors.action.disabledBackground} solid;

--- a/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
+++ b/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
@@ -1,0 +1,60 @@
+import React, { forwardRef } from 'react';
+import { SortAsc, SortDesc } from 'design/Icon';
+import styled from 'styled-components';
+import { Box, Text } from 'design';
+
+interface ClusterSelectorProps {
+  clusterName?: string;
+  isOpened: boolean;
+
+  onClick(): void;
+}
+
+export const ClusterSelector = forwardRef<HTMLDivElement, ClusterSelectorProps>(
+  (props, ref) => {
+    const SortIcon = props.isOpened ? SortAsc : SortDesc;
+    const text = props.clusterName || 'Select Resource';
+    return (
+      <StyledButton
+        ref={ref}
+        onClick={props.onClick}
+        isOpened={props.isOpened}
+        isClusterSelected={!!props.clusterName}
+        m="auto"
+        title={text}
+      >
+        <Text css={{ whiteSpace: 'nowrap' }}>{text}</Text>
+        <SortIcon fontSize={12} ml={3} />
+      </StyledButton>
+    );
+  }
+);
+
+const StyledButton = styled(Box)`
+  width: 100%;
+  height: 40px;
+  border: 0.5px ${props => props.theme.colors.action.disabledBackground} solid;
+  border-radius: 4px;
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 12px;
+  opacity: ${props => props.isClusterSelected ? 1 : 0.6};
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+    border-color: ${props => props.theme.colors.light};
+  }
+
+  ${props => {
+    if (props.isOpened) {
+      return {
+        borderColor: props.theme.colors.secondary.main,
+        opacity: 1,
+      };
+    }
+  }}
+`;

--- a/packages/teleterm/src/ui/TopBar/Clusters/Clusters.tsx
+++ b/packages/teleterm/src/ui/TopBar/Clusters/Clusters.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import Popover from 'design/Popover';
+import styled from 'styled-components';
+import { Box } from 'design';
+import { useClusters } from './useClusters';
+import { ClusterSelector } from './ClusterSelector/ClusterSelector';
+import { ClustersFilterableList } from './ClustersFilterableList/ClustersFilterableList';
+import { useKeyboardShortcuts } from 'teleterm/ui/services/keyboardShortcuts';
+import { KeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
+
+export function Clusters() {
+  const iconRef = useRef();
+  const [isPopoverOpened, setIsPopoverOpened] = useState(false);
+  const clusters = useClusters();
+
+  const togglePopover = useCallback(() => {
+    setIsPopoverOpened(wasOpened => !wasOpened);
+  }, [setIsPopoverOpened]);
+
+  useKeyboardShortcuts(
+    useMemo(
+      () => ({
+        'toggle-clusters': togglePopover,
+      }),
+      [togglePopover]
+    )
+  );
+
+  function selectItem(id: string): void {
+    setIsPopoverOpened(false);
+    clusters.selectItem(id);
+  }
+
+  return (
+    <>
+      <ClusterSelector
+        clusterName={clusters.selectedItem?.name}
+        onClick={togglePopover}
+        isOpened={isPopoverOpened}
+        ref={iconRef}
+      />
+      <Popover
+        open={isPopoverOpened}
+        anchorEl={iconRef.current}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        onClose={() => setIsPopoverOpened(false)}
+      >
+        <Container p="12px">
+          <KeyboardArrowsNavigation>
+            <ClustersFilterableList
+              items={clusters.items}
+              onSelectItem={selectItem}
+              selectedItem={clusters.selectedItem}
+            />
+          </KeyboardArrowsNavigation>
+        </Container>
+      </Popover>
+    </>
+  );
+}
+
+const Container = styled(Box)`
+  background: ${props => props.theme.colors.primary.dark};
+`;

--- a/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClusterItem.tsx
+++ b/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClusterItem.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Flex, Label, Text } from 'design';
+import { CircleCheck } from 'design/Icon';
+import { ListItem } from 'teleterm/ui/components/ListItem';
+import { useKeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
+import { Cluster } from 'teleterm/services/tshd/types';
+import styled from 'styled-components';
+
+interface ClusterItemProps {
+  index: number;
+  item: Cluster;
+  isSelected: boolean;
+
+  onSelect(): void;
+}
+
+export function ClusterItem(props: ClusterItemProps) {
+  const { isActive } = useKeyboardArrowsNavigation({
+    index: props.index,
+    onRun: props.onSelect,
+  });
+
+  const LabelVersion = props.isSelected ? InvertedLabel : Label;
+
+  return (
+    <StyledListItem
+      onClick={props.onSelect}
+      isActive={isActive}
+      isSelected={props.isSelected}
+      isLeaf={props.item.leaf}
+    >
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        flex="1"
+        width="100%"
+        minWidth="0"
+      >
+        <Text typography="body1" title={props.item.name}>
+          {props.item.name}
+        </Text>
+        {!props.item.leaf ? (
+          <LabelVersion ml={1} kind="primary">
+            root
+          </LabelVersion>
+        ) : null}
+        {props.isSelected ? <CircleCheck fontSize={12} /> : null}
+      </Flex>
+    </StyledListItem>
+  );
+}
+
+const StyledListItem = styled(ListItem)`
+  padding-left: ${props => (props.isLeaf ? '32px' : null)};
+  background: ${getBackgroundColor};
+
+  &:hover,
+  &:focus {
+    background: ${getHoverBackgroundColor};
+  }
+`;
+
+const InvertedLabel = styled(Label)`
+  color: ${props => props.theme.colors.secondary.main};
+  background-color: ${props => props.theme.colors.secondary.contrastText};
+`;
+
+function getBackgroundColor(props) {
+  if (props.isSelected) {
+    if (props.isActive) {
+      return props.theme.colors.secondary.light;
+    }
+    return props.theme.colors.secondary.main;
+  }
+  if (props.isActive) {
+    return 'rgba(255, 255, 255, 0.05)';
+  }
+}
+
+function getHoverBackgroundColor(props) {
+  if (props.isSelected) {
+    return props.theme.colors.secondary.light;
+  }
+  if (props.isActive) {
+    return 'rgba(255, 255, 255, 0.05)';
+  }
+}

--- a/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClustersFilterableList.tsx
+++ b/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClustersFilterableList.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { FilterableList } from 'teleterm/ui/components/FilterableList';
+import { ClusterItem } from './ClusterItem';
+import { Box } from 'design';
+import { useKeyboardArrowsNavigationStateUpdate } from 'teleterm/ui/components/KeyboardArrowsNavigation';
+import { Cluster } from 'teleterm/services/tshd/types';
+
+interface ClustersFilterableListProps {
+  items: Cluster[];
+  selectedItem: Cluster;
+
+  onSelectItem(clusterUri: string): void;
+}
+
+export function ClustersFilterableList(props: ClustersFilterableListProps) {
+  const { setActiveIndex } = useKeyboardArrowsNavigationStateUpdate();
+  return (
+    <Box width="260px">
+      <FilterableList<Cluster>
+        items={props.items}
+        filterBy="name"
+        onFilterChange={value =>
+          value.length ? setActiveIndex(0) : setActiveIndex(-1)
+        }
+        placeholder="Search Leaf Cluster"
+        Node={({ item, index }) => (
+          <ClusterItem
+            item={item}
+            index={index}
+            onSelect={() => props.onSelectItem(item.uri)}
+            isSelected={props.selectedItem === item}
+          />
+        )}
+      />
+    </Box>
+  );
+}

--- a/packages/teleterm/src/ui/TopBar/Clusters/index.ts
+++ b/packages/teleterm/src/ui/TopBar/Clusters/index.ts
@@ -1,0 +1,1 @@
+export { Clusters } from './Clusters';

--- a/packages/teleterm/src/ui/TopBar/Clusters/useClusters.ts
+++ b/packages/teleterm/src/ui/TopBar/Clusters/useClusters.ts
@@ -1,0 +1,39 @@
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+
+export function useClusters() {
+  const { workspacesService, clustersService, commandLauncher } =
+    useAppContext();
+
+  workspacesService.useState();
+  clustersService.useState();
+
+  function findLeaves(clusterUri: string) {
+    return clustersService
+      .getClusters()
+      .filter(c => c.leaf && c.uri.startsWith(clusterUri));
+  }
+
+  const rootClusterUri = workspacesService.getRootClusterUri();
+  const localClusterUri =
+    workspacesService.getActiveWorkspace()?.localClusterUri;
+
+  return {
+    selectedItem:
+      localClusterUri && clustersService.findCluster(localClusterUri),
+    selectItem: (localClusterUri: string) => {
+      workspacesService.setWorkspaceLocalClusterUri(
+        rootClusterUri,
+        localClusterUri
+      );
+      commandLauncher.executeCommand('cluster-open', {
+        clusterUri: localClusterUri,
+      });
+    },
+    items: rootClusterUri
+      ? [
+          clustersService.findCluster(rootClusterUri),
+          ...findLeaves(rootClusterUri),
+        ]
+      : [],
+  };
+}

--- a/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
+++ b/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
@@ -6,6 +6,7 @@ import { useConnections } from './useConnections';
 import { ConnectionsIcon } from './ConnectionsIcon/ConnectionsIcon';
 import { ConnectionsFilterableList } from './ConnectionsFilterableList/ConnectionsFilterableList';
 import { useKeyboardShortcuts } from 'teleterm/ui/services/keyboardShortcuts';
+import { KeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
 
 export function Connections() {
   const iconRef = useRef();
@@ -44,12 +45,14 @@ export function Connections() {
         onClose={() => setIsPopoverOpened(false)}
       >
         <Container p="12px">
-          <ConnectionsFilterableList
-            items={connections.items}
-            onActivateItem={activateItem}
-            onRemoveItem={connections.removeItem}
-            onDisconnectItem={connections.disconnectItem}
-          />
+          <KeyboardArrowsNavigation>
+            <ConnectionsFilterableList
+              items={connections.items}
+              onActivateItem={activateItem}
+              onRemoveItem={connections.removeItem}
+              onDisconnectItem={connections.disconnectItem}
+            />
+          </KeyboardArrowsNavigation>
         </Container>
       </Popover>
     </>

--- a/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -22,7 +22,7 @@ export function ConnectionItem(props: ConnectionItemProps) {
   const color = !offline ? 'text.primary' : 'text.placeholder';
   const { isActive } = useKeyboardArrowsNavigation({
     index: props.index,
-    onRunActiveItem: props.onActivate,
+    onRun: props.onActivate,
   });
 
   const actionIcons = {

--- a/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionsFilterableList.tsx
+++ b/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionsFilterableList.tsx
@@ -3,7 +3,7 @@ import { FilterableList } from 'teleterm/ui/components/FilterableList';
 import { TrackedConnection } from 'teleterm/ui/services/connectionTracker';
 import { ConnectionItem } from './ConnectionItem';
 import { Box } from 'design';
-import { KeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
+import { useKeyboardArrowsNavigationStateUpdate } from 'teleterm/ui/components/KeyboardArrowsNavigation';
 
 interface ConnectionsFilterableListProps {
   items: TrackedConnection[];
@@ -18,24 +18,27 @@ interface ConnectionsFilterableListProps {
 export function ConnectionsFilterableList(
   props: ConnectionsFilterableListProps
 ) {
+  const { setActiveIndex } = useKeyboardArrowsNavigationStateUpdate();
+
   return (
     <Box width="200px">
-      <KeyboardArrowsNavigation>
-        <FilterableList<TrackedConnection>
-          items={props.items}
-          filterBy="title"
-          placeholder="Search Connections"
-          Node={({ item, index }) => (
-            <ConnectionItem
-              item={item}
-              index={index}
-              onActivate={() => props.onActivateItem(item.id)}
-              onRemove={() => props.onRemoveItem(item.id)}
-              onDisconnect={() => props.onDisconnectItem(item.id)}
-            />
-          )}
-        />
-      </KeyboardArrowsNavigation>
+      <FilterableList<TrackedConnection>
+        items={props.items}
+        filterBy="title"
+        placeholder="Search Connections"
+        onFilterChange={value =>
+          value.length ? setActiveIndex(0) : setActiveIndex(-1)
+        }
+        Node={({ item, index }) => (
+          <ConnectionItem
+            item={item}
+            index={index}
+            onActivate={() => props.onActivateItem(item.id)}
+            onRemove={() => props.onRemoveItem(item.id)}
+            onDisconnect={() => props.onDisconnectItem(item.id)}
+          />
+        )}
+      />
     </Box>
   );
 }

--- a/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -2,21 +2,32 @@ import React from 'react';
 import { Flex } from 'design';
 import QuickInput from '../QuickInput';
 import { Connections } from './Connections';
+import { Clusters } from './Clusters';
 import { Identity } from './Identity';
+import styled from 'styled-components';
 
 export function TopBar() {
   return (
     <Flex
       justifyContent="space-between"
       p="0 25px"
-      height="50px"
+      height="56px"
       alignItems="center"
     >
       <Connections />
-      <Flex m="0 10px" justifyContent="space-between" alignItems="center">
+      <CentralContainer>
+        <Clusters />
         <QuickInput />
-      </Flex>
+      </CentralContainer>
       <Identity />
     </Flex>
   );
 }
+
+const CentralContainer = styled.div`
+  display: grid;
+  column-gap: 10px;
+  margin: auto 10px;
+  grid-template-columns: minmax(150px, 280px) auto;
+  align-items: center;
+`

--- a/packages/teleterm/src/ui/commandLauncher.ts
+++ b/packages/teleterm/src/ui/commandLauncher.ts
@@ -108,7 +108,7 @@ const commands = {
       if (doc) {
         documentsService.open(doc.uri);
       } else {
-        const newDoc = documentsService.createClusterDocument();
+        const newDoc = documentsService.createClusterDocument({ clusterUri });
         documentsService.add(newDoc);
         documentsService.open(newDoc.uri);
       }

--- a/packages/teleterm/src/ui/components/FilterableList/FilterableList.tsx
+++ b/packages/teleterm/src/ui/components/FilterableList/FilterableList.tsx
@@ -8,6 +8,8 @@ interface FilterableListProps<T> {
   placeholder?: string;
 
   Node(props: { item: T; index: number }): ReactNode;
+
+  onFilterChange?(filter: string): void;
 }
 
 const maxItemsToShow = 10;
@@ -26,7 +28,11 @@ export function FilterableList<T>(props: FilterableListProps<T>) {
     <>
       <DarkInput
         role="searchbox"
-        onChange={e => setSearchValue(e.target.value)}
+        onChange={e => {
+          const { value } = e.target;
+          props.onFilterChange?.(value);
+          setSearchValue(value);
+        }}
         placeholder={props.placeholder}
         autoFocus={true}
       />

--- a/packages/teleterm/src/ui/components/KeyboardArrowsNavigation/useKeyboardArrowsNavigation.ts
+++ b/packages/teleterm/src/ui/components/KeyboardArrowsNavigation/useKeyboardArrowsNavigation.ts
@@ -1,21 +1,21 @@
-import React, { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import {
   KeyboardArrowsNavigationContext,
   RunActiveItemHandler,
 } from './KeyboardArrowsNavigation';
 
 /**
- * onRunActiveItem must be memoized
+ * onRun must be memoized
  */
 
 export function useKeyboardArrowsNavigation({
   index,
-  onRunActiveItem,
+  onRun,
 }: {
   index: number;
-  onRunActiveItem: RunActiveItemHandler;
+  onRun: RunActiveItemHandler;
 }) {
-  const navigationContext = React.useContext(KeyboardArrowsNavigationContext);
+  const navigationContext = useContext(KeyboardArrowsNavigationContext);
 
   if (!navigationContext) {
     throw new Error(
@@ -24,12 +24,18 @@ export function useKeyboardArrowsNavigation({
   }
 
   useEffect(() => {
-    navigationContext.addItem(index, onRunActiveItem);
+    navigationContext.addItem(index, onRun);
 
     return () => navigationContext.removeItem(index);
-  }, [index, onRunActiveItem]);
+  }, [index, onRun, navigationContext.addItem, navigationContext.removeItem]);
 
   return {
     isActive: index === navigationContext.activeIndex,
   };
+}
+
+export function useKeyboardArrowsNavigationStateUpdate() {
+  const { setActiveIndex } = useContext(KeyboardArrowsNavigationContext);
+
+  return { setActiveIndex };
 }

--- a/packages/teleterm/src/ui/components/ListItem.tsx
+++ b/packages/teleterm/src/ui/components/ListItem.tsx
@@ -14,20 +14,17 @@ export const ListItem = styled.li`
   font-weight: ${props => props.theme.regular};
   font-family: ${props => props.theme.font};
   color: ${props => props.theme.colors.text.primary};
-  height: 36px;
+  height: 34px;
   background: inherit;
   border: none;
   border-radius: 4px;
 
   background: ${props =>
-    props.isActive ? props.theme.colors.primary.light : null};
-
-  &:hover {
-    background: ${props => props.theme.colors.primary.light};
-  }
+          props.isActive ? 'rgba(255, 255, 255, 0.05)' : null};
 
   &:focus,
   &:hover {
+    background: rgba(255, 255, 255, 0.05);
     color: ${props => props.theme.colors.primary.contrastText};
   }
 `;

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.test.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.test.ts
@@ -18,8 +18,7 @@ function createService(mockDocks: Document[]): DocumentsService {
   store.state = { documents: [], location: undefined };
   const service = new DocumentsService(
     () => store.state,
-    draftState => store.setState(draftState),
-    'test_uri'
+    draftState => store.setState(draftState)
   );
   mockDocks.forEach(d => service.add(d));
 

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -16,14 +16,15 @@ limitations under the License.
 
 import { unique } from 'teleterm/ui/utils/uid';
 import {
-  DocumentTshKube,
-  Document,
-  DocumentGateway,
-  DocumentTshNode,
+  CreateClusterDocumentOpts,
   CreateGatewayDocumentOpts,
+  Document,
   DocumentCluster,
+  DocumentGateway,
+  DocumentTshKube,
+  DocumentTshNode,
 } from './types';
-import { routing, paths } from 'teleterm/ui/uri';
+import { paths, routing } from 'teleterm/ui/uri';
 
 export class DocumentsService {
   constructor(
@@ -31,7 +32,6 @@ export class DocumentsService {
     private setState: (
       draftState: (draft: { documents: Document[]; location: string }) => void
     ) => void,
-    private clusterUri: string
   ) {}
 
   open(docUri: string) {
@@ -46,12 +46,12 @@ export class DocumentsService {
     this.setLocation(docUri);
   }
 
-  createClusterDocument(): DocumentCluster {
+  createClusterDocument(opts: CreateClusterDocumentOpts): DocumentCluster {
     const uri = routing.getDocUri({ docId: unique() });
-    const clusterName = routing.parseClusterName(this.clusterUri);
+    const clusterName = routing.parseClusterName(opts.clusterUri);
     return {
       uri,
-      clusterUri: this.clusterUri,
+      clusterUri: opts.clusterUri,
       title: clusterName,
       kind: 'doc.cluster',
     };

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -87,3 +87,7 @@ export type CreateGatewayDocumentOpts = {
   title: string;
   port?: string;
 };
+
+export type CreateClusterDocumentOpts = {
+  clusterUri: string;
+};

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -34,6 +34,10 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     super();
   }
 
+  getActiveWorkspace(): Workspace | undefined {
+    return this.state.workspaces[this.state.rootClusterUri];
+  }
+
   getRootClusterUri(): string | undefined {
     return this.state.rootClusterUri;
   }
@@ -59,6 +63,15 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     }));
   }
 
+  setWorkspaceLocalClusterUri(
+    clusterUri: string,
+    localClusterUri: string
+  ): void {
+    this.setState(draftState => {
+      draftState.workspaces[clusterUri].localClusterUri = localClusterUri;
+    });
+  }
+
   getWorkspaceDocumentService(
     clusterUri: string
   ): DocumentsService | undefined {
@@ -72,8 +85,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
           newState =>
             this.setState(draftState => {
               newState(draftState.workspaces[clusterUri]);
-            }),
-          clusterUri
+            })
         )
       );
     }
@@ -97,7 +109,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
           const persistedWorkspace =
             this.statePersistenceService.getWorkspaces().workspaces[clusterUri];
           draftState.workspaces[clusterUri] = {
-            localClusterUri: persistedWorkspace?.localClusterUri,
+            localClusterUri: persistedWorkspace?.localClusterUri || clusterUri,
             location: persistedWorkspace?.location,
             documents: persistedWorkspace?.documents || [],
           };


### PR DESCRIPTION
A few notes:
1. I had to change `KeyboardArrowsNavigation` behaviour a bit: by default none of the items should be selected (`activeIndex: -1`) and when user starts searching then the first item should be selected (`activeIndex: 0`). I was wondering if we don't want to use `KeyboardArrowsNavigation` inside of `FilterableList`, but finally I decided not to do it and add a callback to `FilterableList` to have more flexibility (any thoughts about it?).
2. I reverted the change with providing `clusterUri` to the `DocumentService` (it was used only by `createClusterDocument()`). That document has to be created not only for root, but also for leaf clusters. 
3. I extracted logic for creating a new tab to the `useNewTabOpener` hook.