### PR TITLE
Fix pagination bug

### DIFF
--- a/packages/teleport/src/Apps/useApps.ts
+++ b/packages/teleport/src/Apps/useApps.ts
@@ -82,7 +82,7 @@ export default function useApps(ctx: Ctx) {
       .then(res => {
         setResults(res);
         setFetchStatus(res.startKey ? '' : 'disabled');
-        setStartKeys([res.apps[0]?.id, res.startKey]);
+        setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
       })
       .catch((err: Error) => {

--- a/packages/teleport/src/Console/DocumentNodes/useNodes.ts
+++ b/packages/teleport/src/Console/DocumentNodes/useNodes.ts
@@ -69,7 +69,7 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
       .then(({ logins, nodesRes }) => {
         setResults({ logins, ...nodesRes });
         setFetchStatus(nodesRes.startKey ? '' : 'disabled');
-        setStartKeys([nodesRes.nodes[0]?.id, nodesRes.startKey]);
+        setStartKeys(['', nodesRes.startKey]);
         setAttempt({ status: 'success' });
       })
       .catch((err: Error) => {

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -76,7 +76,7 @@ export default function useDatabases(ctx: Ctx) {
       .then(res => {
         setResults(res);
         setFetchStatus(res.startKey ? '' : 'disabled');
-        setStartKeys([res.databases[0]?.name, res.startKey]);
+        setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
       })
       .catch((err: Error) => {

--- a/packages/teleport/src/Desktops/useDesktops.ts
+++ b/packages/teleport/src/Desktops/useDesktops.ts
@@ -88,7 +88,7 @@ export default function useDesktops(ctx: Ctx) {
       .then(res => {
         setResults(res);
         setFetchStatus(res.startKey ? '' : 'disabled');
-        setStartKeys([res.desktops[0]?.name, res.startKey]);
+        setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
       })
       .catch((err: Error) => {

--- a/packages/teleport/src/Kubes/useKubes.ts
+++ b/packages/teleport/src/Kubes/useKubes.ts
@@ -72,7 +72,7 @@ export default function useKubes(ctx: TeleportContext) {
       .then(res => {
         setResults(res);
         setFetchStatus(res.startKey ? '' : 'disabled');
-        setStartKeys([res.kubes[0]?.name, res.startKey]);
+        setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
       })
       .catch((err: Error) => {

--- a/packages/teleport/src/Nodes/useNodes.ts
+++ b/packages/teleport/src/Nodes/useNodes.ts
@@ -89,7 +89,7 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
       .then(res => {
         setResults(res);
         setFetchStatus(res.startKey ? '' : 'disabled');
-        setStartKeys([res.nodes[0]?.id, res.startKey]);
+        setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
       })
       .catch((err: Error) => {


### PR DESCRIPTION
### Purpose

This PR resolves https://github.com/gravitational/teleport/issues/12289

### Implementation

For certain types of resources, such as apps, the `startKeys` that the back-end uses doesn't match what is being used at the front. This change makes it so that the request for the first page uses a blank `startKey`.