### PR TITLE
Add max-width on Identity popover

### DIFF
--- a/packages/teleterm/src/ui/TopBar/Identity/Identity.tsx
+++ b/packages/teleterm/src/ui/TopBar/Identity/Identity.tsx
@@ -46,7 +46,9 @@ export function Identity() {
         open={isPopoverOpened}
         anchorEl={selectorRef.current}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         onClose={() => setIsPopoverOpened(false)}
+        popoverCss={() => `max-width: min(560px, 90%)`}
       >
         <Container>
           {rootClusters.length ? (

--- a/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -19,6 +19,8 @@ interface IdentityListProps {
 }
 
 export function IdentityList(props: IdentityListProps) {
+  const roles = props.loggedInUser.rolesList.join(', ');
+
   return (
     <Box minWidth="200px" pt="12px">
       {props.loggedInUser && (
@@ -27,7 +29,7 @@ export function IdentityList(props: IdentityListProps) {
             <Box>
               <Text bold>{props.loggedInUser.name}</Text>
               <Text typography="body2" color="text.secondary">
-                {props.loggedInUser.rolesList.join(', ')}
+                {roles}
               </Text>
             </Box>
           </Flex>


### PR DESCRIPTION
This prevents long cluster names or long role lists from breaking the UI. Fixes gravitational/webapps.e#225.

String for testing:

```
drone-prod-app-access, grafana-prod-app-access, grafana-staging-app-access, releases-prod-app-access, releases-staging-app-access, sales-center-prod-app-access, sales-center-prod-db-access, sales-center-staging-app-access,sales-center-staging-db-access
```