### PR TITLE
Improve error handling

### DIFF
--- a/packages/teleterm/src/ui/App.tsx
+++ b/packages/teleterm/src/ui/App.tsx
@@ -9,6 +9,7 @@ import AppContext from './appContext';
 import ThemeProvider from './ThemeProvider';
 import { LayoutManager } from './LayoutManager';
 import { AppInitializer } from 'teleterm/ui/AppInitializer';
+import { NotificationsHost } from 'teleterm/ui/components/Notifcations';
 
 const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
   const { appearance } = ctx.mainProcessClient.configService.get();
@@ -21,6 +22,7 @@ const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
               <AppInitializer>
                 <LayoutManager />
                 <ModalsHost />
+                <NotificationsHost />
               </AppInitializer>
             </ThemeProvider>
           </AppContextProvider>

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Applications/Applications.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Applications/Applications.tsx
@@ -33,6 +33,7 @@ import Table, { Cell } from 'design/DataTable';
 import * as types from 'teleterm/ui/services/clusters/types';
 import { useApps, State } from './useApps';
 import { renderLabelCell } from '../renderLabelCell';
+import { Danger } from 'design/Alert';
 
 export default function Container() {
   const state = useApps();
@@ -40,45 +41,50 @@ export default function Container() {
 }
 
 export function AppList(props: State) {
-  const { apps = [] } = props;
+  const { apps = [], syncStatus } = props;
 
   return (
-    <StyledTable
-      data={apps}
-      columns={[
-        {
-          altKey: 'app-icon',
-          render: renderAppIcon,
-        },
-        {
-          key: 'name',
-          headerText: 'Name',
-          isSortable: true,
-        },
-        {
-          key: 'description',
-          headerText: 'Description',
-          isSortable: true,
-        },
-        {
-          key: 'publicAddr',
-          headerText: 'Address',
-          render: renderAddress,
-          isSortable: true,
-        },
-        {
-          key: 'labelsList',
-          headerText: 'Labels',
-          render: renderLabelCell,
-        },
-        {
-          altKey: 'launch-btn',
-          render: renderConnectButton,
-        },
-      ]}
-      emptyText="No Applications Found"
-      pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
-    />
+    <>
+      {syncStatus.status === 'failed' && (
+        <Danger>{syncStatus.statusText}</Danger>
+      )}
+      <StyledTable
+        data={apps}
+        columns={[
+          {
+            altKey: 'app-icon',
+            render: renderAppIcon,
+          },
+          {
+            key: 'name',
+            headerText: 'Name',
+            isSortable: true,
+          },
+          {
+            key: 'description',
+            headerText: 'Description',
+            isSortable: true,
+          },
+          {
+            key: 'publicAddr',
+            headerText: 'Address',
+            render: renderAddress,
+            isSortable: true,
+          },
+          {
+            key: 'labelsList',
+            headerText: 'Labels',
+            render: renderLabelCell,
+          },
+          {
+            altKey: 'launch-btn',
+            render: renderConnectButton,
+          },
+        ]}
+        emptyText="No Applications Found"
+        pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
+      />
+    </>
   );
 }
 

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
@@ -19,6 +19,7 @@ import { useDatabases, State } from './useDatabases';
 import { ButtonBorder } from 'design';
 import Table, { Cell } from 'design/DataTable';
 import { renderLabelCell } from '../renderLabelCell';
+import { Danger } from 'design/Alert';
 
 export default function Container() {
   const state = useDatabases();
@@ -27,27 +28,32 @@ export default function Container() {
 
 function DatabaseList(props: State) {
   return (
-    <Table
-      data={props.dbs}
-      columns={[
-        {
-          key: 'name',
-          headerText: 'Name',
-          isSortable: true,
-        },
-        {
-          key: 'labelsList',
-          headerText: 'Labels',
-          render: renderLabelCell,
-        },
-        {
-          altKey: 'connect-btn',
-          render: db => renderConnectButton(db.uri, props.connect),
-        },
-      ]}
-      pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
-      emptyText="No Databases Found"
-    />
+    <>
+      {props.syncStatus.status === 'failed' && (
+        <Danger>{props.syncStatus.statusText}</Danger>
+      )}
+      <Table
+        data={props.dbs}
+        columns={[
+          {
+            key: 'name',
+            headerText: 'Name',
+            isSortable: true,
+          },
+          {
+            key: 'labelsList',
+            headerText: 'Labels',
+            render: renderLabelCell,
+          },
+          {
+            altKey: 'connect-btn',
+            render: db => renderConnectButton(db.uri, props.connect),
+          },
+        ]}
+        pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
+        emptyText="No Databases Found"
+      />
+    </>
   );
 }
 

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
@@ -19,6 +19,7 @@ import { useKubes, State } from './useKubes';
 import Table, { Cell } from 'design/DataTable';
 import { ButtonBorder } from 'design';
 import { renderLabelCell } from '../renderLabelCell';
+import { Danger } from 'design/Alert';
 
 export default function Container() {
   const state = useKubes();
@@ -26,30 +27,35 @@ export default function Container() {
 }
 
 function KubeList(props: State) {
-  const { kubes = [], pageSize = 100, connect } = props;
+  const { kubes = [], pageSize = 100, connect, syncStatus } = props;
 
   return (
-    <Table
-      data={kubes}
-      columns={[
-        {
-          key: 'name',
-          headerText: 'Name',
-          isSortable: true,
-        },
-        {
-          key: 'labelsList',
-          headerText: 'Labels',
-          render: renderLabelCell,
-        },
-        {
-          altKey: 'connect-btn',
-          render: kube => renderConnectButtonCell(kube.uri, connect),
-        },
-      ]}
-      emptyText="No Kubernetes Clusters Found"
-      pagination={{ pageSize, pagerPosition: 'bottom' }}
-    />
+    <>
+      {syncStatus.status === 'failed' && (
+        <Danger>{syncStatus.statusText}</Danger>
+      )}
+      <Table
+        data={kubes}
+        columns={[
+          {
+            key: 'name',
+            headerText: 'Name',
+            isSortable: true,
+          },
+          {
+            key: 'labelsList',
+            headerText: 'Labels',
+            render: renderLabelCell,
+          },
+          {
+            altKey: 'connect-btn',
+            render: kube => renderConnectButtonCell(kube.uri, connect),
+          },
+        ]}
+        emptyText="No Kubernetes Clusters Found"
+        pagination={{ pageSize, pagerPosition: 'bottom' }}
+      />
+    </>
   );
 }
 

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
@@ -21,6 +21,7 @@ import Table, { Cell } from 'design/DataTable';
 import { renderLabelCell } from '../renderLabelCell';
 import MenuSshLogin from 'shared/components/MenuSshLogin';
 import { MenuSshLoginTheme } from './MenuSshLoginTheme';
+import { Danger } from 'design/Alert';
 
 export default function Container() {
   const state = useServers();
@@ -28,39 +29,44 @@ export default function Container() {
 }
 
 function ServerList(props: State) {
-  const { servers = [], getSshLogins, connect } = props;
+  const { servers = [], getSshLogins, connect, syncStatus } = props;
   return (
-    <Table
-      columns={[
-        {
-          key: 'hostname',
-          headerText: 'Hostname',
-          isSortable: true,
-        },
-        {
-          key: 'addr',
-          headerText: 'Address',
-          isSortable: true,
-          render: renderAddressCell,
-        },
-        {
-          key: 'labelsList',
-          headerText: 'Labels',
-          render: renderLabelCell,
-        },
-        {
-          altKey: 'connect-btn',
-          render: server =>
-            renderConnectCell(
-              () => getSshLogins(server.uri),
-              login => connect(server.uri, login)
-            ),
-        },
-      ]}
-      emptyText="No Nodes Found"
-      data={servers}
-      pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
-    />
+    <>
+      {syncStatus.status === 'failed' && (
+        <Danger>{syncStatus.statusText}</Danger>
+      )}
+      <Table
+        columns={[
+          {
+            key: 'hostname',
+            headerText: 'Hostname',
+            isSortable: true,
+          },
+          {
+            key: 'addr',
+            headerText: 'Address',
+            isSortable: true,
+            render: renderAddressCell,
+          },
+          {
+            key: 'labelsList',
+            headerText: 'Labels',
+            render: renderLabelCell,
+          },
+          {
+            altKey: 'connect-btn',
+            render: server =>
+              renderConnectCell(
+                () => getSshLogins(server.uri),
+                login => connect(server.uri, login)
+              ),
+          },
+        ]}
+        emptyText="No Nodes Found"
+        data={servers}
+        pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
+      />
+    </>
   );
 }
 

--- a/packages/teleterm/src/ui/appContext.ts
+++ b/packages/teleterm/src/ui/appContext.ts
@@ -24,10 +24,12 @@ import { StatePersistenceService } from 'teleterm/ui/services/statePersistence';
 import { KeyboardShortcutsService } from 'teleterm/ui/services/keyboardShortcuts';
 import { CommandLauncher } from './commandLauncher';
 import { WorkspacesService } from 'teleterm/ui/services/workspacesService/workspacesService';
+import { NotificationsService } from 'teleterm/ui/services/notifications';
 
 export default class AppContext {
   clustersService: ClustersService;
   modalsService: ModalsService;
+  notificationsService: NotificationsService;
   terminalsService: TerminalsService;
   keyboardShortcutsService: KeyboardShortcutsService;
   quickInputService: QuickInputService;
@@ -43,8 +45,12 @@ export default class AppContext {
     this.statePersistenceService = new StatePersistenceService(
       config.fileStorage
     );
-    this.clustersService = new ClustersService(tshClient);
     this.modalsService = new ModalsService();
+    this.notificationsService = new NotificationsService();
+    this.clustersService = new ClustersService(
+      tshClient,
+      this.notificationsService
+    );
     this.workspacesService = new WorkspacesService(
       this.clustersService,
       this.modalsService,

--- a/packages/teleterm/src/ui/boot.tsx
+++ b/packages/teleterm/src/ui/boot.tsx
@@ -28,7 +28,7 @@ function AppLoader() {
   useEffect(() => {
     run();
   }, []);
-  if (status === 'success') {
+  if (status === 'success' || status === 'error') {
     return <App ctx={appContext} />;
   }
   return <div>Loading</div>;

--- a/packages/teleterm/src/ui/components/Notifcations/Notification.tsx
+++ b/packages/teleterm/src/ui/components/Notifcations/Notification.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useRef, useState } from 'react';
+import styled, { css, useTheme } from 'styled-components';
+import { ButtonIcon, Flex, Text } from 'design';
+import { Close, Info, Warning } from 'design/Icon';
+import { NotificationItem, NotificationItemContent } from './types';
+
+interface NotificationProps {
+  item: NotificationItem;
+
+  onRemove(): void;
+}
+
+const notificationConfig: Record<
+  NotificationItem['severity'],
+  { Icon: React.ElementType; getColor(theme): string; isAutoRemovable: boolean }
+> = {
+  error: {
+    Icon: Warning,
+    getColor: theme => theme.colors.danger,
+    isAutoRemovable: false,
+  },
+  warn: {
+    Icon: Warning,
+    getColor: theme => theme.colors.warning,
+    isAutoRemovable: true,
+  },
+  info: {
+    Icon: Info,
+    getColor: theme => theme.colors.info,
+    isAutoRemovable: true,
+  },
+};
+
+const autoRemoveDurationMs = 5000;
+
+export function Notification(props: NotificationProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const timeoutHandler = useRef<number>();
+  const config = notificationConfig[props.item.severity];
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (!isHovered && config.isAutoRemovable) {
+      timeoutHandler.current = setTimeout(
+        props.onRemove,
+        autoRemoveDurationMs
+      ) as unknown as number;
+    }
+
+    return () => {
+      if (timeoutHandler.current) {
+        clearTimeout(timeoutHandler.current);
+      }
+    };
+  }, [isHovered]);
+
+  function toggleIsExpanded() {
+    setIsExpanded(wasExpanded => !wasExpanded);
+  }
+
+  const removeIcon = (
+    <ButtonIcon
+      size={0}
+      ml={1}
+      mr={-1}
+      style={{ visibility: isHovered ? 'visible' : 'hidden' }}
+    >
+      <Close
+        onClick={e => {
+          e.stopPropagation();
+          props.onRemove();
+        }}
+      />
+    </ButtonIcon>
+  );
+
+  return (
+    <Container
+      py={2}
+      pl={3}
+      pr={2}
+      onMouseOver={() => {
+        if (isHovered === false) {
+          setIsHovered(true);
+        }
+      }}
+      onMouseLeave={() => {
+        if (isHovered === true) {
+          setIsHovered(false);
+        }
+      }}
+      onClick={toggleIsExpanded}
+    >
+      <Flex alignItems="center" mr={1} minWidth="0" width="100%">
+        {config && (
+          <config.Icon color={config.getColor(theme)} mr={3} fontSize={16} />
+        )}
+        {getRenderedContent(props.item.content, isExpanded, removeIcon)}
+      </Flex>
+    </Container>
+  );
+}
+
+function getRenderedContent(
+  content: NotificationItemContent,
+  isExpanded: boolean,
+  removeIcon: React.ReactNode
+) {
+  const longerTextCss = isExpanded ? textCss : shortTextCss;
+
+  if (typeof content === 'string') {
+    return (
+      <Flex justifyContent="space-between">
+        <Text
+          typography="body1"
+          fontSize={13}
+          lineHeight={20}
+          css={longerTextCss}
+        >
+          {content}
+        </Text>
+        {removeIcon}
+      </Flex>
+    );
+  }
+  if (typeof content === 'object') {
+    return (
+      <Flex flexDirection="column" minWidth="0" width="100%">
+        <div
+          css={`
+            position: relative;
+          `}
+        >
+          <Text
+            fontSize={13}
+            bold
+            mr="30px"
+            css={`
+              line-height: 20px;
+            `}
+          >
+            {content.title}
+          </Text>
+          <div
+            css={`
+              position: absolute;
+              top: 0;
+              right: 0;
+            `}
+          >
+            {removeIcon}
+          </div>
+        </div>
+        <Text
+          fontSize={13}
+          title={content.description}
+          lineHeight={20}
+          color="text.secondary"
+          css={longerTextCss}
+        >
+          {content.description}
+        </Text>
+      </Flex>
+    );
+  }
+}
+
+const textCss = css`
+  line-height: 20px;
+  overflow-wrap: break-word;
+`;
+
+const shortTextCss = css`
+  ${textCss};
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+`;
+
+const Container = styled(Flex)`
+  flex-direction: row;
+  justify-content: space-between;
+  background: ${props => props.theme.colors.primary.darker};
+  min-height: 40px;
+  width: 320px;
+  margin-bottom: 15px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.24);
+  color: ${props => props.theme.colors.text.primary};
+  opacity: 0.95;
+  border-radius: 4px;
+
+  &:hover {
+    opacity: 1;
+    cursor: pointer;
+  }
+`;

--- a/packages/teleterm/src/ui/components/Notifcations/Notifications.story.tsx
+++ b/packages/teleterm/src/ui/components/Notifcations/Notifications.story.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { ButtonPrimary, Flex } from 'design';
+import { NotificationItem, Notifications } from '.';
+import { unique } from 'teleterm/ui/utils/uid';
+
+export default {
+  title: 'Teleterm/components/Notifications',
+};
+
+function useNotifications() {
+  const [items, setItems] = useState<NotificationItem[]>([]);
+
+  function removeItem(id: string) {
+    setItems(prevItems => prevItems.filter(item => item.id !== id));
+  }
+
+  return { items, setItems, removeItem };
+}
+
+export const TitleAndDescriptionContent = () => {
+  const { setItems, removeItem, items } = useNotifications();
+
+  function notify(severity: NotificationItem['severity']) {
+    setItems(prevItems => [
+      ...prevItems,
+      {
+        id: unique(),
+        severity,
+        content: {
+          title: 'Notification title',
+          description:
+            "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500.",
+        },
+      },
+    ]);
+  }
+
+  return (
+    <Flex>
+      <ButtonPrimary onClick={() => notify('info')} mr={1}>
+        Info
+      </ButtonPrimary>
+      <ButtonPrimary onClick={() => notify('warn')} mr={1}>
+        Warning
+      </ButtonPrimary>
+      <ButtonPrimary onClick={() => notify('error')} mr={1}>
+        Error
+      </ButtonPrimary>
+      <Notifications items={items} onRemoveItem={removeItem} />
+    </Flex>
+  );
+};
+
+export const StringContent = () => {
+  const { setItems, removeItem, items } = useNotifications();
+
+  function notify(severity: NotificationItem['severity']) {
+    setItems(prevItems => [
+      ...prevItems,
+      {
+        id: unique(),
+        severity,
+        content:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500.",
+      },
+    ]);
+  }
+
+  return (
+    <Flex>
+      <ButtonPrimary onClick={() => notify('info')} mr={1}>
+        Info
+      </ButtonPrimary>
+      <ButtonPrimary onClick={() => notify('warn')} mr={1}>
+        Warning
+      </ButtonPrimary>
+      <ButtonPrimary onClick={() => notify('error')} mr={1}>
+        Error
+      </ButtonPrimary>
+      <Notifications items={items} onRemoveItem={removeItem} />
+    </Flex>
+  );
+};

--- a/packages/teleterm/src/ui/components/Notifcations/Notifications.tsx
+++ b/packages/teleterm/src/ui/components/Notifcations/Notifications.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { NotificationItem } from './types';
+import { Notification } from './Notification';
+import styled from 'styled-components';
+
+interface NotificationsProps {
+  items: NotificationItem[];
+
+  onRemoveItem(id: string): void;
+}
+
+export function Notifications(props: NotificationsProps) {
+  return (
+    <Container>
+      {props.items.map(item => (
+        <Notification
+          key={item.id}
+          item={item}
+          onRemove={() => props.onRemoveItem(item.id)}
+        />
+      ))}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  position: fixed;
+  bottom: 12px;
+  right: 12px;
+`;

--- a/packages/teleterm/src/ui/components/Notifcations/NotificationsHost.tsx
+++ b/packages/teleterm/src/ui/components/Notifcations/NotificationsHost.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { Notifications } from './Notifications';
+
+export function NotificationsHost() {
+  const { notificationsService } = useAppContext();
+
+  notificationsService.useState();
+
+  return (
+    <Notifications
+      items={notificationsService.getNotifications()}
+      onRemoveItem={item => notificationsService.removeNotification(item)}
+    />
+  );
+}

--- a/packages/teleterm/src/ui/components/Notifcations/index.ts
+++ b/packages/teleterm/src/ui/components/Notifcations/index.ts
@@ -1,0 +1,3 @@
+export * from './Notifications';
+export * from './NotificationsHost';
+export * from './types';

--- a/packages/teleterm/src/ui/components/Notifcations/types.ts
+++ b/packages/teleterm/src/ui/components/Notifcations/types.ts
@@ -1,0 +1,9 @@
+export interface NotificationItem {
+  content: NotificationItemContent;
+  severity: 'info' | 'warn' | 'error';
+  id: string;
+}
+
+export type NotificationItemContent =
+  | string
+  | { title: string; description: string }

--- a/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -84,7 +84,7 @@ const appMock: tsh.Application = {
 };
 
 function createService(client: Partial<tsh.TshClient>): ClustersService {
-  return new ClustersService(client as tsh.TshClient);
+  return new ClustersService(client as tsh.TshClient, undefined);
 }
 
 function getClientMocks(): Partial<tsh.TshClient> {

--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -234,7 +234,7 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     const cluster = this.state.clusters.get(clusterUri);
     if (!cluster.connected) {
       this.setState(draft => {
-        delete draft.serversSyncStatus[clusterUri];
+        draft.serversSyncStatus.delete(clusterUri);
         helpers.updateMap(clusterUri, draft.servers, []);
       });
 
@@ -242,9 +242,9 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     }
 
     this.setState(draft => {
-      draft.serversSyncStatus[clusterUri] = {
+      draft.serversSyncStatus.set(clusterUri, {
         status: 'processing',
-      };
+      });
     });
 
     try {
@@ -255,10 +255,10 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
       });
     } catch (err) {
       this.setState(draft => {
-        draft.serversSyncStatus[clusterUri] = {
+        draft.serversSyncStatus.set(clusterUri, {
           status: 'failed',
           statusText: err.message,
-        };
+        });
       });
     }
   }

--- a/packages/teleterm/src/ui/services/notifications/index.ts
+++ b/packages/teleterm/src/ui/services/notifications/index.ts
@@ -1,0 +1,1 @@
+export * from './notificationsService';

--- a/packages/teleterm/src/ui/services/notifications/notificationsService.ts
+++ b/packages/teleterm/src/ui/services/notifications/notificationsService.ts
@@ -1,0 +1,51 @@
+import { ImmutableStore } from 'teleterm/ui/services/immutableStore';
+import {
+  NotificationItem,
+  NotificationItemContent,
+} from 'teleterm/ui/components/Notifcations';
+import { useStore } from 'shared/libs/stores';
+import { unique } from 'teleterm/ui/utils/uid';
+
+export class NotificationsService extends ImmutableStore<NotificationItem[]> {
+  state: NotificationItem[] = [];
+
+  notifyError(content: NotificationItemContent): string {
+    return this.notify({ severity: 'error', content });
+  }
+
+  notifyWarning(content: NotificationItemContent): string {
+    return this.notify({ severity: 'warn', content });
+  }
+
+  notifyInfo(content: NotificationItemContent): string {
+    return this.notify({ severity: 'info', content });
+  }
+
+  removeNotification(id: string): void {
+    this.setState(draftState =>
+      draftState.filter(stateItem => stateItem.id !== id)
+    );
+  }
+
+  getNotifications(): NotificationItem[] {
+    return this.state;
+  }
+
+  useState(): NotificationItem[] {
+    return useStore(this).state;
+  }
+
+  private notify(options: Omit<NotificationItem, 'id'>): string {
+    const id = unique();
+
+    this.setState(draftState => {
+      draftState.push({
+        severity: options.severity,
+        content: options.content,
+        id,
+      });
+    });
+
+    return id;
+  }
+}

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
@@ -60,7 +60,7 @@ test('getAutocompleteResult returns correct result for a command suggestion with
   );
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -80,7 +80,7 @@ test('getAutocompleteResult returns correct result for a command suggestion', ()
   );
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -117,7 +117,7 @@ test('getAutocompleteResult returns correct result for an SSH login suggestion',
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -158,7 +158,7 @@ test('getAutocompleteResult returns correct result for an SSH login suggestion w
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -209,7 +209,7 @@ test('getAutocompleteResult returns correct result for a database name suggestio
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -250,7 +250,7 @@ test("getAutocompleteResult doesn't return any suggestions if the only suggestio
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -279,7 +279,7 @@ test('getAutocompleteResult returns no match if any of the pickers returns parti
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -295,7 +295,7 @@ test("the SSH login autocomplete isn't shown if there's no space after `tsh ssh`
   );
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -328,7 +328,7 @@ test("the SSH login autocomplete is shown only if there's at least one space aft
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -370,7 +370,7 @@ test('getAutocompleteResult returns correct result for an SSH host suggestion ri
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -415,7 +415,7 @@ test('getAutocompleteResult returns correct result for a partial match on an SSH
     }));
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -457,7 +457,7 @@ test("getAutocompleteResult returns the first argument as loginHost when there's
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
 
@@ -477,7 +477,7 @@ test("getAutocompleteResult returns the first argument as loginHost when there's
 test('picking a command suggestion in an empty input autocompletes the command', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
   quickInputService.setState({ inputValue: '' });
@@ -503,7 +503,7 @@ test('picking a command suggestion in an empty input autocompletes the command',
 test('picking a command suggestion in an input with a single space preserves the space', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
   quickInputService.setState({ inputValue: ' ' });
@@ -529,7 +529,7 @@ test('picking a command suggestion in an input with a single space preserves the
 test('picking an SSH login suggestion replaces target token in input value', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
   quickInputService.setState({ inputValue: 'tsh ssh roo --foo' });
@@ -552,7 +552,7 @@ test('picking an SSH login suggestion replaces target token in input value', () 
 test('pickSuggestion appends the appendToToken field to the token', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined),
+    new ClustersServiceMock(undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined)
   );
   quickInputService.setState({ inputValue: 'tsh ssh foo' });


### PR DESCRIPTION
In some places informing the user about an error was not sufficient.
I added:
- standard, red labels over the tables in `ClusterResources` (servers, dbs, kubes, apps)
- notifications in other places, where we don't have an option to show static error label (closing db connection, synchronising root cluster) 

Notification component: 
<img width="857" alt="Screenshot 2022-03-29 at 11 49 00" src="https://user-images.githubusercontent.com/20583051/160607162-6faed544-4f83-4f25-ad7e-b1b74a937659.png">
(IMO this looks quite nice for someone with no design experience 🙂)

I also let the app render when the init function fails - this should make it easier to track why the app sometimes stops at `Loading`. 
Closes: https://github.com/gravitational/webapps.e/issues/151