### PR TITLE
Double encode redirect url

### DIFF
--- a/packages/teleport/src/services/history/history.ts
+++ b/packages/teleport/src/services/history/history.ts
@@ -63,6 +63,9 @@ const history = {
       // correctly interpret it as a query param (it will get decoded once
       // from either the server with SSO flow or from local login flow with "getUrlParameter").
       //
+      // In addition, we add a query param flag called `encoded` to help differentiate a query string
+      // manipulated by redirect versus a regular page navigation.
+      //
       // Example SSO flow:
       // My redirect URL is:
       //   https://cluster.dev/web/nodes?search=some-search-value&sort=name:asc
@@ -77,7 +80,9 @@ const history = {
       if (search) {
         const splitted = search.split('?');
         if (splitted.length > 1) {
-          query = encodeURIComponent(`?${encodeURIComponent(splitted[1])}`);
+          query = encodeURIComponent(
+            `?${encodeURIComponent(`${splitted[1]}&encoded`)}`
+          );
         }
       }
 


### PR DESCRIPTION
#### Description
Preserve the original query string with SSO login redirect flow. Please take a look at the comment I placed in the code to understand more.

This became a problem when you had more than one query param eg: `?queryParam1=foo&queryParam2=problem`