### PR TITLE
Add Initial Sorting for Tables

### DIFF
--- a/packages/teleport/src/Apps/useApps.ts
+++ b/packages/teleport/src/Apps/useApps.ts
@@ -37,9 +37,10 @@ export default function useApps(ctx: Ctx) {
   const { attempt, setAttempt } = useAttempt('processing');
   const isEnterprise = ctx.isEnterprise;
   const [fetchStatus, setFetchStatus] = useState<FetchStatus>('');
-  const [params, setParams] = useState<ResourceUrlQueryParams>(() =>
-    getResourceUrlQueryParams(search)
-  );
+  const [params, setParams] = useState<ResourceUrlQueryParams>({
+    sort: { fieldName: 'name', dir: 'ASC' },
+    ...getResourceUrlQueryParams(search),
+  });
 
   const [results, setResults] = useState<AppsResponse>({
     apps: [],

--- a/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -945,7 +945,7 @@ exports[`render DocumentNodes 1`] = `
               <a>
                 Hostname
                 <span
-                  class="c24 c25 icon icon-chevrons-expand-vertical "
+                  class="c24 c25 icon icon-chevron-up "
                   color="light"
                 />
               </a>

--- a/packages/teleport/src/Console/DocumentNodes/useNodes.ts
+++ b/packages/teleport/src/Console/DocumentNodes/useNodes.ts
@@ -34,9 +34,10 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
   const [startKeys, setStartKeys] = useState<string[]>([]);
   const { attempt, setAttempt } = useAttempt('processing');
   const [fetchStatus, setFetchStatus] = useState<FetchStatus>('');
-  const [params, setParams] = useState<ResourceUrlQueryParams>(() =>
-    getResourceUrlQueryParams(search)
-  );
+  const [params, setParams] = useState<ResourceUrlQueryParams>({
+    sort: { fieldName: 'hostname', dir: 'ASC' },
+    ...getResourceUrlQueryParams(search),
+  });
 
   const [results, setResults] = useState<NodesResponse & { logins: string[] }>({
     logins: [],

--- a/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
+++ b/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
@@ -68,8 +68,9 @@ function DatabaseList(props: Props) {
             isSortable: true,
           },
           {
-            key: 'title',
+            key: 'type',
             headerText: 'Type',
+            isSortable: true,
           },
           {
             key: 'labels',

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -893,10 +893,14 @@ exports[`failed 1`] = `
             />
           </a>
         </th>
-        <th
-          style="cursor: default;"
-        >
-          Type
+        <th>
+          <a>
+            Type
+            <span
+              class="c18 c19 icon icon-chevrons-expand-vertical "
+              color="light"
+            />
+          </a>
         </th>
         <th
           style="cursor: default;"
@@ -1629,10 +1633,14 @@ exports[`open source loaded 1`] = `
             />
           </a>
         </th>
-        <th
-          style="cursor: default;"
-        >
-          Type
+        <th>
+          <a>
+            Type
+            <span
+              class="c17 c18 icon icon-chevrons-expand-vertical "
+              color="light"
+            />
+          </a>
         </th>
         <th
           style="cursor: default;"

--- a/packages/teleport/src/Databases/fixtures/index.ts
+++ b/packages/teleport/src/Databases/fixtures/index.ts
@@ -20,7 +20,7 @@ export const databases: Database[] = [
   {
     name: 'aurora',
     description: 'PostgreSQL 11.6: AWS Aurora ',
-    title: 'RDS PostgreSQL',
+    type: 'RDS PostgreSQL',
     protocol: 'postgres',
     labels: [
       { name: 'cluster', value: 'root' },
@@ -30,7 +30,7 @@ export const databases: Database[] = [
   {
     name: 'postgres-gcp',
     description: 'PostgreSQL 9.6: Google Cloud SQL',
-    title: 'Cloud SQL PostgreSQL',
+    type: 'Cloud SQL PostgreSQL',
     protocol: 'postgres',
     labels: [
       { name: 'cluster', value: 'root' },
@@ -40,7 +40,7 @@ export const databases: Database[] = [
   {
     name: 'mysql-aurora-56',
     description: 'MySQL 5.6: AWS Aurora Longname For SQL',
-    title: 'Self-hosted MySQL',
+    type: 'Self-hosted MySQL',
     protocol: 'mysql',
     labels: [
       { name: 'cluster', value: 'root' },

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -40,9 +40,10 @@ export default function useDatabases(ctx: Ctx) {
   const authType = ctx.storeUser.state.authType;
   const [isAddDialogVisible, setIsAddDialogVisible] = useState(false);
   const [fetchStatus, setFetchStatus] = useState<FetchStatus>('');
-  const [params, setParams] = useState<ResourceUrlQueryParams>(() =>
-    getResourceUrlQueryParams(search)
-  );
+  const [params, setParams] = useState<ResourceUrlQueryParams>({
+    sort: { fieldName: 'name', dir: 'ASC' },
+    ...getResourceUrlQueryParams(search),
+  });
 
   const isSearchEmpty = !params?.query && !params?.search;
 

--- a/packages/teleport/src/Desktops/useDesktops.ts
+++ b/packages/teleport/src/Desktops/useDesktops.ts
@@ -39,9 +39,10 @@ export default function useDesktops(ctx: Ctx) {
   const username = ctx.storeUser.state.username;
   const windowsLogins = ctx.storeUser.getWindowsLogins();
   const [fetchStatus, setFetchStatus] = useState<FetchStatus>('');
-  const [params, setParams] = useState<ResourceUrlQueryParams>(() =>
-    getResourceUrlQueryParams(search)
-  );
+  const [params, setParams] = useState<ResourceUrlQueryParams>({
+    sort: { fieldName: 'name', dir: 'ASC' },
+    ...getResourceUrlQueryParams(search),
+  });
 
   const isSearchEmpty = !params?.query && !params?.search;
 

--- a/packages/teleport/src/Nodes/useNodes.ts
+++ b/packages/teleport/src/Nodes/useNodes.ts
@@ -39,9 +39,10 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
   const canCreate = ctx.storeUser.getTokenAccess().create;
   const logins = ctx.storeUser.getSshLogins();
   const [fetchStatus, setFetchStatus] = useState<FetchStatus>('');
-  const [params, setParams] = useState<ResourceUrlQueryParams>(() =>
-    getResourceUrlQueryParams(search)
-  );
+  const [params, setParams] = useState<ResourceUrlQueryParams>({
+    sort: { fieldName: 'hostname', dir: 'ASC' },
+    ...getResourceUrlQueryParams(search),
+  });
 
   const isSearchEmpty = !params?.query && !params?.search;
 

--- a/packages/teleport/src/getUrlQueryParams.tsx
+++ b/packages/teleport/src/getUrlQueryParams.tsx
@@ -24,15 +24,6 @@ export default function getResourceUrlQueryParams(
   const search = searchParams.get('search');
   const sort = searchParams.get('sort');
 
-  console.log({
-    sort: sort
-      ? ({
-          fieldName: sort.split(':')[0],
-          dir: sort.split(':')[1]?.toUpperCase() || 'ASC',
-        } as SortType)
-      : null,
-  });
-
   // Converts the "fieldname:dir" format into {fieldName: "", dir: ""}
   const processedSortParam = sort
     ? ({

--- a/packages/teleport/src/getUrlQueryParams.tsx
+++ b/packages/teleport/src/getUrlQueryParams.tsx
@@ -24,15 +24,28 @@ export default function getResourceUrlQueryParams(
   const search = searchParams.get('search');
   const sort = searchParams.get('sort');
 
-  return {
-    query,
-    search,
+  console.log({
     sort: sort
       ? ({
           fieldName: sort.split(':')[0],
           dir: sort.split(':')[1]?.toUpperCase() || 'ASC',
         } as SortType)
       : null,
+  });
+
+  // Converts the "fieldname:dir" format into {fieldName: "", dir: ""}
+  const processedSortParam = sort
+    ? ({
+        fieldName: sort.split(':')[0],
+        dir: sort.split(':')[1]?.toUpperCase() || 'ASC',
+      } as SortType)
+    : null;
+
+  return {
+    query,
+    search,
+    // Conditionally adds the sort field based on whether it exists or not
+    ...(!!processedSortParam && { sort: processedSortParam }),
   };
 }
 

--- a/packages/teleport/src/services/databases/databases.test.ts
+++ b/packages/teleport/src/services/databases/databases.test.ts
@@ -30,7 +30,7 @@ test('correct formatting of database fetch response', async () => {
       {
         name: 'aurora',
         description: 'PostgreSQL 11.6: AWS Aurora',
-        title: 'RDS PostgreSQL',
+        type: 'RDS PostgreSQL',
         protocol: 'postgres',
         labels: [
           { name: 'cluster', value: 'root' },
@@ -80,7 +80,7 @@ describe('correct formatting of all type and protocol combos', () => {
         search: 'does-not-matter',
       });
 
-      expect(response.databases[0].title).toBe(combined);
+      expect(response.databases[0].type).toBe(combined);
     }
   );
 });

--- a/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/packages/teleport/src/services/databases/makeDatabase.ts
@@ -24,7 +24,7 @@ export default function makeDatabase(json): Database {
   return {
     name,
     description: desc,
-    title: formatDatabaseInfo(type, protocol).title,
+    type: formatDatabaseInfo(type, protocol).title,
     protocol,
     labels,
   };

--- a/packages/teleport/src/services/databases/types.ts
+++ b/packages/teleport/src/services/databases/types.ts
@@ -19,7 +19,7 @@ import { AgentLabel } from 'teleport/services/resources';
 export interface Database {
   name: string;
   description: string;
-  title: string;
+  type: string;
   protocol: DbProtocol;
   labels: AgentLabel[];
 }


### PR DESCRIPTION
## Purpose

Makes tables for Nodes, Apps, Kubes, DB's and Desktops initially sorted for a better user experience.

Adds ability to sort by `type` for Databases.
