### PR TITLE
Show node specific ssh logins options

### DIFF
--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -97,6 +97,7 @@ const clusters = [
 const nodes: Node[] = [
   {
     tunnel: false,
+    sshLogins: ['dev', 'root'],
     id: '104',
     clusterId: 'cluseter-1',
     hostname: 'fujedu',
@@ -114,6 +115,7 @@ const nodes: Node[] = [
   },
   {
     tunnel: false,
+    sshLogins: ['dev', 'root'],
     id: '170',
     clusterId: 'cluseter-1',
     hostname: 'facuzguv',
@@ -131,6 +133,7 @@ const nodes: Node[] = [
   },
   {
     tunnel: true,
+    sshLogins: ['dev', 'root'],
     id: '192',
     clusterId: 'cluseter-1',
     hostname: 'duzsevkig',
@@ -148,6 +151,7 @@ const nodes: Node[] = [
   },
   {
     tunnel: true,
+    sshLogins: ['dev', 'root'],
     id: '64',
     clusterId: 'cluseter-1',
     hostname: 'kuhinur',
@@ -165,6 +169,7 @@ const nodes: Node[] = [
   },
   {
     tunnel: false,
+    sshLogins: ['dev', 'root'],
     id: '81',
     clusterId: 'cluseter-1',
     hostname: 'zebpecda',

--- a/packages/teleport/src/Nodes/fixtures/index.ts
+++ b/packages/teleport/src/Nodes/fixtures/index.ts
@@ -19,6 +19,7 @@ import { Node } from 'teleport/services/nodes';
 export const nodes: Node[] = [
   {
     tunnel: false,
+    sshLogins: ['dev', 'root'],
     id: '104',
     clusterId: 'one',
     hostname: 'fujedu',
@@ -36,6 +37,7 @@ export const nodes: Node[] = [
   },
   {
     tunnel: false,
+    sshLogins: ['dev', 'root'],
     id: '170',
     clusterId: 'one',
     hostname: 'facuzguv',
@@ -53,6 +55,7 @@ export const nodes: Node[] = [
   },
   {
     tunnel: false,
+    sshLogins: ['dev', 'root'],
     id: '192',
     clusterId: 'one',
     hostname: 'duzsevkig',
@@ -70,6 +73,7 @@ export const nodes: Node[] = [
   },
   {
     tunnel: false,
+    sshLogins: ['dev', 'root'],
     id: '64',
     clusterId: 'one',
     hostname: 'kuhinur',
@@ -87,6 +91,7 @@ export const nodes: Node[] = [
   },
   {
     tunnel: false,
+    sshLogins: ['dev', 'root'],
     id: '81',
     clusterId: 'one',
     hostname: 'zebpecda',
@@ -104,6 +109,7 @@ export const nodes: Node[] = [
   },
   {
     tunnel: true,
+    sshLogins: ['dev', 'root'],
     id: '81',
     clusterId: 'one',
     hostname: 'zebpecda',
@@ -121,6 +127,7 @@ export const nodes: Node[] = [
   },
   {
     tunnel: true,
+    sshLogins: ['dev', 'root'],
     id: '81',
     clusterId: 'one',
     hostname: 'zebpecda',

--- a/packages/teleport/src/services/nodes/makeNode.ts
+++ b/packages/teleport/src/services/nodes/makeNode.ts
@@ -17,7 +17,15 @@ limitations under the License.
 import { Node } from './types';
 
 export default function makeNode(json): Node {
-  const { id, siteId, hostname, addr, tunnel, tags = [] } = json;
+  const {
+    id,
+    siteId,
+    hostname,
+    addr,
+    tunnel,
+    tags = [],
+    sshLogins = [],
+  } = json;
 
   return {
     id,
@@ -26,5 +34,6 @@ export default function makeNode(json): Node {
     labels: tags,
     addr,
     tunnel,
+    sshLogins,
   };
 }

--- a/packages/teleport/src/services/nodes/nodes.test.ts
+++ b/packages/teleport/src/services/nodes/nodes.test.ts
@@ -31,6 +31,7 @@ test('correct formatting of nodes fetch response', async () => {
         labels: [{ name: 'env', value: 'dev' }],
         addr: '192.168.86.132:3022',
         tunnel: false,
+        sshLogins: [],
       },
     ],
     startKey: mockResponse.startKey,

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -22,6 +22,7 @@ export interface Node {
   labels: AgentLabel[];
   addr: string;
   tunnel: boolean;
+  sshLogins: string[];
 }
 
 export interface BashCommand {


### PR DESCRIPTION
PR in draft while I do some more testings and check the boxes below

TODO:

- [ ] remove `sshLogins` from user context if it isn't necessary anymore
___

This PR uses a new field `sshLogins` added in [this teleport PR](https://github.com/gravitational/teleport/pull/13266) instead of using the `sshLogins` from the user context.

The `sshLogins` from the context that are being used currently include all logins. This can be confusing for users, since the UI will show some users when they click `Connect` that they can't use for that specific node.

This PR changes this so the logins showed to the user is specific to the node the user is connecting.

Closes https://github.com/gravitational/teleport/issues/6822