### PR TITLE
Add tooltips with keyboard shortcuts

### DIFF
--- a/packages/teleterm/src/ui/Documents/KeyboardShortcutsPanel.tsx
+++ b/packages/teleterm/src/ui/Documents/KeyboardShortcutsPanel.tsx
@@ -1,34 +1,33 @@
 import React from 'react';
 import { Text } from 'design';
 import Document from 'teleterm/ui/Document';
-import { useAppContext } from 'teleterm/ui/appContextProvider';
 import styled from 'styled-components';
-import { Platform } from 'teleterm/mainProcess/types';
+import { useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
+import { KeyboardShortcutType } from 'teleterm/services/config';
 
 export function KeyboardShortcutsPanel() {
-  const ctx = useAppContext();
-  const { keyboardShortcuts } = ctx.mainProcessClient.configService.get();
+  const { getShortcut } = useKeyboardShortcutFormatters();
 
-  const items = [
+  const items: { title: string; shortcutKey: KeyboardShortcutType }[] = [
     {
       title: 'Open New Tab',
-      shortcut: keyboardShortcuts['tab-new'],
+      shortcutKey: 'tab-new',
     },
     {
       title: 'Go To Next Tab',
-      shortcut: keyboardShortcuts['tab-next'],
+      shortcutKey: 'tab-next',
     },
     {
       title: 'Open Connections',
-      shortcut: keyboardShortcuts['toggle-connections'],
+      shortcutKey: 'toggle-connections',
     },
     {
       title: 'Open Clusters',
-      shortcut: keyboardShortcuts['toggle-clusters'],
+      shortcutKey: 'toggle-clusters',
     },
     {
       title: 'Open Profile',
-      shortcut: keyboardShortcuts['toggle-identity'],
+      shortcutKey: 'toggle-identity',
     },
   ];
 
@@ -38,11 +37,10 @@ export function KeyboardShortcutsPanel() {
         {items.map(item => (
           <Entry
             title={item.title}
-            shortcut={displayShortcut(
-              ctx.mainProcessClient.getRuntimeSettings().platform,
-              item.shortcut
-            )}
-            key={item.shortcut}
+            shortcut={getShortcut(item.shortcutKey, {
+              useWhitespaceSeparator: true,
+            })}
+            key={item.shortcutKey}
           />
         ))}
       </Grid>
@@ -61,20 +59,6 @@ function Entry(props: { title: string; shortcut: string }) {
       </MonoText>
     </>
   );
-}
-
-function displayShortcut(platform: Platform, shortcut: string): string {
-  switch (platform) {
-    case 'darwin':
-      return shortcut
-        .replace('-', ' ')
-        .replace('Command', '⌘')
-        .replace('Control', '⌃')
-        .replace('Option', '⌥')
-        .replace('Shift', '⇧');
-    case 'linux':
-      return shortcut.replace('-', ' + ');
-  }
 }
 
 const MonoText = styled(Text)`

--- a/packages/teleterm/src/ui/Documents/KeyboardShortcutsPanel.tsx
+++ b/packages/teleterm/src/ui/Documents/KeyboardShortcutsPanel.tsx
@@ -26,7 +26,7 @@ export function KeyboardShortcutsPanel() {
       shortcutKey: 'toggle-clusters',
     },
     {
-      title: 'Open Profile',
+      title: 'Open Profiles',
       shortcutKey: 'toggle-identity',
     },
   ];

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
@@ -225,8 +225,8 @@ const Shortcut = styled(Box)`
   right: 12px;
   top: 12px;
   padding: 2px 3px;
-  color: rgba(255, 255, 255, 0.6);
-  background-color: rgba(255, 255, 255, 0.05);
+  color: ${({ theme }) => theme.colors.text.secondary};
+  background-color: ${({ theme }) => theme.colors.primary.light};
   line-height: 12px;
   font-size: 12px;
   border-radius: 2px;

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { debounce } from 'lodash';
-import { Flex } from 'design';
+import { Box, Flex } from 'design';
 import { color, height, space, width } from 'styled-system';
 import useQuickInput from './useQuickInput';
 import QuickInputList from './QuickInputList';
@@ -160,6 +160,7 @@ function QuickInput() {
         onKeyDown={handleKeyDown}
         isOpened={visible}
       />
+      {!visible && <Shortcut>{props.keyboardShortcut}</Shortcut>}
       {visible && hasSuggestions && (
         <QuickInputList
           ref={refList}
@@ -196,7 +197,7 @@ const Input = styled.input(props => {
     border: `0.5px ${theme.colors.action.disabledBackground} solid`,
     borderRadius: '4px',
     outline: 'none',
-    padding: '2px 8px',
+    padding: props.isOpened ? '2px 8px' : '2px 46px 2px 8px', // wider right margin makes place for a shortcut
     '::placeholder': {
       color: theme.colors.text.secondary,
     },
@@ -218,6 +219,18 @@ const Input = styled.input(props => {
     ...color(props),
   };
 });
+
+const Shortcut = styled(Box)`
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  padding: 2px 3px;
+  color: rgba(255, 255, 255, 0.6);
+  background-color: rgba(255, 255, 255, 0.05);
+  line-height: 12px;
+  font-size: 12px;
+  border-radius: 2px;
+`;
 
 const KeyEnum = {
   BACKSPACE: 8,

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -16,7 +16,10 @@ limitations under the License.
 
 import React, { useEffect } from 'react';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
-import { useKeyboardShortcuts, useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
+import {
+  useKeyboardShortcuts,
+  useKeyboardShortcutFormatters,
+} from 'teleterm/ui/services/keyboardShortcuts';
 import {
   AutocompleteResult,
   AutocompletePartialMatch,
@@ -25,11 +28,8 @@ import { routing } from 'teleterm/ui/uri';
 import { KeyboardShortcutType } from 'teleterm/services/config';
 
 export default function useQuickInput() {
-  const {
-    quickInputService,
-    workspacesService,
-    commandLauncher,
-  } = useAppContext();
+  const { quickInputService, workspacesService, commandLauncher } =
+    useAppContext();
   workspacesService.useState();
   const documentsService =
     workspacesService.getActiveWorkspaceDocumentService();

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -16,16 +16,20 @@ limitations under the License.
 
 import React, { useEffect } from 'react';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
-import { useKeyboardShortcuts } from 'teleterm/ui/services/keyboardShortcuts';
+import { useKeyboardShortcuts, useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
 import {
   AutocompleteResult,
   AutocompletePartialMatch,
 } from 'teleterm/ui/services/quickInput/types';
 import { routing } from 'teleterm/ui/uri';
+import { KeyboardShortcutType } from 'teleterm/services/config';
 
 export default function useQuickInput() {
-  const { quickInputService, workspacesService, commandLauncher } =
-    useAppContext();
+  const {
+    quickInputService,
+    workspacesService,
+    commandLauncher,
+  } = useAppContext();
   workspacesService.useState();
   const documentsService =
     workspacesService.getActiveWorkspaceDocumentService();
@@ -39,6 +43,8 @@ export default function useQuickInput() {
   );
   const hasSuggestions =
     autocompleteResult.kind === 'autocomplete.partial-match';
+  const openQuickInputShortcutKey: KeyboardShortcutType = 'open-quick-input';
+  const { getShortcut } = useKeyboardShortcutFormatters();
 
   const onFocus = (e: any) => {
     if (e.relatedTarget) {
@@ -66,7 +72,6 @@ export default function useQuickInput() {
 
   const executeCommand = (autocompleteResult: AutocompleteResult) => {
     const { command } = autocompleteResult;
-
 
     switch (command.kind) {
       case 'command.unknown': {
@@ -122,7 +127,7 @@ export default function useQuickInput() {
   };
 
   useKeyboardShortcuts({
-    'open-quick-input': () => {
+    [openQuickInputShortcutKey]: () => {
       quickInputService.show();
     },
   });
@@ -151,6 +156,7 @@ export default function useQuickInput() {
     onInputChange: quickInputService.setInputValue,
     onHide: quickInputService.hide,
     onShow: quickInputService.show,
+    keyboardShortcut: getShortcut(openQuickInputShortcutKey),
   };
 }
 

--- a/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -11,10 +11,12 @@ import {
 import { KeyboardShortcutsService } from 'teleterm/ui/services/keyboardShortcuts';
 import {
   MainProcessClient,
+  RuntimeSettings,
   TabContextMenuOptions,
 } from 'teleterm/mainProcess/types';
 import { ClustersService } from 'teleterm/ui/services/clusters';
 import AppContext from 'teleterm/ui/appContext';
+import { Config } from 'teleterm/services/config';
 
 function getMockDocuments(): Document[] {
   return [
@@ -39,6 +41,21 @@ function getTestSetup({ documents }: { documents: Document[] }) {
 
   const mainProcessClient: Partial<MainProcessClient> = {
     openTabContextMenu: jest.fn(),
+    getRuntimeSettings: () => ({} as RuntimeSettings),
+    configService: {
+      get: () =>
+        ({
+          keyboardShortcuts: {
+            'tab-close': 'Command-W',
+            'tab-new': 'Command-T',
+            'open-quick-input': 'Command-K',
+            'toggle-connections': 'Command-P',
+            'toggle-clusters': 'Command-E',
+            'toggle-identity': 'Command-I',
+          },
+        } as Config),
+      update() {},
+    },
   };
 
   const docsService: Partial<DocumentsService> = {
@@ -186,7 +203,7 @@ test('open new tab', () => {
     kind: 'doc.cluster',
   };
   docsService.createClusterDocument = () => mockedClusterDocument;
-  const $newTabButton = getByTitle('New Tab');
+  const $newTabButton = getByTitle('New Tab', { exact: false });
 
   fireEvent.click($newTabButton);
 

--- a/packages/teleterm/src/ui/TabHost/TabHost.tsx
+++ b/packages/teleterm/src/ui/TabHost/TabHost.tsx
@@ -25,6 +25,7 @@ import { DocumentsRenderer } from 'teleterm/ui/Documents';
 import { useNewTabOpener } from './useNewTabOpener';
 import { ClusterConnectPanel } from './ClusterConnectPanel/ClusterConnectPanel';
 import AppContext from 'teleterm/ui/appContext';
+import { useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
 
 export function TabHostContainer() {
   const ctx = useAppContext();
@@ -48,6 +49,7 @@ export function TabHost({ ctx }: { ctx: AppContext }) {
     localClusterUri:
       ctx.workspacesService.getActiveWorkspace()?.localClusterUri,
   });
+  const { getLabelWithShortcut } = useKeyboardShortcutFormatters();
 
   useTabShortcuts({
     documentsService,
@@ -104,6 +106,8 @@ export function TabHost({ ctx }: { ctx: AppContext }) {
           onMoved={handleTabMoved}
           disableNew={false}
           onNew={openClusterTab}
+          newTabTooltip={getLabelWithShortcut('New Tab', 'tab-new')}
+          closeTabTooltip={getLabelWithShortcut('Close', 'tab-close')}
         />
       </Flex>
       <DocumentsRenderer />

--- a/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -24,6 +24,7 @@ type TabItemProps = {
   index?: number;
   name?: string;
   active?: boolean;
+  closeTabTooltip?: string;
   onClick?(): void;
   onClose?(): void;
   onMoved?(oldIndex: number, newIndex: number): void;
@@ -31,8 +32,16 @@ type TabItemProps = {
 };
 
 export function TabItem(props: TabItemProps) {
-  const { name, active, onClick, onClose, index, onMoved, onContextMenu } =
-    props;
+  const {
+    name,
+    active,
+    onClick,
+    onClose,
+    index,
+    onMoved,
+    onContextMenu,
+    closeTabTooltip,
+  } = props;
   const ref = useRef<HTMLDivElement>(null);
   const canDrag = !!onMoved;
   const { isDragging } = useTabDnD({
@@ -64,7 +73,7 @@ export function TabItem(props: TabItemProps) {
         <ButtonIcon
           size={0}
           mr={1}
-          title="Close"
+          title={closeTabTooltip}
           css={`
             transition: none;
           `}

--- a/packages/teleterm/src/ui/Tabs/Tabs.tsx
+++ b/packages/teleterm/src/ui/Tabs/Tabs.tsx
@@ -32,6 +32,8 @@ export function Tabs(props: Props) {
     disableNew,
     onMoved,
     onContextMenu,
+    newTabTooltip,
+    closeTabTooltip,
     ...styledProps
   } = props;
 
@@ -55,6 +57,7 @@ export function Tabs(props: Props) {
               onClose={() => onClose(item)}
               onContextMenu={() => onContextMenu(item)}
               onMoved={onMoved}
+              closeTabTooltip={closeTabTooltip}
             />
             <Separator />
           </Fragment>
@@ -71,7 +74,7 @@ export function Tabs(props: Props) {
         size={0}
         color="light"
         disabled={disableNew}
-        title="New Tab"
+        title={newTabTooltip}
         onClick={onNew}
       >
         <Icons.Add fontSize="16px" />
@@ -84,6 +87,8 @@ type Props = {
   items: Document[];
   activeTab: string;
   disableNew: boolean;
+  newTabTooltip: string;
+  closeTabTooltip: string;
   onNew: () => void;
   onSelect: (doc: Document) => void;
   onContextMenu: (doc: Document) => void;

--- a/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
+++ b/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import { SortAsc, SortDesc } from 'design/Icon';
 import styled from 'styled-components';
 import { Text } from 'design';
+import { useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
 
 interface ClusterSelectorProps {
   clusterName?: string;
@@ -12,6 +13,7 @@ interface ClusterSelectorProps {
 
 export const ClusterSelector = forwardRef<HTMLDivElement, ClusterSelectorProps>(
   (props, ref) => {
+    const { getLabelWithShortcut } = useKeyboardShortcutFormatters();
     const SortIcon = props.isOpened ? SortAsc : SortDesc;
     const text = props.clusterName || 'Select Cluster';
     return (
@@ -20,9 +22,10 @@ export const ClusterSelector = forwardRef<HTMLDivElement, ClusterSelectorProps>(
         onClick={props.onClick}
         isOpened={props.isOpened}
         isClusterSelected={!!props.clusterName}
-        title={text}
+        title={getLabelWithShortcut('Open Clusters', 'toggle-clusters')}
       >
         <Text
+          title={text}
           css={`
             white-space: nowrap;
           `}

--- a/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
+++ b/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
@@ -16,16 +16,19 @@ export const ClusterSelector = forwardRef<HTMLDivElement, ClusterSelectorProps>(
     const { getLabelWithShortcut } = useKeyboardShortcutFormatters();
     const SortIcon = props.isOpened ? SortAsc : SortDesc;
     const text = props.clusterName || 'Select Cluster';
+
     return (
       <Container
         ref={ref}
         onClick={props.onClick}
         isOpened={props.isOpened}
         isClusterSelected={!!props.clusterName}
-        title={getLabelWithShortcut('Open Clusters', 'toggle-clusters')}
+        title={getLabelWithShortcut(
+          [props.clusterName, 'Open Clusters'].filter(Boolean).join('\n'),
+          'toggle-clusters'
+        )}
       >
         <Text
-          title={text}
           css={`
             white-space: nowrap;
           `}

--- a/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIcon.tsx
+++ b/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIcon.tsx
@@ -3,6 +3,7 @@ import { Cluster } from 'design/Icon';
 import styled from 'styled-components';
 import { Button } from 'design';
 import { ConnectionsIconStatusIndicator } from './ConnectionsIconStatusIndicator';
+import { useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
 
 interface ConnectionsIconProps {
   isAnyConnectionActive: boolean;
@@ -12,6 +13,7 @@ interface ConnectionsIconProps {
 
 export const ConnectionsIcon = forwardRef<HTMLDivElement, ConnectionsIconProps>(
   (props, ref) => {
+    const { getLabelWithShortcut } = useKeyboardShortcutFormatters();
     return (
       <Container ref={ref}>
         <ConnectionsIconStatusIndicator
@@ -22,7 +24,7 @@ export const ConnectionsIcon = forwardRef<HTMLDivElement, ConnectionsIconProps>(
           kind="secondary"
           size="small"
           m="auto"
-          title="Connections"
+          title={getLabelWithShortcut('Open Connections', 'toggle-connections')}
         >
           <Cluster fontSize={16} />
         </StyledButton>

--- a/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
+++ b/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from 'design';
 import styled from 'styled-components';
 import { UserIcon } from './UserIcon';
 import { PamIcon } from './PamIcon';
+import { useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
 
 interface IdentitySelectorProps {
   isOpened: boolean;
@@ -17,12 +18,18 @@ export const IdentitySelector = forwardRef<
   HTMLButtonElement,
   IdentitySelectorProps
 >((props, ref) => {
+  const { getLabelWithShortcut } = useKeyboardShortcutFormatters();
   const isSelected = props.userName && props.clusterName;
   const text = isSelected && `${props.userName}@${props.clusterName}`;
   const Icon = props.isOpened ? SortAsc : SortDesc;
 
   return (
-    <Container isOpened={props.isOpened} ref={ref} onClick={props.onClick}>
+    <Container
+      isOpened={props.isOpened}
+      ref={ref}
+      onClick={props.onClick}
+      title={getLabelWithShortcut('Open Profile', 'toggle-identity')}
+    >
       {isSelected ? (
         <>
           <Box mr={2}>

--- a/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
+++ b/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
@@ -20,7 +20,7 @@ export const IdentitySelector = forwardRef<
 >((props, ref) => {
   const { getLabelWithShortcut } = useKeyboardShortcutFormatters();
   const isSelected = props.userName && props.clusterName;
-  const text = isSelected && `${props.userName}@${props.clusterName}`;
+  const selectorText = isSelected && `${props.userName}@${props.clusterName}`;
   const Icon = props.isOpened ? SortAsc : SortDesc;
 
   return (
@@ -28,19 +28,18 @@ export const IdentitySelector = forwardRef<
       isOpened={props.isOpened}
       ref={ref}
       onClick={props.onClick}
-      title={getLabelWithShortcut('Open Profile', 'toggle-identity')}
+      title={getLabelWithShortcut(
+        [selectorText, 'Open Profiles'].filter(Boolean).join('\n'),
+        'toggle-identity'
+      )}
     >
       {isSelected ? (
         <>
           <Box mr={2}>
             <UserIcon letter={props.userName[0]} />
           </Box>
-          <Text
-            style={{ whiteSpace: 'nowrap' }}
-            typography="subtitle1"
-            title={text}
-          >
-            {text}
+          <Text style={{ whiteSpace: 'nowrap' }} typography="subtitle1">
+            {selectorText}
           </Text>
         </>
       ) : (

--- a/packages/teleterm/src/ui/services/keyboardShortcuts/index.ts
+++ b/packages/teleterm/src/ui/services/keyboardShortcuts/index.ts
@@ -1,3 +1,4 @@
 export * from './keyboardShortcutsService';
+export * from './useKeyboardShortcutFormatters';
 export * from './useKeyboardShortcuts';
 export * from './types';

--- a/packages/teleterm/src/ui/services/keyboardShortcuts/useKeyboardShortcutFormatters.ts
+++ b/packages/teleterm/src/ui/services/keyboardShortcuts/useKeyboardShortcutFormatters.ts
@@ -1,0 +1,65 @@
+import { KeyboardShortcutType } from '../../../services/config';
+import { useAppContext } from '../../appContextProvider';
+import { Platform } from '../../../mainProcess/types';
+
+interface KeyboardShortcutFormatters {
+  getLabelWithShortcut(
+    label: string,
+    shortcutKey: KeyboardShortcutType,
+    options?: KeyboardShortcutFormattingOptions
+  ): string;
+
+  getShortcut(
+    shortcutKey: KeyboardShortcutType,
+    options?: KeyboardShortcutFormattingOptions
+  ): string;
+}
+
+interface KeyboardShortcutFormattingOptions {
+  useWhitespaceSeparator?: boolean;
+}
+
+export function useKeyboardShortcutFormatters(): KeyboardShortcutFormatters {
+  const { mainProcessClient } = useAppContext();
+  const { platform } = mainProcessClient.getRuntimeSettings();
+  const { keyboardShortcuts } = mainProcessClient.configService.get();
+
+  return {
+    getLabelWithShortcut(label, shortcutKey, options) {
+      const formattedShortcut = formatKeyboardShortcut({
+        platform,
+        shortcutValue: keyboardShortcuts[shortcutKey],
+        ...options,
+      });
+      return `${label} (${formattedShortcut})`;
+    },
+    getShortcut(shortcutKey, options) {
+      return formatKeyboardShortcut({
+        platform,
+        shortcutValue: keyboardShortcuts[shortcutKey],
+        ...options,
+      });
+    },
+  };
+}
+
+function formatKeyboardShortcut(options: {
+  platform: Platform;
+  shortcutValue: string;
+  useWhitespaceSeparator?: boolean;
+}): string {
+  switch (options.platform) {
+    case 'darwin':
+      return options.shortcutValue
+        .replace('-', options.useWhitespaceSeparator ? ' ' : '')
+        .replace('Command', '⌘')
+        .replace('Control', '⌃')
+        .replace('Option', '⌥')
+        .replace('Shift', '⇧');
+    default:
+      return options.shortcutValue.replace(
+        '-',
+        options.useWhitespaceSeparator ? ' + ' : '+'
+      );
+  }
+}


### PR DESCRIPTION
Adds tooltips with format `Label (shortcut)` to:
- Connections 
- Cluster selector
- Identity selector
- Close tab icon
- New tab icon

Also, adds inline shortcut to Quick input:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/20583051/168808113-5de10143-3a9e-4584-86a9-99f9eb0e2def.png">

Closes: https://github.com/gravitational/webapps.e/issues/141
