### PR TITLE
Enable `babel-plugin-styled-components` in production and tests

### DIFF
--- a/packages/build/.babelrc.js
+++ b/packages/build/.babelrc.js
@@ -42,10 +42,13 @@ module.exports = {
     development: {
       plugins: [
         ...plugins,
-        'babel-plugin-styled-components',
+        ['babel-plugin-styled-components', { displayName: true, ssr: false }],
       ],
     },
   },
   presets: makePresents(),
-  plugins,
+  plugins: [
+    ...plugins,
+    ['babel-plugin-styled-components', { displayName: false, ssr: false }],
+  ],
 };


### PR DESCRIPTION
Since this plugin was only enabled in the development, [css prop](https://styled-components.com/docs/api#css-prop) worked locally but didn't work in the bundled app.

The plugin also improves bundle size a bit (`2.36 MiB` vs `2.38 MiB` previously).

