### PR TITLE
Indicate whether session.network events were allowed or blocked

### DIFF
--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -3271,7 +3271,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          [ALLOW] Program [bash] successfully opened a connection [10.217.136.161 &lt;-&gt; 190.58.129.4:3000] within a session [44c6cea8-362f-11ea-83aa-125400432324]
+          [DENY] Program [bash] was prevented from opening a connection [10.217.136.161 &lt;-&gt; 190.58.129.4:3000] within a session [44c6cea8-362f-11ea-83aa-125400432324]
         </td>
         <td
           style="min-width: 120px;"

--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -3271,7 +3271,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          Program [bash] opened a connection [10.217.136.161 &lt;-&gt; 190.58.129.4:3000] within a session [44c6cea8-362f-11ea-83aa-125400432324]
+          [ALLOW] Program [bash] successfully opened a connection [10.217.136.161 &lt;-&gt; 190.58.129.4:3000] within a session [44c6cea8-362f-11ea-83aa-125400432324]
         </td>
         <td
           style="min-width: 120px;"
@@ -4310,7 +4310,7 @@ exports[`loaded audit log screen 1`] = `
         <td
           style="word-break: break-word;"
         >
-          Program [bash] opened a connection [10.217.136.161 &lt;-&gt; 190.58.129.4:3000] within a session [44c6cea8-362f-11ea-83aa-125400432324]
+          [ALLOW] Program [bash] successfully opened a connection [10.217.136.161 &lt;-&gt; 190.58.129.4:3000] within a session [44c6cea8-362f-11ea-83aa-125400432324]
         </td>
         <td
           style="min-width: 120px;"

--- a/packages/teleport/src/Audit/fixtures/index.ts
+++ b/packages/teleport/src/Audit/fixtures/index.ts
@@ -51,6 +51,7 @@ export const events = [
     dst_port: '3000',
     version: 4,
     time: '2019-04-22T19:39:26.676Z',
+    action: 1,
   },
   {
     code: 'T4001I',
@@ -1135,6 +1136,7 @@ export const eventsSample = [
     dst_port: '3000',
     version: 4,
     time: '2019-04-22T19:39:26.676Z',
+    action: 0,
   },
   {
     code: 'T4001I',

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -56,8 +56,12 @@ export const formatters: Formatters = {
   [eventCodes.SESSION_NETWORK]: {
     type: 'session.network',
     desc: 'Session Network Connection',
-    format: ({ sid, program, src_addr, dst_addr, dst_port }) =>
-      `Program [${program}] opened a connection [${src_addr} <-> ${dst_addr}:${dst_port}] within a session [${sid}]`,
+    format: ({ action, sid, program, src_addr, dst_addr, dst_port }) => {
+      const a = action === 1 ? '[DENY]' : '[ALLOW]';
+      const desc =
+        action === 1 ? 'was prevented from opening' : 'successfully opened';
+      return `${a} Program [${program}] ${desc} a connection [${src_addr} <-> ${dst_addr}:${dst_port}] within a session [${sid}]`;
+    },
   },
   [eventCodes.SESSION_PROCESS_EXIT]: {
     type: 'session.process_exit',
@@ -445,7 +449,14 @@ export const formatters: Formatters = {
   [eventCodes.MYSQL_STATEMENT_SEND_LONG_DATA]: {
     type: 'db.session.mysql.statements.send_long_data',
     desc: 'MySQL Statement Send Long Data',
-    format: ({ user, db_service, db_name, statement_id, parameter_id, data_size }) =>
+    format: ({
+      user,
+      db_service,
+      db_name,
+      statement_id,
+      parameter_id,
+      data_size,
+    }) =>
       `User [${user}] has sent ${data_size} bytes of data to parameter [${parameter_id}] of statement [${statement_id}] in database [${db_name}] on [${db_service}]`,
   },
   [eventCodes.MYSQL_STATEMENT_CLOSE]: {
@@ -631,20 +642,21 @@ export const formatters: Formatters = {
     format: ({ server_addr }) => `Session connected to [${server_addr}]`,
   },
   [eventCodes.CERTIFICATE_CREATED]: {
-    type: "cert.create",
-    desc: "Certificate Issued",
+    type: 'cert.create',
+    desc: 'Certificate Issued',
     format: ({ cert_type, identity: { user } }) => {
       if (cert_type === 'user') {
-        return `User certificate issued for [${user}]`
+        return `User certificate issued for [${user}]`;
       }
-      return `Certificate of type [${cert_type}] issued for [${user}]`
-    }
+      return `Certificate of type [${cert_type}] issued for [${user}]`;
+    },
   },
   [eventCodes.UNKNOWN]: {
     type: 'unknown',
     desc: 'Unknown Event',
-    format: ({ unknown_type, unknown_code }) => `Unknown '${unknown_type}' event (${unknown_code})`,
-  }
+    format: ({ unknown_type, unknown_code }) =>
+      `Unknown '${unknown_type}' event (${unknown_code})`,
+  },
 };
 
 const unknownFormatter = {

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -757,6 +757,7 @@ type RawEventCommand<T extends EventCode> = RawEvent<
 type RawEventNetwork<T extends EventCode> = RawEvent<
   T,
   {
+    action: number;
     login: string;
     namespace: string;
     pid: number;


### PR DESCRIPTION
We only have a single event type for all `session.network` events, whether the action was allowed or denied. This makes it hard for an administrator or auditor to detect malicious activity, because they have to look at the event JSON to get this info.

Fix this by updating the description in the audit log to clearly indicate whether the action was allowed or denied.

Fixes TEL-Q421-2
Fixes gravitational/teleport.e#331