### PR TITLE
When updating cluster resources, remove only those that belong to this cluster

### DIFF
--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -568,7 +568,7 @@ const helpers = {
   ) {
     // delete all entries under given uri
     for (let k of map.keys()) {
-      if (k.startsWith(parentUri)) {
+      if (routing.ensureClusterUri(k) === parentUri) {
         map.delete(k);
       }
     }

--- a/packages/teleterm/src/ui/uri.ts
+++ b/packages/teleterm/src/ui/uri.ts
@@ -42,6 +42,12 @@ export const routing = {
     return routing.getClusterUri({ rootClusterId });
   },
 
+  // Pass any resource URI to get back a cluster URI.
+  ensureClusterUri(uri: string) {
+    const params = routing.parseClusterUri(uri).params;
+    return routing.getClusterUri(params);
+  },
+
   parseKubeUri(uri: string) {
     return routing.parseUri(uri, paths.kube);
   },


### PR DESCRIPTION
When we have a cluster with leaf clusters, resources of the leaf cluster are not showing sometimes. It happens when its resources are fetched before the resources of the root cluster. In that case `updateMap` removes __all__ resources that start with the root cluster URI (so it removes leaf cluster resources which are already fetched!). 
Closes https://github.com/gravitational/webapps.e/issues/248