### PR TITLE
[v9] Bump Teleport Connect version to 1.0.1 (#796)

### DIFF
--- a/packages/teleterm/package.json
+++ b/packages/teleterm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gravitational/teleterm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Teleport Connect",
   "main": "build/app/dist/main/main.js",
   "author": {


### PR DESCRIPTION
Backport #796.