### PR TITLE
Refactor `Feature`

### DIFF
--- a/packages/teleport/src/Main/useMain.ts
+++ b/packages/teleport/src/Main/useMain.ts
@@ -24,7 +24,15 @@ export default function useMain(features: Feature[]) {
   const { attempt, run } = useAttempt('processing');
 
   useState(() =>
-    run(() => ctx.init().then(() => features.forEach(f => f.register(ctx))))
+    run(() =>
+      ctx.init().then(() =>
+        features.forEach(f => {
+          if (f.isAvailable(ctx)) {
+            f.register(ctx);
+          }
+        })
+      )
+    )
   );
 
   return {

--- a/packages/teleport/src/TopBar/useTopBar.ts
+++ b/packages/teleport/src/TopBar/useTopBar.ts
@@ -35,7 +35,7 @@ export default function useTopBar(ctx: Ctx, stickyCluster: StickyCluster) {
     })
   );
 
-  const title = feature?.getTopNavTitle() || '';
+  const title = feature?.topNavTitle || '';
 
   function loadClusters() {
     return ctx.clusterService.fetchClusters();

--- a/packages/teleport/src/features.ts
+++ b/packages/teleport/src/features.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import * as Icons from 'design/Icon';
+import { Feature } from './types';
 import Ctx from 'teleport/teleportContext';
 import cfg from 'teleport/config';
 import Audit from './Audit';
@@ -33,10 +34,8 @@ import AuthConnectors from './AuthConnectors';
 import Databases from './Databases';
 import Desktops from './Desktops';
 
-export class FeatureClusters {
-  getTopNavTitle() {
-    return 'Clusters';
-  }
+export class FeatureClusters extends Feature {
+  topNavTitle = 'Clusters';
 
   route = {
     title: 'Clusters',
@@ -44,6 +43,11 @@ export class FeatureClusters {
     exact: false,
     component: Clusters,
   };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isAvailable(ctx: Ctx): boolean {
+    return true; // TODO(isaiah)
+  }
 
   register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
@@ -60,10 +64,8 @@ export class FeatureClusters {
   }
 }
 
-export class FeatureAuthConnectors {
-  getTopNavTitle() {
-    return 'Team';
-  }
+export class FeatureAuthConnectors extends Feature {
+  topNavTitle = 'Team';
 
   route = {
     title: 'Auth Connectors',
@@ -72,11 +74,11 @@ export class FeatureAuthConnectors {
     component: AuthConnectors,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().authConnector) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().authConnector;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       group: 'team',
       title: 'Auth Connectors',
@@ -91,10 +93,8 @@ export class FeatureAuthConnectors {
   }
 }
 
-export class FeatureHelpAndSupport {
-  getTopNavTitle() {
-    return 'Help & Support';
-  }
+export class FeatureHelpAndSupport extends Feature {
+  topNavTitle = 'Help & Support';
 
   route = {
     title: 'Help & Support',
@@ -102,6 +102,10 @@ export class FeatureHelpAndSupport {
     exact: true,
     component: Support,
   };
+
+  isAvailable(): boolean {
+    return true;
+  }
 
   register(ctx: Ctx) {
     ctx.storeNav.addTopMenuItem({
@@ -117,10 +121,8 @@ export class FeatureHelpAndSupport {
   }
 }
 
-export class FeatureAudit {
-  getTopNavTitle() {
-    return 'Account Settings';
-  }
+export class FeatureAudit extends Feature {
+  topNavTitle = 'Account Settings';
 
   route = {
     title: 'Audit Log',
@@ -128,11 +130,11 @@ export class FeatureAudit {
     component: Audit,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().audit) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().audit;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       group: 'activity',
       title: 'Audit Log',
@@ -146,16 +148,18 @@ export class FeatureAudit {
   }
 }
 
-export class FeatureAccount {
-  getTopNavTitle() {
-    return 'Account Settings';
-  }
+export class FeatureAccount extends Feature {
+  topNavTitle = 'Account Settings';
 
   route = {
     title: 'Account Settings',
     path: cfg.routes.account,
     component: Account,
   };
+
+  isAvailable(): boolean {
+    return true;
+  }
 
   register(ctx: Ctx) {
     ctx.storeNav.addTopMenuItem({
@@ -170,10 +174,8 @@ export class FeatureAccount {
   }
 }
 
-export class FeatureNodes {
-  getTopNavTitle() {
-    return '';
-  }
+export class FeatureNodes extends Feature {
+  topNavTitle = '';
 
   route = {
     title: 'Servers',
@@ -182,11 +184,11 @@ export class FeatureNodes {
     component: Nodes,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().nodes) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().nodes;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       title: 'Servers',
       Icon: Icons.Server,
@@ -200,10 +202,8 @@ export class FeatureNodes {
   }
 }
 
-export class FeatureRecordings {
-  getTopNavTitle() {
-    return '';
-  }
+export class FeatureRecordings extends Feature {
+  topNavTitle = '';
 
   route = {
     title: 'Session Recordings',
@@ -212,11 +212,11 @@ export class FeatureRecordings {
     component: Recordings,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().recordings) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().recordings;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       group: 'activity',
       title: 'Session Recordings',
@@ -231,10 +231,8 @@ export class FeatureRecordings {
   }
 }
 
-export class FeatureSessions {
-  getTopNavTitle() {
-    return 'Sessions';
-  }
+export class FeatureSessions extends Feature {
+  topNavTitle = 'Sessions';
 
   route = {
     title: 'Sessions',
@@ -243,11 +241,11 @@ export class FeatureSessions {
     component: Sessions,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().activeSessions) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().activeSessions;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       group: 'activity',
       title: 'Active Sessions',
@@ -262,10 +260,8 @@ export class FeatureSessions {
   }
 }
 
-export class FeatureRoles {
-  getTopNavTitle() {
-    return 'Team';
-  }
+export class FeatureRoles extends Feature {
+  topNavTitle = 'Team';
 
   route = {
     title: 'Roles',
@@ -274,11 +270,11 @@ export class FeatureRoles {
     component: Roles,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().roles) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().roles;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       title: 'Roles',
       group: 'team',
@@ -293,10 +289,8 @@ export class FeatureRoles {
   }
 }
 
-export class FeatureUsers {
-  getTopNavTitle() {
-    return 'Team';
-  }
+export class FeatureUsers extends Feature {
+  topNavTitle = 'Team';
 
   route = {
     title: 'Users',
@@ -305,11 +299,11 @@ export class FeatureUsers {
     component: Users,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().users) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().users;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       title: 'Users',
       group: 'team',
@@ -324,10 +318,8 @@ export class FeatureUsers {
   }
 }
 
-export class FeatureApps {
-  getTopNavTitle() {
-    return 'Applications';
-  }
+export class FeatureApps extends Feature {
+  topNavTitle = 'Applications';
 
   route = {
     title: 'Applications',
@@ -336,11 +328,11 @@ export class FeatureApps {
     component: Applications,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().applications) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().applications;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       title: 'Applications',
       Icon: Icons.NewTab,
@@ -354,10 +346,8 @@ export class FeatureApps {
   }
 }
 
-export class FeatureKubes {
-  getTopNavTitle() {
-    return '';
-  }
+export class FeatureKubes extends Feature {
+  topNavTitle = '';
 
   route = {
     title: 'Kubernetes',
@@ -366,11 +356,11 @@ export class FeatureKubes {
     component: Kubes,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().kubernetes) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().kubernetes;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       title: 'Kubernetes',
       Icon: Icons.Kubernetes,
@@ -384,10 +374,8 @@ export class FeatureKubes {
   }
 }
 
-export class FeatureTrust {
-  getTopNavTitle() {
-    return 'Clusters';
-  }
+export class FeatureTrust extends Feature {
+  topNavTitle = 'Clusters';
 
   route = {
     title: 'Trust',
@@ -395,11 +383,11 @@ export class FeatureTrust {
     component: Trust,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().trustedClusters) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().trustedClusters;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       group: 'clusters',
       title: 'Trust',
@@ -413,10 +401,8 @@ export class FeatureTrust {
   }
 }
 
-export class FeatureDatabases {
-  getTopNavTitle() {
-    return '';
-  }
+export class FeatureDatabases extends Feature {
+  topNavTitle = '';
 
   route = {
     title: 'Databases',
@@ -425,11 +411,11 @@ export class FeatureDatabases {
     component: Databases,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().databases) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().databases;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       title: 'Databases',
       Icon: Icons.Database,
@@ -443,10 +429,8 @@ export class FeatureDatabases {
   }
 }
 
-export class FeatureDesktops {
-  getTopNavTitle() {
-    return '';
-  }
+export class FeatureDesktops extends Feature {
+  topNavTitle = '';
 
   route = {
     title: 'Desktops',
@@ -455,11 +439,11 @@ export class FeatureDesktops {
     component: Desktops,
   };
 
-  register(ctx: Ctx) {
-    if (!ctx.getFeatureFlags().desktops) {
-      return;
-    }
+  isAvailable(ctx: Ctx): boolean {
+    return ctx.getFeatureFlags().desktops;
+  }
 
+  register(ctx: Ctx) {
     ctx.storeNav.addSideItem({
       title: 'Desktops',
       Icon: Icons.Desktop,
@@ -473,7 +457,7 @@ export class FeatureDesktops {
   }
 }
 
-export default function getFeatures() {
+export default function getFeatures(): Feature[] {
   return [
     new FeatureNodes(),
     new FeatureApps(),

--- a/packages/teleport/src/types.ts
+++ b/packages/teleport/src/types.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import Ctx from 'teleport/teleportContext';
 
 export type NavGroup = 'team' | 'activity' | 'clusters';
 
@@ -32,10 +33,11 @@ export interface Context {
   getFeatureFlags(): FeatureFlags;
 }
 
-export interface Feature {
-  route: FeatureRoute;
-  getTopNavTitle(): string;
-  register(ctx: Context): void;
+export abstract class Feature {
+  abstract topNavTitle: string;
+  abstract route: FeatureRoute;
+  abstract isAvailable(ctx: Ctx): boolean;
+  abstract register(ctx: Ctx): void;
 }
 
 export type StickyCluster = {


### PR DESCRIPTION
Updates specific features to extend an abstract Feature class, which demands an `isAvailable()` in order to try to remind us to be more conscientious about disabling features in the nav bar that users aren't allowed to access.

This refactor is just changing the code structure. The behavior is still the same. Next, I will go through the features that have a `TODO(isaiah)` in their `isAvailable`, and figure out the ACL flag to use and/or add to ensure that the features are only shown when available.

The motivation here is to be able to give users simple instructions for disabling UI features, which is apparently a common request (see https://github.com/gravitational/webapps/issues/836, https://github.com/gravitational/teleport/discussions/11920)

`webapps.e` should be updated with the merge commit for the corresponding enterprise PR: https://github.com/gravitational/webapps.e/pull/292

Corresponds with: https://github.com/gravitational/teleport/pull/12962