### PR TITLE
Revert "Use x64 arch when building & packaging Teleterm"

### DIFF
--- a/packages/teleterm/package.json
+++ b/packages/teleterm/package.json
@@ -16,8 +16,8 @@
     "build": "yarn build-natives && yarn build-main && yarn build-renderer",
     "build-main": "webpack build --config webpack.main.config.js --progress --mode=production",
     "build-renderer": "webpack build --config webpack.renderer.prod.config.js --progress",
-    "build-natives": "electron-builder install-app-deps --arch x64",
-    "package": "electron-builder build --publish never -c.extraMetadata.name=teleterm --x64"
+    "build-natives": "electron-builder install-app-deps",
+    "package": "electron-builder build --publish never -c.extraMetadata.name=teleterm"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This reverts commit 276e9a97402bdffce2e0fbea2a781d51c30cbce3.

Turns out that for development, we need to use arm64 version of native
deps. The build server is going to use x64 anyway, as per the reverted
commit, but when making manual demo builds, we'll have to remember to
use x64 for Teleterm and tsh.