### PR TITLE
Use teleterm/logger in runtimeSettings

### DIFF
--- a/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { app } from 'electron';
-import { Logger } from 'shared/libs/logger';
+import Logger from 'teleterm/logger';
 import { RuntimeSettings } from './types';
 
 const { argv, env } = process;


### PR DESCRIPTION
While trying to fix the issue with tsh connection on startup, I tried to use the Logger that was already imported in `runtimeSettings`. It turned out that attempting to use it would always crash the app, as the logger from shared/libs/logger attempts to call `window`, which doesn't exist in the context of Electron main process.

So instead we just use the one from `teleterm/logger` which calls `console` directly.