### PR TITLE
Limit navigation capabilities to reduce attack surface

### DIFF
--- a/packages/teleterm/src/main.ts
+++ b/packages/teleterm/src/main.ts
@@ -47,6 +47,34 @@ app.whenReady().then(() => {
   mainProcess.createWindow();
 });
 
+// Limit navigation capabilities to reduce the attack surface.
+// See TEL-Q122-19 from "Teleport Core Testing Q1 2022" security audit.
+//
+// See also points 12, 13 and 14 from the Electron's security tutorial.
+// https://github.com/electron/electron/blob/v17.2.0/docs/tutorial/security.md#12-verify-webview-options-before-creation
+app.on('web-contents-created', (_, contents) => {
+  contents.on('will-navigate', (event, navigationUrl) => {
+    logger.warn(`Navigation to ${navigationUrl} blocked by 'will-navigate'`);
+    event.preventDefault();
+  });
+
+  // The usage of webview is blocked by default, but let's include the handler just in case.
+  // https://github.com/electron/electron/blob/v17.2.0/docs/api/webview-tag.md#enabling
+  contents.on('will-attach-webview', (event, _, params) => {
+    logger.warn(
+      `Opening a webview to ${params.src} blocked by 'will-attach-webview'`
+    );
+    event.preventDefault();
+  });
+
+  contents.setWindowOpenHandler(({ url }) => {
+    logger.warn(
+      `Opening a new window to ${url} blocked by 'setWindowOpenHandler'`
+    );
+    return { action: 'deny' };
+  });
+});
+
 function initMainLogger(settings: types.RuntimeSettings) {
   const service = createLoggerService({
     dev: settings.dev,


### PR DESCRIPTION
This takes care of TEL-Q122-19 from the recent security audit.

At the moment we don't create new windows nor navigate away from the rendered app, so we can just block everything. Obviously when adding support for multiple windows we'll have to change that and use Node's URL parser, preferably.

To test this, I made it so that the table with servers renders a regular link next to each hostname. Shift + click tries to open the link in a new window.

Testing the `<webview>` tag required adding `webviewTag: true` to `webPreferences` of the `BrowserWindow`.

https://github.com/gravitational/webapps/blob/f8cfdf3839e9efa7faf9067e57c0442baab360c9/packages/teleterm/src/mainProcess/mainProcess.ts#L55-L59