### PR TITLE
Skip previous document reopen when selecting a connection

### DIFF
--- a/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -76,7 +76,9 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
       this._trackedConnectionOperationsFactory.create(connection);
 
     if (rootClusterUri !== this._workspacesService.getRootClusterUri()) {
-      await this._workspacesService.setActiveWorkspace(rootClusterUri);
+      await this._workspacesService.setActiveWorkspace(rootClusterUri, {
+        skipPreviousDocuments: true,
+      });
     }
     activate();
   }

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -110,7 +110,10 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     this.statePersistenceService.saveWorkspaces(this.state);
   }
 
-  setActiveWorkspace(clusterUri: string): Promise<void> {
+  setActiveWorkspace(
+    clusterUri: string,
+    options?: { skipPreviousDocuments?: boolean }
+  ): Promise<void> {
     const setWorkspace = () => {
       this.setState(draftState => {
         if (!draftState.workspaces[clusterUri]) {
@@ -174,7 +177,10 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     })
       .then(() => {
         return new Promise<void>(resolve => {
-          if (!this.canReopenPreviousDocuments(this.getWorkspace(clusterUri))) {
+          if (
+            options?.skipPreviousDocuments ||
+            !this.canReopenPreviousDocuments(this.getWorkspace(clusterUri))
+          ) {
             this.discardPreviousDocuments(clusterUri);
             return resolve();
           }


### PR DESCRIPTION
When selecting a connection from another workspace we shouldn't ask for documents reopen, but simply open that connection.