### PR TITLE
Fix check for the --insecure flag

### DIFF
--- a/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -14,7 +14,7 @@ const RESOURCES_PATH = app.isPackaged
 const dev = env.NODE_ENV === 'development' || env.DEBUG_PROD === 'true';
 
 // Allows running tsh in insecure mode (development)
-const isInsecure = dev || argv.slice(2).indexOf('--insecure') !== -1;
+const isInsecure = dev || argv.includes('--insecure');
 
 function getRuntimeSettings(): RuntimeSettings {
   const userDataDir = app.getPath('userData');


### PR DESCRIPTION
Fixes gravitational/webapps.e#147.

Without this people at Teleport would have harder time trying out Teleconnect in insecure mode – they'd need to know to put `--insecure` as at least the second flag. This PR makes it so that it works as expected.