### PR TITLE
Passwordless wiring

### DIFF
--- a/packages/shared/services/types.ts
+++ b/packages/shared/services/types.ts
@@ -18,6 +18,8 @@ export type AuthProviderType = 'oidc' | 'saml' | 'github';
 
 export type Auth2faType = 'otp' | 'off' | 'optional' | 'on' | 'webauthn';
 
+export type AuthType = 'local' | 'github' | 'oidc' | 'saml';
+
 // PreferredMfaType is used to determine which MFA option
 // is preferred when more than one option can be available
 // and only one should be preferred.

--- a/packages/teleport/src/Account/ManageDevices/AddDevice/AddDevice.tsx
+++ b/packages/teleport/src/Account/ManageDevices/AddDevice/AddDevice.tsx
@@ -64,7 +64,7 @@ export function AddDevice({
   const [otpToken, setOtpToken] = useState('');
   const [deviceName, setDeviceName] = useState('');
 
-  const mfaOptions = useMemo<MfaOption[]>(
+  const mfaOptions = useMemo(
     () =>
       createMfaOptions({
         auth2faType: auth2faType,
@@ -74,7 +74,7 @@ export function AddDevice({
     []
   );
 
-  const [mfaOption, setMfaOption] = useState<MfaOption>(mfaOptions[0]);
+  const [mfaOption, setMfaOption] = useState(mfaOptions[0]);
 
   function onSetMfaOption(option: MfaOption) {
     setOtpToken('');
@@ -86,7 +86,7 @@ export function AddDevice({
     e.preventDefault();
 
     if (mfaOption.value === 'webauthn') {
-      addWebauthnDevice(deviceName);
+      addWebauthnDevice(deviceName, 'mfa');
     }
     if (mfaOption.value === 'otp') {
       addTotpDevice(otpToken, deviceName);

--- a/packages/teleport/src/Account/ManageDevices/AddDevice/useAddDevice.ts
+++ b/packages/teleport/src/Account/ManageDevices/AddDevice/useAddDevice.ts
@@ -18,6 +18,7 @@ import { useState, useEffect } from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import Ctx from 'teleport/teleportContext';
 import authService from 'teleport/services/auth';
+import { DeviceUsage } from 'teleport/services/mfa';
 import cfg from 'teleport/config';
 
 export default function useAddDevice(
@@ -43,12 +44,13 @@ export default function useAddDevice(
       .catch(addDeviceAttempt.handleError);
   }
 
-  function addWebauthnDevice(deviceName: string) {
+  function addWebauthnDevice(deviceName: string, deviceUsage: DeviceUsage) {
     addDeviceAttempt.setAttempt({ status: 'processing' });
     ctx.mfaService
       .addNewWebauthnDevice({
         tokenId: token,
         deviceName,
+        deviceUsage,
       })
       .then(() => {
         onClose();

--- a/packages/teleport/src/Login/Login.test.tsx
+++ b/packages/teleport/src/Login/Login.test.tsx
@@ -100,7 +100,10 @@ test('login with password and webauthn', async () => {
 
   // test login pathways
   await waitFor(() => fireEvent.click(getByText(/login/i)));
-  expect(auth.loginWithWebauthn).toHaveBeenCalledWith('username', '123');
+  expect(auth.loginWithWebauthn).toHaveBeenCalledWith({
+    username: 'username',
+    password: '123',
+  });
   expect(history.push).toHaveBeenCalledWith('http://localhost/web', true);
 });
 

--- a/packages/teleport/src/Login/useLogin.ts
+++ b/packages/teleport/src/Login/useLogin.ts
@@ -17,7 +17,7 @@
 import { useAttempt } from 'shared/hooks';
 import history from 'teleport/services/history';
 import cfg from 'teleport/config';
-import auth from 'teleport/services/auth';
+import auth, { UserCredentials } from 'teleport/services/auth';
 import { AuthProvider } from 'shared/services';
 
 export default function useLogin() {
@@ -36,10 +36,10 @@ export default function useLogin() {
       });
   }
 
-  function onLoginWithWebauthn(name, password) {
+  function onLoginWithWebauthn(creds?: UserCredentials) {
     attemptActions.start();
     auth
-      .loginWithWebauthn(name, password)
+      .loginWithWebauthn(creds)
       .then(onSuccess)
       .catch(err => {
         attemptActions.error(err);

--- a/packages/teleport/src/Welcome/useToken.ts
+++ b/packages/teleport/src/Welcome/useToken.ts
@@ -49,7 +49,7 @@ export default function useToken(tokenId: string) {
       .catch(submitAttempt.handleError);
   }
 
-  function onSubmitWithWebauthn(password: string) {
+  function onSubmitWithWebauthn(password?: string) {
     submitAttempt.setAttempt({ status: 'processing' });
     auth
       .resetPasswordWithWebauthn(tokenId, password)

--- a/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
+++ b/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
@@ -88,7 +88,10 @@ test('auth2faType: webauthn', async () => {
   });
 
   fireEvent.click(getByText(/login/i));
-  expect(onLoginWithWebauthn).toHaveBeenCalledWith('username', '123');
+  expect(onLoginWithWebauthn).toHaveBeenCalledWith({
+    username: 'username',
+    password: '123',
+  });
 });
 
 test('input validation error handling', async () => {

--- a/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -28,6 +28,7 @@ import {
   requiredField,
 } from 'shared/components/Validation/rules';
 import createMfaOptions, { MfaOption } from 'shared/utils/createMfaOptions';
+import { UserCredentials } from 'teleport/services/auth';
 import SSOButtonList from './SsoButtons';
 
 export default function LoginForm(props: Props) {
@@ -78,7 +79,7 @@ export default function LoginForm(props: Props) {
 
     switch (mfaType?.value) {
       case 'webauthn':
-        onLoginWithWebauthn(user, pass);
+        onLoginWithWebauthn({ username: user, password: pass });
         break;
       default:
         onLogin(user, pass, token);
@@ -278,6 +279,6 @@ export type Props = {
   onRecover?: (isRecoverPassword: boolean) => void;
   clearAttempt?: () => void;
   onLoginWithSso(provider: AuthProvider): void;
-  onLoginWithWebauthn(username: string, password: string): void;
+  onLoginWithWebauthn(creds: UserCredentials): void;
   onLogin(username: string, password: string, token: string): void;
 };

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -16,7 +16,12 @@ limitations under the License.
 
 import { generatePath } from 'react-router';
 import { merge } from 'lodash';
-import { AuthProvider, Auth2faType, PreferredMfaType } from 'shared/services';
+import {
+  AuthProvider,
+  Auth2faType,
+  AuthType,
+  PreferredMfaType,
+} from 'shared/services';
 import { RecordingType } from 'teleport/services/recordings';
 import { SortType } from './components/ServersideSearchPanel/useServerSideSearchPanel';
 import generateResourcePath from './generateResourcePath';
@@ -34,7 +39,7 @@ const cfg = {
     localAuthEnabled: true,
     providers: [] as AuthProvider[],
     second_factor: 'off' as Auth2faType,
-    authType: 'local',
+    authType: 'local' as AuthType,
     preferredLocalMfa: '' as PreferredMfaType,
   },
 

--- a/packages/teleport/src/services/auth/auth.ts
+++ b/packages/teleport/src/services/auth/auth.ts
@@ -138,7 +138,6 @@ const auth = {
           token: tokenId,
           password: password ? base64EncodeUnicode(password) : null,
           webauthnCreationResponse: makeWebauthnCreationResponse(res),
-          passwordless: !password,
         };
 
         return api.put(cfg.getPasswordTokenUrl(), request);

--- a/packages/teleport/src/services/auth/auth.ts
+++ b/packages/teleport/src/services/auth/auth.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
+import { DeviceType, DeviceUsage } from 'teleport/services/mfa';
 import makePasswordToken from './makePasswordToken';
 import { makeRecoveryCodes } from './makeRecoveryCodes';
 import {
@@ -24,7 +25,7 @@ import {
   makeWebauthnAssertionResponse,
   makeWebauthnCreationResponse,
 } from './makeMfa';
-import { DeviceType } from './types';
+import { UserCredentials } from './types';
 
 const auth = {
   checkWebauthnSupport() {
@@ -39,10 +40,15 @@ const auth = {
     );
   },
 
-  createMfaRegistrationChallenge(tokenId: string, deviceType: DeviceType) {
+  createMfaRegistrationChallenge(
+    tokenId: string,
+    deviceType: DeviceType,
+    deviceUsage: DeviceUsage = 'mfa'
+  ) {
     return api
       .post(cfg.getMfaCreateRegistrationChallengeUrl(tokenId), {
         deviceType,
+        deviceUsage,
       })
       .then(makeMfaRegistrationChallenge);
   },
@@ -54,11 +60,15 @@ const auth = {
   },
 
   // mfaLoginBegin retrieves users mfa challenges for their
-  // registered devices after verifying given username and password
-  // at login.
-  mfaLoginBegin(user: string, pass: string) {
+  // registered devices. Empty creds indicates request for passwordless challenges.
+  // Otherwise non-passwordless challenges requires creds to be verified.
+  mfaLoginBegin(creds?: UserCredentials) {
     return api
-      .post(cfg.api.mfaLoginBegin, { user, pass })
+      .post(cfg.api.mfaLoginBegin, {
+        passwordless: !creds,
+        user: creds?.username,
+        pass: creds?.password,
+      })
       .then(makeMfaAuthenticateChallenge);
   },
 
@@ -81,10 +91,10 @@ const auth = {
     return api.post(cfg.api.sessionPath, data);
   },
 
-  loginWithWebauthn(user: string, pass: string) {
+  loginWithWebauthn(creds?: UserCredentials) {
     return auth
       .checkWebauthnSupport()
-      .then(() => auth.mfaLoginBegin(user, pass))
+      .then(() => auth.mfaLoginBegin(creds))
       .then(res =>
         navigator.credentials.get({
           publicKey: res.webauthnPublicKey,
@@ -92,7 +102,7 @@ const auth = {
       )
       .then(res => {
         const request = {
-          user,
+          user: creds?.username,
           webauthnAssertionResponse: makeWebauthnAssertionResponse(res),
         };
 
@@ -105,10 +115,19 @@ const auth = {
     return api.get(path).then(makePasswordToken);
   },
 
-  resetPasswordWithWebauthn(tokenId: string, password: string) {
+  // resetPasswordWithWebauthn either sets a new password and a new webauthn device,
+  // or if passwordless is requested (indicated by empty password param),
+  // skips setting a new password and only sets a passwordless device.
+  resetPasswordWithWebauthn(tokenId: string, password?: string) {
     return auth
       .checkWebauthnSupport()
-      .then(() => auth.createMfaRegistrationChallenge(tokenId, 'webauthn'))
+      .then(() =>
+        auth.createMfaRegistrationChallenge(
+          tokenId,
+          'webauthn',
+          password ? 'mfa' : 'passwordless'
+        )
+      )
       .then(res =>
         navigator.credentials.create({
           publicKey: res.webauthnPublicKey,
@@ -117,8 +136,9 @@ const auth = {
       .then(res => {
         const request = {
           token: tokenId,
-          password: base64EncodeUnicode(password),
+          password: password ? base64EncodeUnicode(password) : null,
           webauthnCreationResponse: makeWebauthnCreationResponse(res),
+          passwordless: !password,
         };
 
         return api.put(cfg.getPasswordTokenUrl(), request);

--- a/packages/teleport/src/services/auth/types.ts
+++ b/packages/teleport/src/services/auth/types.ts
@@ -16,8 +16,6 @@
 
 export type Base64urlString = string;
 
-export type DeviceType = 'totp' | 'webauthn';
-
 export type UserCredentials = {
   username: string;
   password: string;

--- a/packages/teleport/src/services/mfa/mfa.ts
+++ b/packages/teleport/src/services/mfa/mfa.ts
@@ -48,7 +48,13 @@ class MfaService {
   addNewWebauthnDevice(req: AddNewHardwareDeviceRequest) {
     return auth
       .checkWebauthnSupport()
-      .then(() => auth.createMfaRegistrationChallenge(req.tokenId, 'webauthn'))
+      .then(() =>
+        auth.createMfaRegistrationChallenge(
+          req.tokenId,
+          'webauthn',
+          req.deviceUsage
+        )
+      )
       .then(res =>
         navigator.credentials.create({
           publicKey: res.webauthnPublicKey,

--- a/packages/teleport/src/services/mfa/types.ts
+++ b/packages/teleport/src/services/mfa/types.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type MfaDevice = {
   id: string;
   name: string;
@@ -15,4 +31,8 @@ export type AddNewTotpDeviceRequest = {
 export type AddNewHardwareDeviceRequest = {
   tokenId: string;
   deviceName: string;
+  deviceUsage?: DeviceUsage;
 };
+
+export type DeviceType = 'totp' | 'webauthn';
+export type DeviceUsage = 'passwordless' | 'mfa';

--- a/packages/teleport/src/services/mfa/types.ts
+++ b/packages/teleport/src/services/mfa/types.ts
@@ -35,4 +35,6 @@ export type AddNewHardwareDeviceRequest = {
 };
 
 export type DeviceType = 'totp' | 'webauthn';
+
+// DeviceUsage is the intended usage of the device (MFA, Passwordless, etc).
 export type DeviceUsage = 'passwordless' | 'mfa';


### PR DESCRIPTION
#### Description
Updates api request bodies to pass on passwordless requests. Does not change any functionality, just wiring (still waiting on final design)

Note: `teleterm` passwordless work will be done separately


#### Related PR
To enable passwordless registration (for invites and resets), this [PR](https://github.com/gravitational/teleport/pull/11748) needs to be merged