### PR TITLE
Use only dmg target for Teleport Connect

### DIFF
--- a/packages/teleterm/package.json
+++ b/packages/teleterm/package.json
@@ -63,6 +63,7 @@
       "build/app/dist"
     ],
     "mac": {
+      "target": "dmg",
       "type": "distribution",
       "hardenedRuntime": true,
       "entitlements": "assets/entitlements.mac.plist",


### PR DESCRIPTION
By default, electron-builder uses both dmg and zip. The latter is made for
Squirrel.Mac, which we don't use at the moment.