### PR TITLE
Fix path to packaged assets in Teleterm

### DIFF
--- a/packages/teleterm/webpack.renderer.extend.js
+++ b/packages/teleterm/webpack.renderer.extend.js
@@ -5,7 +5,7 @@ const resolvepath = require('@gravitational/build/webpack/resolvepath');
 
 function extend(cfg) {
   cfg.entry = { app: ['./src/ui/boot'] };
-  cfg.output.publicPath = '';
+  cfg.output.publicPath = 'auto';
   cfg.output.path = resolvepath('build/app/dist/renderer');
   cfg.output.libraryTarget = 'umd';
   cfg.output.globalObject = 'this';


### PR DESCRIPTION
When packaged, the main window opens this file:

    window.loadFile(path.join(__dirname, '../renderer/index.html'));

The assets are under ../renderer/assets, but since Webpack used absolute path for it, Electron tried to load them from /assets instead.

I'm not sure if that's the best way to modify our Webpack config, let me know if you have a better idea.

Fixes gravitational/webapps.e#153.