### PR TITLE
Do not show the login dialog when a user adds a cluster that is connected 

### DIFF
--- a/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
+++ b/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
@@ -2,12 +2,23 @@ import React, { useState } from 'react';
 import { ClusterAdd } from './ClusterAdd';
 import { ClusterLogin } from './ClusterLogin';
 import Dialog from 'design/Dialog';
+import { useAppContext } from 'teleterm/ui/appContextProvider';
 
 export function ClusterConnect(props: ClusterConnectProps) {
   const [createdClusterUri, setCreatedClusterUri] = useState<
     string | undefined
   >();
+  const { clustersService } = useAppContext();
   const clusterUri = props.clusterUri || createdClusterUri;
+
+  function handleClusterAdd(clusterUri: string): void {
+    const cluster = clustersService.findCluster(clusterUri);
+    if (cluster?.connected) {
+      props.onSuccess(clusterUri);
+    } else {
+      setCreatedClusterUri(clusterUri);
+    }
+  }
 
   return (
     <Dialog
@@ -21,10 +32,7 @@ export function ClusterConnect(props: ClusterConnectProps) {
       open={true}
     >
       {!clusterUri ? (
-        <ClusterAdd
-          onCancel={props.onCancel}
-          onSuccess={setCreatedClusterUri}
-        />
+        <ClusterAdd onCancel={props.onCancel} onSuccess={handleClusterAdd} />
       ) : (
         <ClusterLogin
           clusterUri={clusterUri}


### PR DESCRIPTION
Related issue: https://github.com/gravitational/webapps.e/issues/242

Thanks to this PR user won't see login dialog if it is already logged to the cluster.

Teleport counterpart: https://github.com/gravitational/teleport/pull/12940