### PR TITLE
Fix types for Logger/NullService

### DIFF
--- a/packages/teleterm/src/logger.ts
+++ b/packages/teleterm/src/logger.ts
@@ -1,4 +1,5 @@
 import * as types from 'teleterm/types';
+import { LoggerService } from 'teleterm/services/logger/types';
 
 export default class Logger {
   private static service: types.LoggerService;
@@ -39,7 +40,7 @@ export default class Logger {
 }
 
 // NullService is a logger service implementation which swallows logs. For use in tests.
-export class NullService {
+export class NullService implements LoggerService {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   createLogger(loggerName: string): types.Logger {
     return {

--- a/packages/teleterm/src/services/logger/loggerService.ts
+++ b/packages/teleterm/src/services/logger/loggerService.ts
@@ -1,9 +1,9 @@
 import { createLogger as createWinston, format, transports } from 'winston';
 import { isObject } from 'lodash';
-import { Logger, LoggerService } from './types';
+import { Logger, NodeLoggerService } from './types';
 import split2 from 'split2';
 
-export default function createLoggerService(opts: Options): LoggerService {
+export default function createLoggerService(opts: Options): NodeLoggerService {
   const instance = createWinston({
     level: 'info',
     exitOnError: false,

--- a/packages/teleterm/src/services/logger/types.ts
+++ b/packages/teleterm/src/services/logger/types.ts
@@ -7,6 +7,9 @@ export interface Logger {
 }
 
 export interface LoggerService {
-  pipeProcessOutputIntoLogger(stream: Stream): void;
   createLogger(context: string): Logger;
+}
+
+export interface NodeLoggerService extends LoggerService {
+  pipeProcessOutputIntoLogger(stream: Stream): void;
 }

--- a/packages/teleterm/src/services/tshd/middleware.test.ts
+++ b/packages/teleterm/src/services/tshd/middleware.test.ts
@@ -5,7 +5,6 @@ import Logger from 'teleterm/logger';
 it('do not log sensitive info like password', () => {
   const infoLogger = jest.fn();
   Logger.init({
-    pipeProcessOutputIntoLogger: () => {},
     createLogger: () => ({
       info: infoLogger,
       error: () => {},


### PR DESCRIPTION
pipeProcessOutputIntoLogger has been moved to a separate interface, because
Stream is not an API that's available in the browser.