### PR TITLE
Fix null role response from users fetch

### DIFF
--- a/packages/teleport/src/services/user/makeUser.ts
+++ b/packages/teleport/src/services/user/makeUser.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Gravitational, Inc.
+ * Copyright 2020-2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ export default function makeUser(json): User {
   const [name, roles, authType] = at(json, ['name', 'roles', 'authType']);
   return {
     name,
-    roles,
+    roles: roles || [],
     authType: authType === 'local' ? 'teleport local user' : authType,
     isLocal: authType === 'local',
   };

--- a/packages/teleport/src/services/user/user.test.ts
+++ b/packages/teleport/src/services/user/user.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Gravitational, Inc.
+ * Copyright 2020-2022 Gravitational, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,9 +177,15 @@ test('undefined values in context response gives proper default values', async (
   });
 });
 
-test('fetch users, null response gives empty array', async () => {
+test('fetch users, null response values gives empty array', async () => {
   jest.spyOn(api, 'get').mockResolvedValue(null);
-
-  const response = await user.fetchUsers();
+  let response = await user.fetchUsers();
   expect(response).toStrictEqual([]);
+
+  jest.spyOn(api, 'get').mockResolvedValue([{ name: '', authType: '' }]);
+
+  response = await user.fetchUsers();
+  expect(response).toStrictEqual([
+    { authType: '', isLocal: false, name: '', roles: [] },
+  ]);
 });


### PR DESCRIPTION
#### Description
a user ran into an issue in the UI where `cannot read properties of null (reading 'sort')` when listing users:  https://goteleport.slack.com/archives/CEZH6UL64/p1654536009001459

I was able to replicate this issue by modifying a user's yaml file through `tctl` and delete the `role` field, and `tctl create user.yaml -f`. A user can exist with no roles which returns as `null` from the back, which wasn't handled in the UI.