### PR TITLE
[v9] Prevent `restorePersistedState()` crash when there is no persisted workspace for a cluster (#825)

### DIFF
--- a/packages/teleterm/src/ui/AppInitializer.tsx
+++ b/packages/teleterm/src/ui/AppInitializer.tsx
@@ -5,13 +5,19 @@ import styled from 'styled-components';
 
 export const AppInitializer: FC = props => {
   const ctx = useAppContext();
-  const [{ status }, init] = useAsync(() => ctx.init());
+  const [state, init] = useAsync(() => ctx.init());
 
   useEffect(() => {
     init();
   }, []);
 
-  if (status === 'success' || status === 'error') {
+  useEffect(() => {
+    if (state.status === 'error') {
+      ctx.notificationsService.notifyError(state.statusText);
+    }
+  }, [state]);
+
+  if (state.status === 'success' || state.status === 'error') {
     return <>{props.children}</>;
   }
 

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -1,0 +1,115 @@
+import { Workspace, WorkspacesService } from './workspacesService';
+import { ClustersService } from '../clusters';
+import { StatePersistenceService } from '../statePersistence';
+
+describe('restoring workspace', () => {
+  function getTestSetup(options: {
+    clusterUri: string; // assumes that only one cluster can be added
+    persistedWorkspaces: Record<string, Workspace>;
+  }) {
+    const statePersistenceService: Partial<StatePersistenceService> = {
+      getWorkspacesState: () => ({
+        workspaces: options.persistedWorkspaces,
+      }),
+      saveWorkspacesState: jest.fn(),
+    };
+
+    const clustersService: Partial<ClustersService> = {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+      findRootClusterByResource: jest.fn(),
+      findCluster: jest.fn(),
+      findGateway: jest.fn(),
+      getClusters: () => [
+        {
+          uri: options.clusterUri,
+          name: 'Test cluster',
+          connected: true,
+          leaf: false,
+          proxyHost: 'test:3030',
+          actualName: 'Test cluster',
+          loggedInUser: {
+            name: 'Alice',
+            rolesList: [],
+            sshLoginsList: [],
+          },
+        },
+      ],
+    };
+
+    const clusterDocument = {
+      kind: 'doc.cluster',
+      title: 'Cluster Test',
+      clusterUri: options.clusterUri,
+      uri: 'docs/test-cluster-uri',
+    };
+
+    const workspacesService = new WorkspacesService(
+      undefined,
+      // @ts-expect-error using mocks
+      clustersService,
+      undefined,
+      statePersistenceService
+    );
+
+    workspacesService.getWorkspaceDocumentService = () => ({
+      // @ts-expect-error using mocks
+      createClusterDocument() {
+        return clusterDocument;
+      },
+    });
+
+    return { workspacesService, clusterDocument };
+  }
+
+  it('restores the workspace if it there is a persisted state for given clusterUri', () => {
+    const testClusterUri = '/clusters/test-uri';
+    const testWorkspace: Workspace = {
+      localClusterUri: testClusterUri,
+      documents: [
+        {
+          kind: 'doc.terminal_shell',
+          uri: 'docs/some_uri',
+          title: '/Users/alice/Documents',
+        },
+      ],
+      location: 'docs/some_uri',
+    };
+
+    const { workspacesService, clusterDocument } = getTestSetup({
+      clusterUri: testClusterUri,
+      persistedWorkspaces: { [testClusterUri]: testWorkspace },
+    });
+
+    workspacesService.restorePersistedState();
+    expect(workspacesService.getWorkspaces()).toStrictEqual({
+      [testClusterUri]: {
+        localClusterUri: testWorkspace.localClusterUri,
+        documents: [clusterDocument],
+        location: clusterDocument.uri,
+        previous: {
+          documents: testWorkspace.documents,
+          location: testWorkspace.location,
+        },
+      },
+    });
+  });
+
+  it('creates empty workspace if there is no persisted state for given clusterUri', () => {
+    const testClusterUri = '/clusters/test-uri';
+    const { workspacesService, clusterDocument } = getTestSetup({
+      clusterUri: testClusterUri,
+      persistedWorkspaces: {},
+    });
+
+    workspacesService.restorePersistedState();
+    expect(workspacesService.getWorkspaces()).toStrictEqual({
+      [testClusterUri]: {
+        localClusterUri: testClusterUri,
+        documents: [clusterDocument],
+        location: clusterDocument.uri,
+        previous: undefined,
+      },
+    });
+  });
+});

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -200,7 +200,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
         const workspaceDefaultState = this.getWorkspaceDefaultState(
           persistedWorkspace?.localClusterUri || cluster.uri
         );
-        const persistedWorkspaceDocuments = persistedWorkspace.documents;
+        const persistedWorkspaceDocuments = persistedWorkspace?.documents;
 
         workspaces[cluster.uri] = {
           ...workspaceDefaultState,
@@ -246,7 +246,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     previousDocuments,
     currentDocuments,
   }: {
-    previousDocuments: Document[];
+    previousDocuments?: Document[];
     currentDocuments: Document[];
   }): boolean {
     const omitUriAndTitle = (documents: Document[]) =>


### PR DESCRIPTION
Backport #825.