### PR TITLE
[v9] Use the mac package download link instead of the tarball (#738)

### DIFF
--- a/packages/teleport/src/Apps/AddApp/__snapshots__/AddApp.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/AddApp/__snapshots__/AddApp.story.test.tsx.snap
@@ -1380,7 +1380,7 @@ exports[`render manual tab with local user 1`] = `
             >
               <a
                 class="c11"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-darwin-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-5.0.0-dev.pkg"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -1814,7 +1814,7 @@ exports[`render manual tab with sso user 1`] = `
             >
               <a
                 class="c11"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-darwin-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-5.0.0-dev.pkg"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -2269,7 +2269,7 @@ exports[`render manual tab with token 1`] = `
             >
               <a
                 class="c11"
-                href="https://get.gravitational.com/teleport-v5.0.0-dev-darwin-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-5.0.0-dev.pkg"
                 rel="noreferrer"
                 target="_blank"
               >

--- a/packages/teleport/src/Databases/AddDatabase/__snapshots__/AddDatabase.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/AddDatabase/__snapshots__/AddDatabase.story.test.tsx.snap
@@ -485,7 +485,7 @@ exports[`render with token 1`] = `
           >
             <a
               class="c10"
-              href="https://get.gravitational.com/teleport-v6.1.3-darwin-amd64-bin.tar.gz"
+              href="https://get.gravitational.com/teleport-6.1.3.pkg"
               rel="noreferrer"
               target="_blank"
             >
@@ -1022,7 +1022,7 @@ exports[`render without token 1`] = `
           >
             <a
               class="c10"
-              href="https://get.gravitational.com/teleport-v6.1.3-darwin-amd64-bin.tar.gz"
+              href="https://get.gravitational.com/teleport-6.1.3.pkg"
               rel="noreferrer"
               target="_blank"
             >
@@ -1605,7 +1605,7 @@ exports[`render without token with SSO auth 1`] = `
           >
             <a
               class="c10"
-              href="https://get.gravitational.com/teleport-v6.1.3-darwin-amd64-bin.tar.gz"
+              href="https://get.gravitational.com/teleport-6.1.3.pkg"
               rel="noreferrer"
               target="_blank"
             >

--- a/packages/teleport/src/Nodes/AddNode/__snapshots__/AddNode.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/AddNode/__snapshots__/AddNode.story.test.tsx.snap
@@ -1011,7 +1011,7 @@ exports[`render manual tab with join token 1`] = `
             >
               <a
                 class="c14"
-                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-darwin-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-5.0.0-dev.pkg"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -1442,7 +1442,7 @@ exports[`render manual tab with local user 1`] = `
             >
               <a
                 class="c14"
-                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-darwin-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-5.0.0-dev.pkg"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -1919,7 +1919,7 @@ exports[`render manual tab with sso user 1`] = `
             >
               <a
                 class="c14"
-                href="https://get.gravitational.com/teleport-ent-v5.0.0-dev-darwin-amd64-bin.tar.gz"
+                href="https://get.gravitational.com/teleport-ent-5.0.0-dev.pkg"
                 rel="noreferrer"
                 target="_blank"
               >

--- a/packages/teleport/src/services/links.ts
+++ b/packages/teleport/src/services/links.ts
@@ -24,7 +24,7 @@ export default function getDownloadLink(
   let infix = 'linux-amd64';
   const enterprise = isEnterprise ? 'ent-' : '';
   if (type === 'mac') {
-    infix = 'darwin-amd64';
+    return `${DOWNLOAD_BASE_URL}teleport-${enterprise}${version}.pkg`;
   } else if (type === 'linux32') {
     infix = 'linux-386';
   }


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/11738