### PR TITLE
Add automation to update webassets on push

### DIFF
--- a/.github/actions/docker-build-webassets/action.yaml
+++ b/.github/actions/docker-build-webassets/action.yaml
@@ -1,0 +1,11 @@
+name: docker-build-webassets
+author: Zac Bergquist <zac@goteleport.com>
+description: Build Teleport webassets in Docker
+
+runs:
+  using: docker
+  image: ../../../Dockerfile
+  entrypoint: sh
+  args:
+    - -c
+    - yarn install && yarn run build-teleport

--- a/.github/workflows/update-webassets.yaml
+++ b/.github/workflows/update-webassets.yaml
@@ -1,0 +1,55 @@
+name: Update Webassets
+
+on:
+  push:
+    branches:
+      - master
+      - teleport-v**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Get webapps, and the webapps.e submodule
+      - name: Checkout webapps
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          submodules: recursive
+          fetch-depth: 0
+
+      # Get webassets, and the webassets.e submodule
+      - name: Checkout webassets
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          repository: gravitational/webassets
+          submodules: recursive
+          path: dist
+
+      # This workflow only runs on push to a protected branch, so the code
+      # has already been reviewed and is trusted. This means it is safe to
+      # the version of the action that we checked out and we don't need to
+      # always use master.
+      - name: Build webassets
+        uses: ./.github/actions/docker-build-webassets
+
+      - name: Push updates
+        run: |
+          git config --global user.email github-goteleport-core-svc@goteleport.com
+          git config --global user.name "$GITHUB_ACTOR"
+
+          export WEBAPPS_BRANCH=$(git branch --show-current)
+
+          cd dist/e
+          git switch $WEBAPPS_BRANCH
+          git add -A
+          git commit -m "Update webassets.e from gravitational/webapps@$GITHUB_SHA"
+          git push
+
+          cd ..
+          git switch $WEBAPPS_BRANCH
+          git add -A
+          git commit -m "Update webassets from gravitational/webapps@$GITHUB_SHA"
+          git push

--- a/.github/workflows/update-webassets.yaml
+++ b/.github/workflows/update-webassets.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          repository: gravitational/webassets
+          repository: gravitational/webassets-fork # TODO(zmb3): switch off the fork
           submodules: recursive
           path: dist
 

--- a/.github/workflows/update-webassets.yaml
+++ b/.github/workflows/update-webassets.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - master
-      - teleport-v**
+      # TODO(zmb3): enable on release branches
+      #- teleport-v**
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16.3-slim
-RUN apt-get update && apt-get install git g++ make python -y
+RUN apt-get update && apt-get install git g++ make python tree -y
 
 RUN mkdir -p web-apps
 COPY yarn.lock web-apps/
@@ -23,7 +23,7 @@ RUN yarn install
 
 # copy the rest of the files and run yarn build command
 COPY  . .
-ARG NPM_SCRIPT
+ARG NPM_SCRIPT=nop
 ARG OUTPUT
 # run npm script with optional --output-path parameter
 RUN yarn $NPM_SCRIPT $([ -z $OUTPUT ] || echo --output-path=$OUTPUT)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx packages/",
     "type-check": "tsc --noEmit",
     "prettier-check": "yarn prettier --check 'packages/**/*.{ts,tsx,js,jsx,md}'",
-    "prettier-write": "yarn prettier --write 'packages/**/*.{ts,tsx,js,jsx,md}'"
+    "prettier-write": "yarn prettier --write 'packages/**/*.{ts,tsx,js,jsx,md}'",
+    "nop": "exit 0"
   },
   "private": true,
   "resolutions": {


### PR DESCRIPTION
This will run using a service account which is the only account
permitted to push to webassets and webassets.e.

The action will run when any commits are pushed to the protected
branches in webapps. This means that commits to webapps.e do not
directly trigger updates - this automation will run when the
enterprise submodule ref is updated in webapps.

The "nop" yarn script allows us to separate the building of the docker
image from the build of Teleport, so that GitHub actions can run the
yarn build after buildling an image from our dockerfile. This is
necessary because container steps do not support build args.