### PR TITLE
Remove use of deprecated POST `/webapi/sessions` login endpoint

### DIFF
--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -113,6 +113,7 @@ const cfg = {
     renewTokenPath: '/v1/webapi/sessions/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
     sessionPath: '/v1/webapi/sessions',
+    webSessionPath: '/v1/webapi/sessions/web',
     userContextPath: '/v1/webapi/sites/:clusterId/context',
     userStatusPath: '/v1/webapi/user/status',
     passwordTokenPath: '/v1/webapi/users/password/token/:tokenId?',

--- a/packages/teleport/src/services/auth/auth.test.ts
+++ b/packages/teleport/src/services/auth/auth.test.ts
@@ -33,7 +33,7 @@ describe('services/auth', () => {
     jest.spyOn(api, 'post').mockResolvedValue({});
 
     await auth.login(email, password, '');
-    expect(api.post).toHaveBeenCalledWith(cfg.api.sessionPath, {
+    expect(api.post).toHaveBeenCalledWith(cfg.api.webSessionPath, {
       user: email,
       pass: password,
       second_factor_token: '',
@@ -49,7 +49,7 @@ describe('services/auth', () => {
     };
 
     await auth.login(email, password, 'xxx');
-    expect(api.post).toHaveBeenCalledWith(cfg.api.sessionPath, data);
+    expect(api.post).toHaveBeenCalledWith(cfg.api.webSessionPath, data);
   });
 
   test('resetPassword()', async () => {

--- a/packages/teleport/src/services/auth/auth.ts
+++ b/packages/teleport/src/services/auth/auth.ts
@@ -88,7 +88,7 @@ const auth = {
       second_factor_token: otpCode,
     };
 
-    return api.post(cfg.api.sessionPath, data);
+    return api.post(cfg.api.webSessionPath, data);
   },
 
   loginWithWebauthn(creds?: UserCredentials) {


### PR DESCRIPTION
As per https://github.com/gravitational/teleport/blob/master/lib/web/apiserver.go#L304 , POST `/webapi/sessions` has been migrated to POST `/webapi/sessions/web`.

