### PR TITLE
Add get-teleport-connect-dir script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build-e": "yarn build-teleport-e",
     "build": "yarn lint && yarn type-check && yarn build-oss && yarn build-e",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx packages/",
+    "get-teleport-connect-dir": "node -p \"require('./package.json').teleportConnectDir\"",
     "type-check": "yarn tsc"
   },
   "private": true,
@@ -36,5 +37,6 @@
       "packages/webapps*/**",
       "packages/teleterm"
     ]
-  }
+  },
+  "teleportConnectDir": "packages/teleterm"
 }


### PR DESCRIPTION
At some point, we want to rename packages/teleterm to something else.

This script will enable our build scripts (see gravitational/teleport#12257)
to automatically pick up this change without requiring us to change
the build scripts as well.