### PR TITLE
Fix getting cwd in presence of lsof warnings

### DIFF
--- a/packages/teleterm/src/services/pty/ptyProcess.ts
+++ b/packages/teleterm/src/services/pty/ptyProcess.ts
@@ -165,12 +165,7 @@ async function getWorkingDirectory(pid: number): Promise<string> {
       // -p: PID
       // -d: only include the file descriptor, cwd
       // -F: fields to output (the n character outputs 3 things, the last one is cwd)
-      const { stdout, stderr } = await asyncExec(
-        `lsof -a -p ${pid} -d cwd -F n`
-      );
-      if (stderr) {
-        throw new Error(stderr);
-      }
+      const { stdout } = await asyncExec(`lsof -a -p ${pid} -d cwd -F n`);
       return stdout.split('\n').filter(Boolean).reverse()[0].substring(1);
     case 'linux':
       const asyncReadlink = promisify(readlink);


### PR DESCRIPTION
lsof uses stderr to print out warnings. This caused the previous version
of ptyProcess to throw an error, even though the exit code of lsof was 0.

The existing code already handles non-zero exit codes (asyncExec will
reject the promise). Since we don't know why stderr was inspected in
the first place, let's just remove the check for it.