### PR TITLE
Use x64 arch when building & packaging Teleterm

### DIFF
--- a/packages/teleterm/package.json
+++ b/packages/teleterm/package.json
@@ -16,8 +16,8 @@
     "build": "yarn build-natives && yarn build-main && yarn build-renderer",
     "build-main": "webpack build --config webpack.main.config.js --progress --mode=production",
     "build-renderer": "webpack build --config webpack.renderer.prod.config.js --progress",
-    "build-natives": "electron-builder install-app-deps",
-    "package": "electron-builder build --publish never -c.extraMetadata.name=teleterm"
+    "build-natives": "electron-builder install-app-deps --arch x64",
+    "package": "electron-builder build --publish never -c.extraMetadata.name=teleterm --x64"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Our build system doesn't support arm64 for Mac releases yet (see gravitational/teleport#4226 for more information). Because of that, for the preview release we're likely going to have only the x64 version of Teleterm.

This means that the shipped version of tsh should also be the x64 version.

I tried to change electron-builder's config to use x64 for macOS, but the config options don't seem to work. I tried `mac.defaultArch` as well as changing `mac.target` in various ways but `electron-builder install-app-deps` just doesn't pick up those options. Both were set through `packages/teleterm/package.json`