### PR TITLE
Adds the Servers tab as a configurable UI feature

### DIFF
--- a/packages/teleport/src/Main/fixtures/index.ts
+++ b/packages/teleport/src/Main/fixtures/index.ts
@@ -41,6 +41,7 @@ export const fullAcl: Acl = {
   billing: fullAccess,
   dbServers: fullAccess,
   desktops: fullAccess,
+  nodes: fullAccess,
   clipboardSharingEnabled: true,
   desktopSessionRecordingEnabled: true,
 };

--- a/packages/teleport/src/features.ts
+++ b/packages/teleport/src/features.ts
@@ -183,6 +183,10 @@ export class FeatureNodes {
   };
 
   register(ctx: Ctx) {
+    if (!ctx.getFeatureFlags().nodes) {
+      return;
+    }
+
     ctx.storeNav.addSideItem({
       title: 'Servers',
       Icon: Icons.Server,

--- a/packages/teleport/src/services/user/makeAcl.ts
+++ b/packages/teleport/src/services/user/makeAcl.ts
@@ -44,6 +44,7 @@ export default function makeAcl(json): Acl {
     json.desktopSessionRecording !== undefined
       ? json.desktopSessionRecording
       : true;
+  const nodes = json.nodes || defaultAccess;
 
   return {
     sshLogins,
@@ -63,6 +64,7 @@ export default function makeAcl(json): Acl {
     desktops,
     clipboardSharingEnabled,
     desktopSessionRecordingEnabled,
+    nodes,
   };
 }
 

--- a/packages/teleport/src/services/user/types.ts
+++ b/packages/teleport/src/services/user/types.ts
@@ -63,6 +63,7 @@ export interface Acl {
   billing: Access;
   dbServers: Access;
   desktops: Access;
+  nodes: Access;
 }
 
 export interface User {

--- a/packages/teleport/src/services/user/user.test.ts
+++ b/packages/teleport/src/services/user/user.test.ts
@@ -65,6 +65,13 @@ test('undefined values in context response gives proper default values', async (
         create: false,
         remove: false,
       },
+      nodes: {
+        create: false,
+        edit: false,
+        list: false,
+        read: false,
+        remove: false,
+      },
       roles: {
         list: false,
         read: false,

--- a/packages/teleport/src/stores/storeUserContext.ts
+++ b/packages/teleport/src/stores/storeUserContext.ts
@@ -100,4 +100,8 @@ export default class StoreUserContext extends Store<UserContext> {
   getClipboardAccess() {
     return this.state.acl.clipboardSharingEnabled;
   }
+
+  getNodeAccess() {
+    return this.state.acl.nodes;
+  }
 }

--- a/packages/teleport/src/teleportContext.tsx
+++ b/packages/teleport/src/teleportContext.tsx
@@ -76,6 +76,7 @@ class TeleportContext implements types.Context {
       billing: userContext.getBillingAccess().list,
       databases: userContext.getDatabaseAccess().list,
       desktops: userContext.getDesktopAccess().list,
+      nodes: userContext.getNodeAccess().list,
     };
   }
 }


### PR DESCRIPTION
Per a discussion in the community [Slack](https://goteleport.slack.com/archives/CEZH6UL64/p1649705079426479), its not uncommon for users to want to hide some of the feature tabs in the sidebar. This is currently possible for all features except Server access; these changes make the Server access tab configurable as well.

A user with this role
```
kind: role
metadata:
  name: remove_servers
spec:
  allow: {}
  deny:
    rules:
    - resources: [node]
      verbs: [list]
version: v5
```

will see a UI that looks like

<img width="1276" alt="Screen Shot 2022-04-12 at 10 18 00" src="https://user-images.githubusercontent.com/13578537/162983210-28a56341-7c1b-4369-8eef-dfc62c986e86.png">
ike

