### PR TITLE
Bump Teleport Connect version to 1.0.1

### DIFF
--- a/packages/teleterm/package.json
+++ b/packages/teleterm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gravitational/teleterm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Teleport Connect",
   "main": "build/app/dist/main/main.js",
   "author": {


### PR DESCRIPTION
By the GA release we should have a better versioning scheme in place, but for now let's just bump the version to 1.0.1 so that we can release this preview version with the fix for OTP (gravitational/teleport#12322).