### PR TITLE
Prevent `restorePersistedState()` crash when there is no workspace for a cluster

### DIFF
--- a/packages/teleterm/src/ui/AppInitializer.tsx
+++ b/packages/teleterm/src/ui/AppInitializer.tsx
@@ -5,13 +5,19 @@ import styled from 'styled-components';
 
 export const AppInitializer: FC = props => {
   const ctx = useAppContext();
-  const [{ status }, init] = useAsync(() => ctx.init());
+  const [state, init] = useAsync(() => ctx.init());
 
   useEffect(() => {
     init();
   }, []);
 
-  if (status === 'success' || status === 'error') {
+  useEffect(() => {
+    if (state.status === 'error') {
+      ctx.notificationsService.notifyError(state.statusText);
+    }
+  }, [state]);
+
+  if (state.status === 'success' || state.status === 'error') {
     return <>{props.children}</>;
   }
 

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -62,7 +62,7 @@ describe('restoring workspace', () => {
     return { workspacesService, clusterDocument };
   }
 
-  it('should restore the workspace if it there is a persisted state for given clusterUri', () => {
+  it('restores the workspace if it there is a persisted state for given clusterUri', () => {
     const testClusterUri = '/clusters/test-uri';
     const testWorkspace: Workspace = {
       localClusterUri: testClusterUri,
@@ -95,7 +95,7 @@ describe('restoring workspace', () => {
     });
   });
 
-  it('should create empty workspace if there is no persisted state for given clusterUri', () => {
+  it('creates empty workspace if there is no persisted state for given clusterUri', () => {
     const testClusterUri = '/clusters/test-uri';
     const { workspacesService, clusterDocument } = getTestSetup({
       clusterUri: testClusterUri,

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -1,0 +1,115 @@
+import { Workspace, WorkspacesService } from './workspacesService';
+import { ClustersService } from '../clusters';
+import { StatePersistenceService } from '../statePersistence';
+
+describe('restoring workspace', () => {
+  function getTestSetup(options: {
+    clusterUri: string; // assumes that only one cluster can be added
+    persistedWorkspaces: Record<string, Workspace>;
+  }) {
+    const statePersistenceService: Partial<StatePersistenceService> = {
+      getWorkspacesState: () => ({
+        workspaces: options.persistedWorkspaces,
+      }),
+      saveWorkspacesState: jest.fn(),
+    };
+
+    const clustersService: Partial<ClustersService> = {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+      findRootClusterByResource: jest.fn(),
+      findCluster: jest.fn(),
+      findGateway: jest.fn(),
+      getClusters: () => [
+        {
+          uri: options.clusterUri,
+          name: 'Test cluster',
+          connected: true,
+          leaf: false,
+          proxyHost: 'test:3030',
+          actualName: 'Test cluster',
+          loggedInUser: {
+            name: 'Alice',
+            rolesList: [],
+            sshLoginsList: [],
+          },
+        },
+      ],
+    };
+
+    const clusterDocument = {
+      kind: 'doc.cluster',
+      title: 'Cluster Test',
+      clusterUri: options.clusterUri,
+      uri: 'docs/test-cluster-uri',
+    };
+
+    const workspacesService = new WorkspacesService(
+      undefined,
+      // @ts-expect-error using mocks
+      clustersService,
+      undefined,
+      statePersistenceService
+    );
+
+    workspacesService.getWorkspaceDocumentService = () => ({
+      // @ts-expect-error using mocks
+      createClusterDocument() {
+        return clusterDocument;
+      },
+    });
+
+    return { workspacesService, clusterDocument };
+  }
+
+  it('should restore the workspace if it there is a persisted state for given clusterUri', () => {
+    const testClusterUri = '/clusters/test-uri';
+    const testWorkspace: Workspace = {
+      localClusterUri: testClusterUri,
+      documents: [
+        {
+          kind: 'doc.terminal_shell',
+          uri: 'docs/some_uri',
+          title: '/Users/alice/Documents',
+        },
+      ],
+      location: 'docs/some_uri',
+    };
+
+    const { workspacesService, clusterDocument } = getTestSetup({
+      clusterUri: testClusterUri,
+      persistedWorkspaces: { [testClusterUri]: testWorkspace },
+    });
+
+    workspacesService.restorePersistedState();
+    expect(workspacesService.getWorkspaces()).toStrictEqual({
+      [testClusterUri]: {
+        localClusterUri: testWorkspace.localClusterUri,
+        documents: [clusterDocument],
+        location: clusterDocument.uri,
+        previous: {
+          documents: testWorkspace.documents,
+          location: testWorkspace.location,
+        },
+      },
+    });
+  });
+
+  it('should create empty workspace if there is no persisted state for given clusterUri', () => {
+    const testClusterUri = '/clusters/test-uri';
+    const { workspacesService, clusterDocument } = getTestSetup({
+      clusterUri: testClusterUri,
+      persistedWorkspaces: {},
+    });
+
+    workspacesService.restorePersistedState();
+    expect(workspacesService.getWorkspaces()).toStrictEqual({
+      [testClusterUri]: {
+        localClusterUri: testClusterUri,
+        documents: [clusterDocument],
+        location: clusterDocument.uri,
+        previous: undefined,
+      },
+    });
+  });
+});

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -200,7 +200,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
         const workspaceDefaultState = this.getWorkspaceDefaultState(
           persistedWorkspace?.localClusterUri || cluster.uri
         );
-        const persistedWorkspaceDocuments = persistedWorkspace.documents;
+        const persistedWorkspaceDocuments = persistedWorkspace?.documents;
 
         workspaces[cluster.uri] = {
           ...workspaceDefaultState,
@@ -246,7 +246,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     previousDocuments,
     currentDocuments,
   }: {
-    previousDocuments: Document[];
+    previousDocuments?: Document[];
     currentDocuments: Document[];
   }): boolean {
     const omitUriAndTitle = (documents: Document[]) =>


### PR DESCRIPTION
Closes https://github.com/gravitational/webapps.e/issues/275

Main reason of the problem:
`restorePersistedState()` starts iterating through the clusters and tries to restore a workspace for each of them, if it starts with the cluster which doesn't have a workspace it will crash on reading `persistedWorkspace.documents` and it won't restore anything.

Additionally, we couldn't spot the problem easily as we didn't show errors from the `init()` function anywhere.