### PR TITLE
Create agent type for resources

### DIFF
--- a/packages/design/src/DataTable/Cells.tsx
+++ b/packages/design/src/DataTable/Cells.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { Label } from 'design';
 import * as Icons from 'design/Icon';
 import { displayDate } from 'shared/services/loc';
-import { AgentLabel } from 'teleport/services/resources';
-import { ServersideProps, SortDir, TableColumn } from './types';
+import {
+  ServersideProps,
+  SortDir,
+  TableColumn,
+  LabelDescription,
+} from './types';
 
 export const Cell = props => <td children={props.children} {...props} />;
 
@@ -87,8 +91,8 @@ export const ClickableLabelCell = ({
   labels,
   onClick,
 }: {
-  labels: AgentLabel[];
-  onClick: (label: AgentLabel) => void;
+  labels: LabelDescription[];
+  onClick: (label: LabelDescription) => void;
 }) => {
   const $labels = labels.map(label => (
     <Label

--- a/packages/design/src/DataTable/types.ts
+++ b/packages/design/src/DataTable/types.ts
@@ -71,3 +71,8 @@ export type SortDir = 'ASC' | 'DESC';
 export type FetchStatus = 'loading' | 'disabled' | '';
 
 export type TableColumn<T> = TableColumnWithKey<T> | TableColumnWithAltKey<T>;
+
+export type LabelDescription = {
+  name: string;
+  value: string;
+};

--- a/packages/teleport/src/Apps/AppList/AppList.tsx
+++ b/packages/teleport/src/Apps/AppList/AppList.tsx
@@ -33,7 +33,7 @@ import {
 } from 'design/theme/palette';
 import { AmazonAws } from 'design/Icon';
 import { App } from 'teleport/services/apps';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 import ServersideSearchPanel from 'teleport/components/ServersideSearchPanel';
 import { ResourceUrlQueryParams } from 'teleport/getUrlQueryParams';
 import AwsLaunchButton from './AwsLaunchButton';

--- a/packages/teleport/src/Apps/useApps.ts
+++ b/packages/teleport/src/Apps/useApps.ts
@@ -18,7 +18,7 @@ import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router';
 import { FetchStatus, SortType } from 'design/DataTable/types';
 import useAttempt from 'shared/hooks/useAttemptNext';
-import { AppsResponse } from 'teleport/services/apps';
+import { AppsResponse, App } from 'teleport/services/apps';
 import history from 'teleport/services/history';
 import Ctx from 'teleport/teleportContext';
 import getResourceUrlQueryParams, {
@@ -26,7 +26,7 @@ import getResourceUrlQueryParams, {
 } from 'teleport/getUrlQueryParams';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import labelClick from 'teleport/labelClick';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export default function useApps(ctx: Ctx) {
   const canCreate = ctx.storeUser.getTokenAccess().create;
@@ -82,7 +82,11 @@ export default function useApps(ctx: Ctx) {
     ctx.appService
       .fetchApps(clusterId, { ...params, limit: pageSize })
       .then(res => {
-        setResults(res);
+        setResults({
+          apps: res.agents as App[],
+          startKey: res.startKey,
+          totalCount: res.totalCount,
+        });
         setFetchStatus(res.startKey ? '' : 'disabled');
         setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
@@ -105,7 +109,7 @@ export default function useApps(ctx: Ctx) {
       .then(res => {
         setResults({
           ...results,
-          apps: res.apps,
+          apps: res.agents as App[],
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -130,7 +134,7 @@ export default function useApps(ctx: Ctx) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          apps: res.apps,
+          apps: res.agents as App[],
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Apps/useApps.ts
+++ b/packages/teleport/src/Apps/useApps.ts
@@ -18,7 +18,7 @@ import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router';
 import { FetchStatus, SortType } from 'design/DataTable/types';
 import useAttempt from 'shared/hooks/useAttemptNext';
-import { AppsResponse, App } from 'teleport/services/apps';
+import { AppsResponse } from 'teleport/services/apps';
 import history from 'teleport/services/history';
 import Ctx from 'teleport/teleportContext';
 import getResourceUrlQueryParams, {
@@ -83,7 +83,7 @@ export default function useApps(ctx: Ctx) {
       .fetchApps(clusterId, { ...params, limit: pageSize })
       .then(res => {
         setResults({
-          apps: res.agents as App[],
+          apps: res.agents,
           startKey: res.startKey,
           totalCount: res.totalCount,
         });
@@ -109,7 +109,7 @@ export default function useApps(ctx: Ctx) {
       .then(res => {
         setResults({
           ...results,
-          apps: res.agents as App[],
+          apps: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -134,7 +134,7 @@ export default function useApps(ctx: Ctx) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          apps: res.agents as App[],
+          apps: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -63,7 +63,7 @@ export function createContext() {
   ctx.fetchNodes = () => {
     return Promise.resolve({
       logins: ['root'],
-      nodesRes: { nodes, totalCount: nodes.length },
+      nodesRes: { agents: nodes, totalCount: nodes.length },
     });
   };
 

--- a/packages/teleport/src/Console/DocumentNodes/useNodes.ts
+++ b/packages/teleport/src/Console/DocumentNodes/useNodes.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Gravitational, Inc.
+Copyright 2019-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@ import { useLocation } from 'react-router';
 import { FetchStatus, SortType } from 'design/DataTable/types';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import history from 'teleport/services/history';
-import { NodesResponse } from 'teleport/services/nodes';
+import { NodesResponse, Node } from 'teleport/services/nodes';
 import getResourceUrlQueryParams, {
   ResourceUrlQueryParams,
 } from 'teleport/getUrlQueryParams';
 import { useConsoleContext } from './../consoleContextProvider';
 import * as stores from './../stores';
 import labelClick from 'teleport/labelClick';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
   const consoleCtx = useConsoleContext();
@@ -69,7 +69,12 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
     consoleCtx
       .fetchNodes(clusterId, { ...params, limit: pageSize })
       .then(({ logins, nodesRes }) => {
-        setResults({ logins, ...nodesRes });
+        setResults({
+          logins,
+          nodes: nodesRes.agents as Node[],
+          startKey: nodesRes.startKey,
+          totalCount: nodesRes.totalCount,
+        });
         setFetchStatus(nodesRes.startKey ? '' : 'disabled');
         setStartKeys(['', nodesRes.startKey]);
         setAttempt({ status: 'success' });
@@ -93,7 +98,7 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
         setResults({
           logins,
           ...results,
-          nodes: nodesRes.nodes,
+          nodes: nodesRes.agents as Node[],
           startKey: nodesRes.startKey,
         });
         setFetchStatus(nodesRes.startKey ? '' : 'disabled');
@@ -116,7 +121,7 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
         setResults({
           logins,
           ...results,
-          nodes: nodesRes.nodes,
+          nodes: nodesRes.agents as Node[],
           startKey: nodesRes.startKey,
         });
         const tempStartKeys = startKeys;

--- a/packages/teleport/src/Console/DocumentNodes/useNodes.ts
+++ b/packages/teleport/src/Console/DocumentNodes/useNodes.ts
@@ -19,7 +19,7 @@ import { useLocation } from 'react-router';
 import { FetchStatus, SortType } from 'design/DataTable/types';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import history from 'teleport/services/history';
-import { NodesResponse, Node } from 'teleport/services/nodes';
+import { NodesResponse } from 'teleport/services/nodes';
 import getResourceUrlQueryParams, {
   ResourceUrlQueryParams,
 } from 'teleport/getUrlQueryParams';
@@ -71,7 +71,7 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
       .then(({ logins, nodesRes }) => {
         setResults({
           logins,
-          nodes: nodesRes.agents as Node[],
+          nodes: nodesRes.agents,
           startKey: nodesRes.startKey,
           totalCount: nodesRes.totalCount,
         });
@@ -98,7 +98,7 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
         setResults({
           logins,
           ...results,
-          nodes: nodesRes.agents as Node[],
+          nodes: nodesRes.agents,
           startKey: nodesRes.startKey,
         });
         setFetchStatus(nodesRes.startKey ? '' : 'disabled');
@@ -121,7 +121,7 @@ export default function useNodes({ clusterId, id }: stores.DocumentNodes) {
         setResults({
           logins,
           ...results,
-          nodes: nodesRes.agents as Node[],
+          nodes: nodesRes.agents,
           startKey: nodesRes.startKey,
         });
         const tempStartKeys = startKeys;

--- a/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
+++ b/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
@@ -20,7 +20,7 @@ import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import { AuthType } from 'teleport/services/user';
 import { Database, DbProtocol } from 'teleport/services/databases';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 import ConnectDialog from 'teleport/Databases/ConnectDialog';
 import ServersideSearchPanel from 'teleport/components/ServersideSearchPanel';
 import { ResourceUrlQueryParams } from 'teleport/getUrlQueryParams';

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -24,9 +24,9 @@ import getResourceUrlQueryParams, {
 } from 'teleport/getUrlQueryParams';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import history from 'teleport/services/history';
-import { DatabasesResponse } from 'teleport/services/databases';
+import { DatabasesResponse, Database } from 'teleport/services/databases';
 import labelClick from 'teleport/labelClick';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export default function useDatabases(ctx: Ctx) {
   const { search, pathname } = useLocation();
@@ -76,7 +76,11 @@ export default function useDatabases(ctx: Ctx) {
     ctx.databaseService
       .fetchDatabases(clusterId, { ...params, limit: pageSize })
       .then(res => {
-        setResults(res);
+        setResults({
+          databases: res.agents as Database[],
+          startKey: res.startKey,
+          totalCount: res.totalCount,
+        });
         setFetchStatus(res.startKey ? '' : 'disabled');
         setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
@@ -99,7 +103,7 @@ export default function useDatabases(ctx: Ctx) {
       .then(res => {
         setResults({
           ...results,
-          databases: res.databases,
+          databases: res.agents as Database[],
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -124,7 +128,7 @@ export default function useDatabases(ctx: Ctx) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          databases: res.databases,
+          databases: res.agents as Database[],
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Databases/useDatabases.ts
+++ b/packages/teleport/src/Databases/useDatabases.ts
@@ -24,7 +24,7 @@ import getResourceUrlQueryParams, {
 } from 'teleport/getUrlQueryParams';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import history from 'teleport/services/history';
-import { DatabasesResponse, Database } from 'teleport/services/databases';
+import { DatabasesResponse } from 'teleport/services/databases';
 import labelClick from 'teleport/labelClick';
 import { AgentLabel } from 'teleport/services/agents';
 
@@ -77,7 +77,7 @@ export default function useDatabases(ctx: Ctx) {
       .fetchDatabases(clusterId, { ...params, limit: pageSize })
       .then(res => {
         setResults({
-          databases: res.agents as Database[],
+          databases: res.agents,
           startKey: res.startKey,
           totalCount: res.totalCount,
         });
@@ -103,7 +103,7 @@ export default function useDatabases(ctx: Ctx) {
       .then(res => {
         setResults({
           ...results,
-          databases: res.agents as Database[],
+          databases: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -128,7 +128,7 @@ export default function useDatabases(ctx: Ctx) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          databases: res.agents as Database[],
+          databases: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
+++ b/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import { Desktop } from 'teleport/services/desktops';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 import { LoginItem, MenuLogin } from 'shared/components/MenuLogin';
 import ServersideSearchPanel from 'teleport/components/ServersideSearchPanel';
 import { ResourceUrlQueryParams } from 'teleport/getUrlQueryParams';

--- a/packages/teleport/src/Desktops/useDesktops.ts
+++ b/packages/teleport/src/Desktops/useDesktops.ts
@@ -22,13 +22,13 @@ import Ctx from 'teleport/teleportContext';
 import cfg from 'teleport/config';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import history from 'teleport/services/history';
-import { DesktopsResponse } from 'teleport/services/desktops';
+import { DesktopsResponse, Desktop } from 'teleport/services/desktops';
 import getResourceUrlQueryParams, {
   ResourceUrlQueryParams,
 } from 'teleport/getUrlQueryParams';
 import { openNewTab } from 'teleport/lib/util';
 import labelClick from 'teleport/labelClick';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export default function useDesktops(ctx: Ctx) {
   const { attempt, setAttempt } = useAttempt('processing');
@@ -88,7 +88,11 @@ export default function useDesktops(ctx: Ctx) {
     ctx.desktopService
       .fetchDesktops(clusterId, { ...params, limit: pageSize })
       .then(res => {
-        setResults(res);
+        setResults({
+          desktops: res.agents as Desktop[],
+          startKey: res.startKey,
+          totalCount: res.totalCount,
+        });
         setFetchStatus(res.startKey ? '' : 'disabled');
         setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
@@ -111,7 +115,7 @@ export default function useDesktops(ctx: Ctx) {
       .then(res => {
         setResults({
           ...results,
-          desktops: res.desktops,
+          desktops: res.agents as Desktop[],
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -136,7 +140,7 @@ export default function useDesktops(ctx: Ctx) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          desktops: res.desktops,
+          desktops: res.agents as Desktop[],
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Desktops/useDesktops.ts
+++ b/packages/teleport/src/Desktops/useDesktops.ts
@@ -22,7 +22,7 @@ import Ctx from 'teleport/teleportContext';
 import cfg from 'teleport/config';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import history from 'teleport/services/history';
-import { DesktopsResponse, Desktop } from 'teleport/services/desktops';
+import { DesktopsResponse } from 'teleport/services/desktops';
 import getResourceUrlQueryParams, {
   ResourceUrlQueryParams,
 } from 'teleport/getUrlQueryParams';
@@ -89,7 +89,7 @@ export default function useDesktops(ctx: Ctx) {
       .fetchDesktops(clusterId, { ...params, limit: pageSize })
       .then(res => {
         setResults({
-          desktops: res.agents as Desktop[],
+          desktops: res.agents,
           startKey: res.startKey,
           totalCount: res.totalCount,
         });
@@ -115,7 +115,7 @@ export default function useDesktops(ctx: Ctx) {
       .then(res => {
         setResults({
           ...results,
-          desktops: res.agents as Desktop[],
+          desktops: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -140,7 +140,7 @@ export default function useDesktops(ctx: Ctx) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          desktops: res.agents as Desktop[],
+          desktops: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Kubes/KubeList/KubeList.tsx
+++ b/packages/teleport/src/Kubes/KubeList/KubeList.tsx
@@ -20,7 +20,7 @@ import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import { Kube } from 'teleport/services/kube';
 import { AuthType } from 'teleport/services/user';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 import ServersideSearchPanel from 'teleport/components/ServersideSearchPanel';
 import { ResourceUrlQueryParams } from 'teleport/getUrlQueryParams';
 import ConnectDialog from '../ConnectDialog';

--- a/packages/teleport/src/Kubes/useKubes.ts
+++ b/packages/teleport/src/Kubes/useKubes.ts
@@ -19,14 +19,14 @@ import { useLocation } from 'react-router';
 import { FetchStatus, SortType } from 'design/DataTable/types';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import history from 'teleport/services/history';
-import { KubesResponse } from 'teleport/services/kube';
+import { KubesResponse, Kube } from 'teleport/services/kube';
 import TeleportContext from 'teleport/teleportContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import getResourceUrlQueryParams, {
   ResourceUrlQueryParams,
 } from 'teleport/getUrlQueryParams';
 import labelClick from 'teleport/labelClick';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export default function useKubes(ctx: TeleportContext) {
   const { clusterId, isLeafCluster } = useStickyClusterId();
@@ -72,7 +72,11 @@ export default function useKubes(ctx: TeleportContext) {
     ctx.kubeService
       .fetchKubernetes(clusterId, { ...params, limit: pageSize })
       .then(res => {
-        setResults(res);
+        setResults({
+          kubes: res.agents as Kube[],
+          startKey: res.startKey,
+          totalCount: res.totalCount,
+        });
         setFetchStatus(res.startKey ? '' : 'disabled');
         setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
@@ -95,7 +99,7 @@ export default function useKubes(ctx: TeleportContext) {
       .then(res => {
         setResults({
           ...results,
-          kubes: res.kubes,
+          kubes: res.agents as Kube[],
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -120,7 +124,7 @@ export default function useKubes(ctx: TeleportContext) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          kubes: res.kubes,
+          kubes: res.agents as Kube[],
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Kubes/useKubes.ts
+++ b/packages/teleport/src/Kubes/useKubes.ts
@@ -19,7 +19,7 @@ import { useLocation } from 'react-router';
 import { FetchStatus, SortType } from 'design/DataTable/types';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import history from 'teleport/services/history';
-import { KubesResponse, Kube } from 'teleport/services/kube';
+import { KubesResponse } from 'teleport/services/kube';
 import TeleportContext from 'teleport/teleportContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 import getResourceUrlQueryParams, {
@@ -73,7 +73,7 @@ export default function useKubes(ctx: TeleportContext) {
       .fetchKubernetes(clusterId, { ...params, limit: pageSize })
       .then(res => {
         setResults({
-          kubes: res.agents as Kube[],
+          kubes: res.agents,
           startKey: res.startKey,
           totalCount: res.totalCount,
         });
@@ -99,7 +99,7 @@ export default function useKubes(ctx: TeleportContext) {
       .then(res => {
         setResults({
           ...results,
-          kubes: res.agents as Kube[],
+          kubes: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -124,7 +124,7 @@ export default function useKubes(ctx: TeleportContext) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          kubes: res.agents as Kube[],
+          kubes: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Main/Main.story.tsx
+++ b/packages/teleport/src/Main/Main.story.tsx
@@ -64,12 +64,14 @@ function useMainStory() {
     ctx.auditService.fetchEvents = () =>
       Promise.resolve({ events, startKey: '' });
     ctx.clusterService.fetchClusters = () => Promise.resolve(clusters);
-    ctx.nodeService.fetchNodes = () => Promise.resolve({ nodes });
+    ctx.nodeService.fetchNodes = () => Promise.resolve({ agents: nodes });
     ctx.sshService.fetchSessions = () => Promise.resolve(sessions);
-    ctx.appService.fetchApps = () => Promise.resolve({ apps });
-    ctx.kubeService.fetchKubernetes = () => Promise.resolve({ kubes });
-    ctx.databaseService.fetchDatabases = () => Promise.resolve({ databases });
-    ctx.desktopService.fetchDesktops = () => Promise.resolve({ desktops });
+    ctx.appService.fetchApps = () => Promise.resolve({ agents: apps });
+    ctx.kubeService.fetchKubernetes = () => Promise.resolve({ agents: kubes });
+    ctx.databaseService.fetchDatabases = () =>
+      Promise.resolve({ agents: databases });
+    ctx.desktopService.fetchDesktops = () =>
+      Promise.resolve({ agents: desktops });
     ctx.storeUser.setState(userContext);
     getFeatures().forEach(f => f.register(ctx));
     return ctx;

--- a/packages/teleport/src/Nodes/useNodes.ts
+++ b/packages/teleport/src/Nodes/useNodes.ts
@@ -22,13 +22,13 @@ import history from 'teleport/services/history';
 import Ctx from 'teleport/teleportContext';
 import { StickyCluster } from 'teleport/types';
 import cfg from 'teleport/config';
-import { NodesResponse } from 'teleport/services/nodes';
+import { NodesResponse, Node } from 'teleport/services/nodes';
 import { openNewTab } from 'teleport/lib/util';
 import getResourceUrlQueryParams, {
   ResourceUrlQueryParams,
 } from 'teleport/getUrlQueryParams';
 import labelClick from 'teleport/labelClick';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
   const { isLeafCluster, clusterId } = stickyCluster;
@@ -89,7 +89,11 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
     ctx.nodeService
       .fetchNodes(clusterId, { ...params, limit: pageSize })
       .then(res => {
-        setResults(res);
+        setResults({
+          nodes: res.agents as Node[],
+          startKey: res.startKey,
+          totalCount: res.totalCount,
+        });
         setFetchStatus(res.startKey ? '' : 'disabled');
         setStartKeys(['', res.startKey]);
         setAttempt({ status: 'success' });
@@ -112,7 +116,7 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
       .then(res => {
         setResults({
           ...results,
-          nodes: res.nodes,
+          nodes: res.agents as Node[],
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -137,7 +141,7 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          nodes: res.nodes,
+          nodes: res.agents as Node[],
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/Nodes/useNodes.ts
+++ b/packages/teleport/src/Nodes/useNodes.ts
@@ -22,7 +22,7 @@ import history from 'teleport/services/history';
 import Ctx from 'teleport/teleportContext';
 import { StickyCluster } from 'teleport/types';
 import cfg from 'teleport/config';
-import { NodesResponse, Node } from 'teleport/services/nodes';
+import { NodesResponse } from 'teleport/services/nodes';
 import { openNewTab } from 'teleport/lib/util';
 import getResourceUrlQueryParams, {
   ResourceUrlQueryParams,
@@ -90,7 +90,7 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
       .fetchNodes(clusterId, { ...params, limit: pageSize })
       .then(res => {
         setResults({
-          nodes: res.agents as Node[],
+          nodes: res.agents,
           startKey: res.startKey,
           totalCount: res.totalCount,
         });
@@ -116,7 +116,7 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
       .then(res => {
         setResults({
           ...results,
-          nodes: res.agents as Node[],
+          nodes: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus(res.startKey ? '' : 'disabled');
@@ -141,7 +141,7 @@ export default function useNodes(ctx: Ctx, stickyCluster: StickyCluster) {
         setStartKeys(tempStartKeys);
         setResults({
           ...results,
-          nodes: res.agents as Node[],
+          nodes: res.agents,
           startKey: res.startKey,
         });
         setFetchStatus('');

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -19,7 +19,7 @@ import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import { LoginItem, MenuLogin } from 'shared/components/MenuLogin';
 import { Node } from 'teleport/services/nodes';
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 import ServersideSearchPanel from 'teleport/components/ServersideSearchPanel';
 import { ResourceUrlQueryParams } from 'teleport/getUrlQueryParams';
 

--- a/packages/teleport/src/labelClick.ts
+++ b/packages/teleport/src/labelClick.ts
@@ -1,4 +1,4 @@
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 import { ResourceUrlQueryParams } from './getUrlQueryParams';
 import encodeUrlQueryParams from './encodeUrlQueryParams';
 

--- a/packages/teleport/src/services/agents/index.ts
+++ b/packages/teleport/src/services/agents/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Gravitational, Inc.
+ * Copyright 2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,4 @@
  * limitations under the License.
  */
 
-export type Resource<T extends Kind> = {
-  id: string;
-  kind: T;
-  name: string;
-  // content is config in yaml format.
-  content: string;
-};
-
-export type KindRole = 'role';
-export type KindTrustedCluster = 'trusted_cluster';
-export type KindAuthConnectors = 'github' | 'saml' | 'oidc';
-export type Kind = KindRole | KindTrustedCluster | KindAuthConnectors;
+export * from './types';

--- a/packages/teleport/src/services/agents/types.ts
+++ b/packages/teleport/src/services/agents/types.ts
@@ -20,9 +20,9 @@ import { Node } from 'teleport/services/nodes';
 import { Kube } from 'teleport/services/kube';
 import { Desktop } from 'teleport/services/desktops';
 
-export type AgentKinds = App | Database | Node | Kube | Desktop;
+export type AgentKind = App | Database | Node | Kube | Desktop;
 
-export type AgentResponse<T extends AgentKinds> = {
+export type AgentResponse<T extends AgentKind> = {
   agents: T[];
   startKey?: string;
   totalCount?: number;

--- a/packages/teleport/src/services/agents/types.ts
+++ b/packages/teleport/src/services/agents/types.ts
@@ -22,8 +22,8 @@ import { Desktop } from 'teleport/services/desktops';
 
 export type AgentKinds = App | Database | Node | Kube | Desktop;
 
-export type AgentResponse = {
-  agents: AgentKinds[];
+export type AgentResponse<T extends AgentKinds> = {
+  agents: T[];
   startKey?: string;
   totalCount?: number;
 };

--- a/packages/teleport/src/services/agents/types.ts
+++ b/packages/teleport/src/services/agents/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { App } from 'teleport/services/apps';
+import { Database } from 'teleport/services/databases';
+import { Node } from 'teleport/services/nodes';
+import { Kube } from 'teleport/services/kube';
+import { Desktop } from 'teleport/services/desktops';
+
+export type AgentKinds = App | Database | Node | Kube | Desktop;
+
+export type AgentResponse = {
+  agents: AgentKinds[];
+  startKey?: string;
+  totalCount?: number;
+};
+
+export type AgentLabel = {
+  name: string;
+  value: string;
+};
+
+export type AgentFilter = {
+  // query is query expression using the predicate language.
+  query?: string;
+  // search contains search words/phrases separated by space.
+  search?: string;
+  sort?: SortType;
+  limit?: number;
+  startKey?: string;
+};
+
+export type SortType = {
+  fieldName: string;
+  dir: SortDir;
+};
+
+export type SortDir = 'ASC' | 'DESC';

--- a/packages/teleport/src/services/apps/apps.test.ts
+++ b/packages/teleport/src/services/apps/apps.test.ts
@@ -24,7 +24,7 @@ test('correct formatting of apps fetch response', async () => {
   });
 
   expect(response).toEqual({
-    apps: [
+    agents: [
       {
         id: 'cluster-id-app-name-app-name.example.com',
         name: 'app-name',
@@ -53,7 +53,7 @@ test('null response from apps fetch', async () => {
   });
 
   expect(response).toEqual({
-    apps: [],
+    agents: [],
     startKey: undefined,
     totalCount: undefined,
   });
@@ -65,7 +65,7 @@ test('null labels field in apps fetch response', async () => {
     search: 'does-not-matter',
   });
 
-  expect(response.apps[0].labels).toEqual([]);
+  expect(response.agents[0].labels).toEqual([]);
 });
 
 const mockResponse = {

--- a/packages/teleport/src/services/apps/apps.ts
+++ b/packages/teleport/src/services/apps/apps.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Gravitational, Inc.
+ * Copyright 2020-2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,18 @@
 import api from 'teleport/services/api';
 import cfg, { UrlAppParams, UrlResourcesParams } from 'teleport/config';
 import makeApp from './makeApps';
-import { AppsResponse } from './types';
+import { AgentResponse } from 'teleport/services/agents';
 
 const service = {
   fetchApps(
     clusterId: string,
     params: UrlResourcesParams
-  ): Promise<AppsResponse> {
+  ): Promise<AgentResponse> {
     return api.get(cfg.getApplicationsUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 
       return {
-        apps: items.map(makeApp),
+        agents: items.map(makeApp),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
       };

--- a/packages/teleport/src/services/apps/apps.ts
+++ b/packages/teleport/src/services/apps/apps.ts
@@ -16,14 +16,15 @@
 
 import api from 'teleport/services/api';
 import cfg, { UrlAppParams, UrlResourcesParams } from 'teleport/config';
-import makeApp from './makeApps';
 import { AgentResponse } from 'teleport/services/agents';
+import makeApp from './makeApps';
+import { App } from './types';
 
 const service = {
   fetchApps(
     clusterId: string,
     params: UrlResourcesParams
-  ): Promise<AgentResponse> {
+  ): Promise<AgentResponse<App>> {
     return api.get(cfg.getApplicationsUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 

--- a/packages/teleport/src/services/apps/types.ts
+++ b/packages/teleport/src/services/apps/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Gravitational, Inc.
+ * Copyright 2020-2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export interface App {
   id: string;

--- a/packages/teleport/src/services/databases/databases.test.ts
+++ b/packages/teleport/src/services/databases/databases.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2021-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ limitations under the License.
 
 import DatabaseService from './databases';
 import api from 'teleport/services/api';
+import { Database } from './types';
 
 test('correct formatting of database fetch response', async () => {
   jest.spyOn(api, 'get').mockResolvedValue(mockResponse);
@@ -26,7 +27,7 @@ test('correct formatting of database fetch response', async () => {
   });
 
   expect(response).toEqual({
-    databases: [
+    agents: [
       {
         name: 'aurora',
         description: 'PostgreSQL 11.6: AWS Aurora',
@@ -52,7 +53,7 @@ test('null response from database fetch', async () => {
   });
 
   expect(response).toEqual({
-    databases: [],
+    agents: [],
     startKey: undefined,
     totalCount: undefined,
   });
@@ -80,7 +81,8 @@ describe('correct formatting of all type and protocol combos', () => {
         search: 'does-not-matter',
       });
 
-      expect(response.databases[0].type).toBe(combined);
+      const dbs = response.agents as Database[];
+      expect(dbs[0].type).toBe(combined);
     }
   );
 });
@@ -93,7 +95,7 @@ test('null labels field in database fetch response', async () => {
     search: 'does-not-matter',
   });
 
-  expect(response.databases[0].labels).toEqual([]);
+  expect(response.agents[0].labels).toEqual([]);
 });
 
 const mockResponse = {

--- a/packages/teleport/src/services/databases/databases.ts
+++ b/packages/teleport/src/services/databases/databases.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2021-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,18 +17,18 @@ limitations under the License.
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
 import makeDatabase from './makeDatabase';
-import { DatabasesResponse } from './types';
+import { AgentResponse } from 'teleport/services/agents';
 
 class DatabaseService {
   fetchDatabases(
     clusterId: string,
     params: UrlResourcesParams
-  ): Promise<DatabasesResponse> {
+  ): Promise<AgentResponse> {
     return api.get(cfg.getDatabasesUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 
       return {
-        databases: items.map(makeDatabase),
+        agents: items.map(makeDatabase),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
       };

--- a/packages/teleport/src/services/databases/databases.ts
+++ b/packages/teleport/src/services/databases/databases.ts
@@ -16,14 +16,15 @@ limitations under the License.
 
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
-import makeDatabase from './makeDatabase';
 import { AgentResponse } from 'teleport/services/agents';
+import { Database } from './types';
+import makeDatabase from './makeDatabase';
 
 class DatabaseService {
   fetchDatabases(
     clusterId: string,
     params: UrlResourcesParams
-  ): Promise<AgentResponse> {
+  ): Promise<AgentResponse<Database>> {
     return api.get(cfg.getDatabasesUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 

--- a/packages/teleport/src/services/databases/types.ts
+++ b/packages/teleport/src/services/databases/types.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2021-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export interface Database {
   name: string;

--- a/packages/teleport/src/services/desktops/desktops.test.ts
+++ b/packages/teleport/src/services/desktops/desktops.test.ts
@@ -24,7 +24,7 @@ test('correct formatting of desktops fetch response', async () => {
   });
 
   expect(response).toEqual({
-    desktops: [
+    agents: [
       {
         os: 'windows',
         name: 'DC1-teleport-demo',
@@ -45,7 +45,7 @@ test('null response from desktops fetch', async () => {
   });
 
   expect(response).toEqual({
-    desktops: [],
+    agents: [],
     startKey: undefined,
     totalCount: undefined,
   });
@@ -57,7 +57,7 @@ test('null labels field in desktops fetch response', async () => {
     search: 'does-not-matter',
   });
 
-  expect(response.desktops[0].labels).toEqual([]);
+  expect(response.agents[0].labels).toEqual([]);
 });
 
 const mockResponse = {

--- a/packages/teleport/src/services/desktops/desktops.ts
+++ b/packages/teleport/src/services/desktops/desktops.ts
@@ -16,14 +16,15 @@ limitations under the License.
 
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
-import makeDesktop from './makeDesktop';
 import { AgentResponse } from 'teleport/services/agents';
+import { Desktop } from './types';
+import makeDesktop from './makeDesktop';
 
 class DesktopService {
   fetchDesktops(
     clusterId: string,
     params: UrlResourcesParams
-  ): Promise<AgentResponse> {
+  ): Promise<AgentResponse<Desktop>> {
     return api.get(cfg.getDesktopsUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 

--- a/packages/teleport/src/services/desktops/desktops.ts
+++ b/packages/teleport/src/services/desktops/desktops.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2021-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,18 +17,18 @@ limitations under the License.
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
 import makeDesktop from './makeDesktop';
-import { DesktopsResponse } from './types';
+import { AgentResponse } from 'teleport/services/agents';
 
 class DesktopService {
   fetchDesktops(
     clusterId: string,
     params: UrlResourcesParams
-  ): Promise<DesktopsResponse> {
+  ): Promise<AgentResponse> {
     return api.get(cfg.getDesktopsUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 
       return {
-        desktops: items.map(makeDesktop),
+        agents: items.map(makeDesktop),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
       };

--- a/packages/teleport/src/services/desktops/types.ts
+++ b/packages/teleport/src/services/desktops/types.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2021-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 // Desktop is a remote desktop.
 export type Desktop = {

--- a/packages/teleport/src/services/kube/kube.test.ts
+++ b/packages/teleport/src/services/kube/kube.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2021-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ test('correct processed fetch response formatting', async () => {
   });
 
   expect(response).toEqual({
-    kubes: [
+    agents: [
       {
         name: 'tele.logicoma.dev-prod',
         labels: [
@@ -49,7 +49,7 @@ test('handling of null fetch response', async () => {
   });
 
   expect(response).toEqual({
-    kubes: [],
+    agents: [],
     startKey: undefined,
     totalCount: undefined,
   });
@@ -65,7 +65,7 @@ test('handling of null labels', async () => {
     search: 'does-not-matter',
   });
 
-  expect(response.kubes).toEqual([{ name: 'test', labels: [] }]);
+  expect(response.agents).toEqual([{ name: 'test', labels: [] }]);
 });
 
 const mockApiResponse = {

--- a/packages/teleport/src/services/kube/kube.ts
+++ b/packages/teleport/src/services/kube/kube.ts
@@ -16,14 +16,15 @@ limitations under the License.
 
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
-import makeKube from './makeKube';
 import { AgentResponse } from 'teleport/services/agents';
+import { Kube } from './types';
+import makeKube from './makeKube';
 
 class KubeService {
   fetchKubernetes(
     clusterId,
     params: UrlResourcesParams
-  ): Promise<AgentResponse> {
+  ): Promise<AgentResponse<Kube>> {
     return api.get(cfg.getKubernetesUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 

--- a/packages/teleport/src/services/kube/kube.ts
+++ b/packages/teleport/src/services/kube/kube.ts
@@ -17,18 +17,18 @@ limitations under the License.
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
 import makeKube from './makeKube';
-import { KubesResponse } from './types';
+import { AgentResponse } from 'teleport/services/agents';
 
 class KubeService {
   fetchKubernetes(
     clusterId,
     params: UrlResourcesParams
-  ): Promise<KubesResponse> {
+  ): Promise<AgentResponse> {
     return api.get(cfg.getKubernetesUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 
       return {
-        kubes: items.map(makeKube),
+        agents: items.map(makeKube),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
       };

--- a/packages/teleport/src/services/kube/types.ts
+++ b/packages/teleport/src/services/kube/types.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2021-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 export interface Kube {
   name: string;
   labels: AgentLabel[];

--- a/packages/teleport/src/services/nodes/nodes.test.ts
+++ b/packages/teleport/src/services/nodes/nodes.test.ts
@@ -23,7 +23,7 @@ test('correct formatting of nodes fetch response', async () => {
   const response = await nodesService.fetchNodes('does-not-matter');
 
   expect(response).toEqual({
-    nodes: [
+    agents: [
       {
         id: '00a53f99-993b-40bc-af51-5ba259af4e43',
         clusterId: 'im-a-cluster-name',
@@ -45,7 +45,7 @@ test('null response from nodes fetch', async () => {
   const response = await nodesService.fetchNodes('does-not-matter');
 
   expect(response).toEqual({
-    nodes: [],
+    agents: [],
     startKey: undefined,
     totalCount: undefined,
   });
@@ -56,7 +56,7 @@ test('null labels field in nodes fetch response', async () => {
   jest.spyOn(api, 'get').mockResolvedValue({ items: [{ labels: null }] });
   const response = await nodesService.fetchNodes('does-not-matter');
 
-  expect(response.nodes[0].labels).toEqual([]);
+  expect(response.agents[0].labels).toEqual([]);
 });
 
 const mockResponse = {

--- a/packages/teleport/src/services/nodes/nodes.ts
+++ b/packages/teleport/src/services/nodes/nodes.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Gravitational, Inc.
+Copyright 2019-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,18 +17,18 @@ limitations under the License.
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
 import makeNode from './makeNode';
-import { NodesResponse } from './types';
+import { AgentResponse } from 'teleport/services/agents';
 
 class NodeService {
   fetchNodes(
     clusterId?: string,
     params?: UrlResourcesParams
-  ): Promise<NodesResponse> {
+  ): Promise<AgentResponse> {
     return api.get(cfg.getClusterNodesUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 
       return {
-        nodes: items.map(makeNode),
+        agents: items.map(makeNode),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
       };

--- a/packages/teleport/src/services/nodes/nodes.ts
+++ b/packages/teleport/src/services/nodes/nodes.ts
@@ -16,14 +16,15 @@ limitations under the License.
 
 import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
-import makeNode from './makeNode';
 import { AgentResponse } from 'teleport/services/agents';
+import { Node } from './types';
+import makeNode from './makeNode';
 
 class NodeService {
   fetchNodes(
     clusterId?: string,
     params?: UrlResourcesParams
-  ): Promise<AgentResponse> {
+  ): Promise<AgentResponse<Node>> {
     return api.get(cfg.getClusterNodesUrl(clusterId, params)).then(json => {
       const items = json?.items || [];
 

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel } from 'teleport/services/agents';
 
 export interface Node {
   id: string;


### PR DESCRIPTION
part of access request work

#### Description
This refactor should also aid in the refactoring of pagination work

- Create a agent file, containing agent types
- Remove design packing importing from teleport package

** easier to review by commit

#### Required to merge
- [x] merge counter part PR https://github.com/gravitational/webapps.e/pull/286
- [x] update e-ref

#### Testing
Checked each resource was able to render list, next and prev: 
 - nodes, db, apps, desktops, kubes, and console nodes