### PR TITLE
Various small fixes and touch ups

### DIFF
--- a/packages/shared/services/types.ts
+++ b/packages/shared/services/types.ts
@@ -30,8 +30,11 @@ export type PrimaryAuthType = 'local' | 'passwordless' | 'sso';
 // is preferred when more than one option can be available
 // and only one should be preferred.
 //
-// TODO(lisa) remove, currently does nothing.
-export type PreferredMfaType = 'webauthn' | '';
+// DELETE IN 11.0.0, preferredMfaType currently has no usage, other
+// than in teleterm, where we check if auth settings return
+// the deprecated `u2f` option (v9). Starting v10
+// 'u2f' will automatically be aliased to 'webauthn'.
+export type PreferredMfaType = 'webauthn' | 'u2f' | '';
 
 export type AuthProvider = {
   displayName?: string;

--- a/packages/teleport/src/Account/ManageDevices/AddDevice/AddDevice.story.tsx
+++ b/packages/teleport/src/Account/ManageDevices/AddDevice/AddDevice.story.tsx
@@ -58,6 +58,7 @@ const props: State = {
   clearAttempt: () => null,
   onClose: () => null,
   auth2faType: 'on',
+  isPasswordlessEnabled: true,
   qrCode:
     'iVBORw0KGgoAAAANSUhEUgAAAcgAAAHIEAAAAAC/Wvl1AAAJV0lEQVR4nOzdsW4jORZA0fbC///LXowV' +
     'TFIWmqAefUtzTrDJeEtltS+YPDx+fn39ASL+99svAPzr85//+fj47df4ycr5ff1bXD9h/2f3vcenTf0L' +

--- a/packages/teleport/src/Account/ManageDevices/AddDevice/AddDevice.tsx
+++ b/packages/teleport/src/Account/ManageDevices/AddDevice/AddDevice.tsx
@@ -71,6 +71,7 @@ export function AddDevice({
   onClose,
   qrCode,
   auth2faType,
+  isPasswordlessEnabled,
 }: State) {
   const [otpToken, setOtpToken] = useState('');
   const [deviceName, setDeviceName] = useState('');
@@ -207,7 +208,7 @@ export function AddDevice({
                   readonly={addDeviceAttempt.status === 'processing'}
                 />
               )}
-              {mfaOption.value === 'webauthn' && (
+              {mfaOption.value === 'webauthn' && isPasswordlessEnabled && (
                 <FieldSelect
                   width="50%"
                   label="Allow Passwordless Login?"

--- a/packages/teleport/src/Account/ManageDevices/AddDevice/useAddDevice.ts
+++ b/packages/teleport/src/Account/ManageDevices/AddDevice/useAddDevice.ts
@@ -80,6 +80,7 @@ export default function useAddDevice(
     clearAttempt,
     qrCode,
     auth2faType: cfg.getAuth2faType(),
+    isPasswordlessEnabled: cfg.isPasswordlessEnabled(),
   };
 }
 

--- a/packages/teleport/src/Apps/Apps.tsx
+++ b/packages/teleport/src/Apps/Apps.tsx
@@ -61,14 +61,13 @@ export function Apps(props: State) {
     onLabelClick,
   } = props;
 
-  const hasNoApps =
-    attempt.status === 'success' && results.apps.length === 0 && isSearchEmpty;
+  const hasNoApps = results.apps.length === 0 && isSearchEmpty;
 
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Applications</FeatureHeaderTitle>
-        {!hasNoApps && (
+        {attempt.status === 'success' && !hasNoApps && (
           <AgentButtonAdd
             agent="application"
             beginsWithVowel={true}
@@ -105,7 +104,7 @@ export function Apps(props: State) {
           onLabelClick={onLabelClick}
         />
       )}
-      {hasNoApps && (
+      {attempt.status === 'success' && hasNoApps && (
         <Empty
           clusterId={clusterId}
           canCreate={canCreate && !isLeafCluster}

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -293,7 +293,7 @@ exports[`empty state for enterprise, can create 1`] = `
 `;
 
 exports[`failed state 1`] = `
-.c4 {
+.c3 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -310,62 +310,17 @@ exports[`failed state 1`] = `
   color: #FFFFFF;
 }
 
-.c4 a {
+.c3 a {
   color: #FFFFFF;
 }
 
-.c8 {
+.c7 {
   box-sizing: border-box;
   margin-right: 16px;
   width: 100%;
 }
 
-.c3 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  width: 240px;
-}
-
-.c3:active {
-  opacity: 0.56;
-}
-
-.c3:hover,
-.c3:focus {
-  background: #651FFF;
-}
-
-.c3:active {
-  background: #354AA4;
-}
-
-.c3:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c27 {
+.c26 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -394,40 +349,40 @@ exports[`failed state 1`] = `
   width: 88px;
 }
 
-.c27:active {
+.c26:active {
   opacity: 0.56;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c27:active {
+.c26:active {
   opacity: 0.24;
 }
 
-.c27:disabled {
+.c26:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c31 {
+.c30 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
   font-size: 22px;
 }
 
-.c32 {
+.c31 {
   display: inline-block;
   transition: color .3s;
   margin-left: 4px;
@@ -435,14 +390,14 @@ exports[`failed state 1`] = `
   font-size: 14px;
 }
 
-.c37 {
+.c36 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
   font-size: 16px;
 }
 
-.c17 {
+.c16 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -451,7 +406,7 @@ exports[`failed state 1`] = `
   margin: 0px;
 }
 
-.c21 {
+.c20 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -462,7 +417,7 @@ exports[`failed state 1`] = `
   color: #FFFFFF;
 }
 
-.c25 {
+.c24 {
   overflow: hidden;
   text-overflow: ellipsis;
   text-transform: uppercase;
@@ -471,7 +426,7 @@ exports[`failed state 1`] = `
   margin: 0px;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
@@ -479,18 +434,18 @@ exports[`failed state 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   display: flex;
   align-items: center;
 }
 
-.c20 {
+.c19 {
   box-sizing: border-box;
   display: flex;
 }
 
-.c24 {
+.c23 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -501,7 +456,7 @@ exports[`failed state 1`] = `
   justify-content: center;
 }
 
-.c28 {
+.c27 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -512,7 +467,7 @@ exports[`failed state 1`] = `
   justify-content: center;
 }
 
-.c29 {
+.c28 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -523,7 +478,7 @@ exports[`failed state 1`] = `
   justify-content: center;
 }
 
-.c30 {
+.c29 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -534,14 +489,14 @@ exports[`failed state 1`] = `
   justify-content: center;
 }
 
-.c34 {
+.c33 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
   justify-content: flex-end;
 }
 
-.c35 {
+.c34 {
   box-sizing: border-box;
   margin-right: 8px;
   display: flex;
@@ -589,7 +544,7 @@ exports[`failed state 1`] = `
   padding-bottom: 24px;
 }
 
-.c22 {
+.c21 {
   background: #222C59;
   box-shadow: 0 4px 16px rgba(0,0,0,0.24);
   border-collapse: collapse;
@@ -598,39 +553,39 @@ exports[`failed state 1`] = `
   width: 100%;
 }
 
-.c22 > thead > tr > th,
-.c22 > tbody > tr > th,
-.c22 > tfoot > tr > th,
-.c22 > thead > tr > td,
-.c22 > tbody > tr > td,
-.c22 > tfoot > tr > td {
+.c21 > thead > tr > th,
+.c21 > tbody > tr > th,
+.c21 > tfoot > tr > th,
+.c21 > thead > tr > td,
+.c21 > tbody > tr > td,
+.c21 > tfoot > tr > td {
   padding: 8px 8px;
   vertical-align: middle;
 }
 
-.c22 > thead > tr > th:first-child,
-.c22 > tbody > tr > th:first-child,
-.c22 > tfoot > tr > th:first-child,
-.c22 > thead > tr > td:first-child,
-.c22 > tbody > tr > td:first-child,
-.c22 > tfoot > tr > td:first-child {
+.c21 > thead > tr > th:first-child,
+.c21 > tbody > tr > th:first-child,
+.c21 > tfoot > tr > th:first-child,
+.c21 > thead > tr > td:first-child,
+.c21 > tbody > tr > td:first-child,
+.c21 > tfoot > tr > td:first-child {
   padding-left: 24px;
 }
 
-.c22 > thead > tr > th:last-child,
-.c22 > tbody > tr > th:last-child,
-.c22 > tfoot > tr > th:last-child,
-.c22 > thead > tr > td:last-child,
-.c22 > tbody > tr > td:last-child,
-.c22 > tfoot > tr > td:last-child {
+.c21 > thead > tr > th:last-child,
+.c21 > tbody > tr > th:last-child,
+.c21 > tfoot > tr > th:last-child,
+.c21 > thead > tr > td:last-child,
+.c21 > tbody > tr > td:last-child,
+.c21 > tfoot > tr > td:last-child {
   padding-right: 24px;
 }
 
-.c22 > tbody > tr > td {
+.c21 > tbody > tr > td {
   vertical-align: baseline;
 }
 
-.c22 > thead > tr > th {
+.c21 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
   cursor: pointer;
@@ -644,26 +599,26 @@ exports[`failed state 1`] = `
   white-space: nowrap;
 }
 
-.c22 > thead > tr > th .c18 {
+.c21 > thead > tr > th .c17 {
   font-weight: bold;
   font-size: 8px;
   margin-left: 8px;
 }
 
-.c22 > tbody > tr > td {
+.c21 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
 }
 
-.c22 tbody tr {
+.c21 tbody tr {
   border-bottom: 1px solid #1C254D;
 }
 
-.c22 tbody tr:hover {
+.c21 tbody tr:hover {
   background-color: rgb(37,49,98);
 }
 
-.c5 {
+.c4 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -675,7 +630,7 @@ exports[`failed state 1`] = `
   border-top-right-radius: 8px;
 }
 
-.c33 {
+.c32 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -687,7 +642,7 @@ exports[`failed state 1`] = `
   border-bottom-left-radius: 8px;
 }
 
-.c26 {
+.c25 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -705,32 +660,32 @@ exports[`failed state 1`] = `
   cursor: pointer;
 }
 
-.c36 {
+.c35 {
   background: none;
   border: none;
   cursor: pointer;
 }
 
-.c36 .c18 {
+.c35 .c17 {
   font-size: 20px;
   transition: all 0.3s;
   opacity: 0.5;
 }
 
-.c36:hover .c18,
-.c36:focus .c18 {
+.c35:hover .c17,
+.c35:focus .c17 {
   opacity: 1;
 }
 
-.c36:disabled {
+.c35:disabled {
   cursor: default;
 }
 
-.c36:disabled .c18 {
+.c35:disabled .c17 {
   opacity: 0.1;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   height: 100%;
   right: 0;
@@ -741,7 +696,7 @@ exports[`failed state 1`] = `
   border-radius: 200px;
 }
 
-.c9 {
+.c8 {
   position: relative;
   display: flex;
   overflow: hidden;
@@ -751,7 +706,7 @@ exports[`failed state 1`] = `
   background: #111B48;
 }
 
-.c10 {
+.c9 {
   border: none;
   outline: none;
   box-sizing: border-box;
@@ -766,27 +721,27 @@ exports[`failed state 1`] = `
   padding-right: 184px;
 }
 
-.c10:hover,
-.c10:focus,
-.c10:active {
+.c9:hover,
+.c9:focus,
+.c9:active {
   background: #1C254D;
   box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
   color: rgba(255,255,255,0.87);
 }
 
-.c10::placeholder {
+.c9::placeholder {
   color: rgba(255,255,255,0.24);
   font-size: 12px;
 }
 
-.c13 {
+.c12 {
   position: relative;
   display: flex;
   align-items: center;
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   width: 32px;
   height: 12px;
   border-radius: 12px;
@@ -794,7 +749,7 @@ exports[`failed state 1`] = `
   cursor: pointer;
 }
 
-.c16:before {
+.c15:before {
   content: '';
   position: absolute;
   top: 50%;
@@ -805,21 +760,21 @@ exports[`failed state 1`] = `
   background: #651FFF;
 }
 
-.c14 {
+.c13 {
   opacity: 0;
   position: absolute;
   cursor: pointer;
 }
 
-.c14:checked + .c15 {
+.c13:checked + .c14 {
   background: #512FC9;
 }
 
-.c14:checked + .c15:before {
+.c13:checked + .c14:before {
   transform: translate(16px,-50%);
 }
 
-.c12 {
+.c11 {
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -828,7 +783,7 @@ exports[`failed state 1`] = `
   width: 120px;
 }
 
-.c23 > tbody > tr > td {
+.c22 > tbody > tr > td {
   vertical-align: middle;
 }
 
@@ -844,18 +799,9 @@ exports[`failed state 1`] = `
       >
         Applications
       </div>
-      <button
-        class="c3"
-        kind="primary"
-        title=""
-        width="240px"
-      >
-        Add 
-        application
-      </button>
     </div>
     <div
-      class="c4"
+      class="c3"
       kind="danger"
     >
       <div>
@@ -863,47 +809,47 @@ exports[`failed state 1`] = `
       </div>
     </div>
     <form
-      class="c5"
+      class="c4"
     >
       <div
-        class="c6"
+        class="c5"
         width="100%"
       >
         <div
-          class="c7"
+          class="c6"
           style="width: 70%;"
         >
           <div
-            class="c8"
+            class="c7"
             width="100%"
           >
             <div
-              class="c9"
+              class="c8"
             >
               <input
-                class="c10"
+                class="c9"
                 placeholder="SEARCH..."
                 value=""
               />
               <div
-                class="c11"
+                class="c10"
               >
                 <div
-                  class="c12"
+                  class="c11"
                 >
                   <label
-                    class="c13"
+                    class="c12"
                   >
                     <input
-                      class="c14"
+                      class="c13"
                       type="checkbox"
                     />
                     <div
-                      class="c15 c16"
+                      class="c14 c15"
                     />
                   </label>
                   <div
-                    class="c17"
+                    class="c16"
                   >
                     Advanced
                   </div>
@@ -915,17 +861,17 @@ exports[`failed state 1`] = `
             style="line-height: 0px;"
           >
             <span
-              class="c18 c19 icon icon-info_outline "
+              class="c17 c18 icon icon-info_outline "
               color="light"
               style="cursor: pointer; font-size: 20px;"
             />
           </div>
         </div>
         <div
-          class="c20"
+          class="c19"
         >
           <div
-            class="c21"
+            class="c20"
             color="primary.contrastText"
           >
             SHOWING 
@@ -946,7 +892,7 @@ exports[`failed state 1`] = `
       </div>
     </form>
     <table
-      class="c22 c23"
+      class="c21 c22"
     >
       <thead>
         <tr>
@@ -957,7 +903,7 @@ exports[`failed state 1`] = `
             <a>
               Name
               <span
-                class="c18 c19 icon icon-chevron-up "
+                class="c17 c18 icon icon-chevron-up "
                 color="light"
               />
             </a>
@@ -966,7 +912,7 @@ exports[`failed state 1`] = `
             <a>
               Description
               <span
-                class="c18 c19 icon icon-chevrons-expand-vertical "
+                class="c17 c18 icon icon-chevrons-expand-vertical "
                 color="light"
               />
             </a>
@@ -992,12 +938,12 @@ exports[`failed state 1`] = `
             style="user-select: none;"
           >
             <div
-              class="c24"
+              class="c23"
               height="32px"
               width="32px"
             >
               <div
-                class="c25"
+                class="c24"
                 font-size="3"
               >
                 J
@@ -1016,13 +962,13 @@ exports[`failed state 1`] = `
           </td>
           <td>
             <div
-              class="c26"
+              class="c25"
               kind="secondary"
             >
               env: prod
             </div>
             <div
-              class="c26"
+              class="c25"
               kind="secondary"
             >
               cluster: one
@@ -1032,8 +978,64 @@ exports[`failed state 1`] = `
             align="right"
           >
             <a
-              class="c27"
+              class="c26"
               href="/web/launch/jenkins.one/one/jenkins.teleport-proxy.com"
+              kind="border"
+              rel="noreferrer"
+              target="_blank"
+              width="88px"
+            >
+              LAUNCH
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td
+            style="user-select: none;"
+          >
+            <div
+              class="c27"
+              height="32px"
+              width="32px"
+            >
+              <div
+                class="c24"
+                font-size="3"
+              >
+                M
+              </div>
+            </div>
+          </td>
+          <td>
+            Mattermost1
+          </td>
+          <td>
+            This is a Mattermost app
+          </td>
+          <td>
+            https://
+            mattermost.teleport-proxy.com
+          </td>
+          <td>
+            <div
+              class="c25"
+              kind="secondary"
+            >
+              env: dev
+            </div>
+            <div
+              class="c25"
+              kind="secondary"
+            >
+              cluster: two
+            </div>
+          </td>
+          <td
+            align="right"
+          >
+            <a
+              class="c26"
+              href="/web/launch/mattermost.one/one/mattermost.teleport-proxy.com"
               kind="border"
               rel="noreferrer"
               target="_blank"
@@ -1053,63 +1055,7 @@ exports[`failed state 1`] = `
               width="32px"
             >
               <div
-                class="c25"
-                font-size="3"
-              >
-                M
-              </div>
-            </div>
-          </td>
-          <td>
-            Mattermost1
-          </td>
-          <td>
-            This is a Mattermost app
-          </td>
-          <td>
-            https://
-            mattermost.teleport-proxy.com
-          </td>
-          <td>
-            <div
-              class="c26"
-              kind="secondary"
-            >
-              env: dev
-            </div>
-            <div
-              class="c26"
-              kind="secondary"
-            >
-              cluster: two
-            </div>
-          </td>
-          <td
-            align="right"
-          >
-            <a
-              class="c27"
-              href="/web/launch/mattermost.one/one/mattermost.teleport-proxy.com"
-              kind="border"
-              rel="noreferrer"
-              target="_blank"
-              width="88px"
-            >
-              LAUNCH
-            </a>
-          </td>
-        </tr>
-        <tr>
-          <td
-            style="user-select: none;"
-          >
-            <div
-              class="c29"
-              height="32px"
-              width="32px"
-            >
-              <div
-                class="c25"
+                class="c24"
                 font-size="3"
               >
                 G
@@ -1128,13 +1074,13 @@ exports[`failed state 1`] = `
           </td>
           <td>
             <div
-              class="c26"
+              class="c25"
               kind="secondary"
             >
               env: dev
             </div>
             <div
-              class="c26"
+              class="c25"
               kind="secondary"
             >
               cluster: one
@@ -1144,7 +1090,7 @@ exports[`failed state 1`] = `
             align="right"
           >
             <a
-              class="c27"
+              class="c26"
               href="/web/launch/grafana.one/one/grafana.teleport-proxy.com"
               kind="border"
               rel="noreferrer"
@@ -1160,12 +1106,12 @@ exports[`failed state 1`] = `
             style="user-select: none;"
           >
             <div
-              class="c30"
+              class="c29"
               height="32px"
               width="32px"
             >
               <span
-                class="c18 c31 icon icon-amazonaws "
+                class="c17 c30 icon icon-amazonaws "
                 color="light"
                 font-size="6"
               />
@@ -1183,19 +1129,19 @@ exports[`failed state 1`] = `
           </td>
           <td>
             <div
-              class="c26"
+              class="c25"
               kind="secondary"
             >
               aws_account_id: A1234
             </div>
             <div
-              class="c26"
+              class="c25"
               kind="secondary"
             >
               env: dev
             </div>
             <div
-              class="c26"
+              class="c25"
               kind="secondary"
             >
               cluster: two
@@ -1205,13 +1151,13 @@ exports[`failed state 1`] = `
             align="right"
           >
             <button
-              class="c27"
+              class="c26"
               kind="border"
               width="88px"
             >
               LAUNCH
               <span
-                class="c18 c32 icon icon-caret-down "
+                class="c17 c31 icon icon-caret-down "
                 color="text.secondary"
                 font-size="2"
               />
@@ -1221,36 +1167,36 @@ exports[`failed state 1`] = `
       </tbody>
     </table>
     <nav
-      class="c33"
+      class="c32"
     >
       <div
-        class="c34"
+        class="c33"
         width="100%"
       >
         <div
-          class="c35"
+          class="c34"
         />
         <div
-          class="c20"
+          class="c19"
         >
           <button
-            class="c36"
+            class="c35"
             disabled=""
             title="Previous page"
           >
             <span
-              class="c18 c37 icon icon-arrow-left-circle "
+              class="c17 c36 icon icon-arrow-left-circle "
               color="light"
               font-size="3"
             />
           </button>
           <button
-            class="c36"
+            class="c35"
             disabled=""
             title="Next page"
           >
             <span
-              class="c18 c37 icon icon-arrow-right-circle "
+              class="c17 c36 icon icon-arrow-right-circle "
               color="light"
               font-size="3"
             />

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -65,16 +65,13 @@ export function Databases(props: State) {
     onLabelClick,
   } = props;
 
-  const hasNoDatabases =
-    attempt.status === 'success' &&
-    results.databases.length === 0 &&
-    isSearchEmpty;
+  const hasNoDatabases = results.databases.length === 0 && isSearchEmpty;
 
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Databases</FeatureHeaderTitle>
-        {!hasNoDatabases && (
+        {attempt.status === 'success' && !hasNoDatabases && (
           <ButtonAdd
             isLeafCluster={isLeafCluster}
             canCreate={canCreate}
@@ -114,7 +111,7 @@ export function Databases(props: State) {
           />
         </>
       )}
-      {hasNoDatabases && (
+      {attempt.status === 'success' && hasNoDatabases && (
         <Empty
           clusterId={clusterId}
           canCreate={canCreate && !isLeafCluster}

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -293,7 +293,7 @@ exports[`empty state for enterprise, can create 1`] = `
 `;
 
 exports[`failed 1`] = `
-.c4 {
+.c3 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -310,62 +310,17 @@ exports[`failed 1`] = `
   color: #FFFFFF;
 }
 
-.c4 a {
+.c3 a {
   color: #FFFFFF;
 }
 
-.c8 {
+.c7 {
   box-sizing: border-box;
   margin-right: 16px;
   width: 100%;
 }
 
-.c3 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  width: 240px;
-}
-
-.c3:active {
-  opacity: 0.56;
-}
-
-.c3:hover,
-.c3:focus {
-  background: #651FFF;
-}
-
-.c3:active {
-  background: #354AA4;
-}
-
-.c3:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c24 {
+.c23 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -393,40 +348,40 @@ exports[`failed 1`] = `
   padding: 0px 16px;
 }
 
-.c24:active {
+.c23:active {
   opacity: 0.56;
 }
 
-.c24:hover,
-.c24:focus {
+.c23:hover,
+.c23:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c24:active {
+.c23:active {
   opacity: 0.24;
 }
 
-.c24:disabled {
+.c23:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c29 {
+.c28 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
   font-size: 16px;
 }
 
-.c17 {
+.c16 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -435,7 +390,7 @@ exports[`failed 1`] = `
   margin: 0px;
 }
 
-.c21 {
+.c20 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -446,7 +401,7 @@ exports[`failed 1`] = `
   color: #FFFFFF;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
@@ -454,25 +409,25 @@ exports[`failed 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   display: flex;
   align-items: center;
 }
 
-.c20 {
+.c19 {
   box-sizing: border-box;
   display: flex;
 }
 
-.c26 {
+.c25 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
   justify-content: flex-end;
 }
 
-.c27 {
+.c26 {
   box-sizing: border-box;
   margin-right: 8px;
   display: flex;
@@ -520,7 +475,7 @@ exports[`failed 1`] = `
   padding-bottom: 24px;
 }
 
-.c22 {
+.c21 {
   background: #222C59;
   box-shadow: 0 4px 16px rgba(0,0,0,0.24);
   border-collapse: collapse;
@@ -529,39 +484,39 @@ exports[`failed 1`] = `
   width: 100%;
 }
 
-.c22 > thead > tr > th,
-.c22 > tbody > tr > th,
-.c22 > tfoot > tr > th,
-.c22 > thead > tr > td,
-.c22 > tbody > tr > td,
-.c22 > tfoot > tr > td {
+.c21 > thead > tr > th,
+.c21 > tbody > tr > th,
+.c21 > tfoot > tr > th,
+.c21 > thead > tr > td,
+.c21 > tbody > tr > td,
+.c21 > tfoot > tr > td {
   padding: 8px 8px;
   vertical-align: middle;
 }
 
-.c22 > thead > tr > th:first-child,
-.c22 > tbody > tr > th:first-child,
-.c22 > tfoot > tr > th:first-child,
-.c22 > thead > tr > td:first-child,
-.c22 > tbody > tr > td:first-child,
-.c22 > tfoot > tr > td:first-child {
+.c21 > thead > tr > th:first-child,
+.c21 > tbody > tr > th:first-child,
+.c21 > tfoot > tr > th:first-child,
+.c21 > thead > tr > td:first-child,
+.c21 > tbody > tr > td:first-child,
+.c21 > tfoot > tr > td:first-child {
   padding-left: 24px;
 }
 
-.c22 > thead > tr > th:last-child,
-.c22 > tbody > tr > th:last-child,
-.c22 > tfoot > tr > th:last-child,
-.c22 > thead > tr > td:last-child,
-.c22 > tbody > tr > td:last-child,
-.c22 > tfoot > tr > td:last-child {
+.c21 > thead > tr > th:last-child,
+.c21 > tbody > tr > th:last-child,
+.c21 > tfoot > tr > th:last-child,
+.c21 > thead > tr > td:last-child,
+.c21 > tbody > tr > td:last-child,
+.c21 > tfoot > tr > td:last-child {
   padding-right: 24px;
 }
 
-.c22 > tbody > tr > td {
+.c21 > tbody > tr > td {
   vertical-align: baseline;
 }
 
-.c22 > thead > tr > th {
+.c21 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
   cursor: pointer;
@@ -575,26 +530,26 @@ exports[`failed 1`] = `
   white-space: nowrap;
 }
 
-.c22 > thead > tr > th .c18 {
+.c21 > thead > tr > th .c17 {
   font-weight: bold;
   font-size: 8px;
   margin-left: 8px;
 }
 
-.c22 > tbody > tr > td {
+.c21 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
 }
 
-.c22 tbody tr {
+.c21 tbody tr {
   border-bottom: 1px solid #1C254D;
 }
 
-.c22 tbody tr:hover {
+.c21 tbody tr:hover {
   background-color: rgb(37,49,98);
 }
 
-.c5 {
+.c4 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -606,7 +561,7 @@ exports[`failed 1`] = `
   border-top-right-radius: 8px;
 }
 
-.c25 {
+.c24 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -618,7 +573,7 @@ exports[`failed 1`] = `
   border-bottom-left-radius: 8px;
 }
 
-.c23 {
+.c22 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -636,32 +591,32 @@ exports[`failed 1`] = `
   cursor: pointer;
 }
 
-.c28 {
+.c27 {
   background: none;
   border: none;
   cursor: pointer;
 }
 
-.c28 .c18 {
+.c27 .c17 {
   font-size: 20px;
   transition: all 0.3s;
   opacity: 0.5;
 }
 
-.c28:hover .c18,
-.c28:focus .c18 {
+.c27:hover .c17,
+.c27:focus .c17 {
   opacity: 1;
 }
 
-.c28:disabled {
+.c27:disabled {
   cursor: default;
 }
 
-.c28:disabled .c18 {
+.c27:disabled .c17 {
   opacity: 0.1;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   height: 100%;
   right: 0;
@@ -672,7 +627,7 @@ exports[`failed 1`] = `
   border-radius: 200px;
 }
 
-.c9 {
+.c8 {
   position: relative;
   display: flex;
   overflow: hidden;
@@ -682,7 +637,7 @@ exports[`failed 1`] = `
   background: #111B48;
 }
 
-.c10 {
+.c9 {
   border: none;
   outline: none;
   box-sizing: border-box;
@@ -697,27 +652,27 @@ exports[`failed 1`] = `
   padding-right: 184px;
 }
 
-.c10:hover,
-.c10:focus,
-.c10:active {
+.c9:hover,
+.c9:focus,
+.c9:active {
   background: #1C254D;
   box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
   color: rgba(255,255,255,0.87);
 }
 
-.c10::placeholder {
+.c9::placeholder {
   color: rgba(255,255,255,0.24);
   font-size: 12px;
 }
 
-.c13 {
+.c12 {
   position: relative;
   display: flex;
   align-items: center;
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   width: 32px;
   height: 12px;
   border-radius: 12px;
@@ -725,7 +680,7 @@ exports[`failed 1`] = `
   cursor: pointer;
 }
 
-.c16:before {
+.c15:before {
   content: '';
   position: absolute;
   top: 50%;
@@ -736,21 +691,21 @@ exports[`failed 1`] = `
   background: #651FFF;
 }
 
-.c14 {
+.c13 {
   opacity: 0;
   position: absolute;
   cursor: pointer;
 }
 
-.c14:checked + .c15 {
+.c13:checked + .c14 {
   background: #512FC9;
 }
 
-.c14:checked + .c15:before {
+.c13:checked + .c14:before {
   transform: translate(16px,-50%);
 }
 
-.c12 {
+.c11 {
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -770,17 +725,9 @@ exports[`failed 1`] = `
     >
       Databases
     </div>
-    <button
-      class="c3"
-      kind="primary"
-      title=""
-      width="240px"
-    >
-      Add Database
-    </button>
   </div>
   <div
-    class="c4"
+    class="c3"
     kind="danger"
   >
     <div>
@@ -788,47 +735,47 @@ exports[`failed 1`] = `
     </div>
   </div>
   <form
-    class="c5"
+    class="c4"
   >
     <div
-      class="c6"
+      class="c5"
       width="100%"
     >
       <div
-        class="c7"
+        class="c6"
         style="width: 70%;"
       >
         <div
-          class="c8"
+          class="c7"
           width="100%"
         >
           <div
-            class="c9"
+            class="c8"
           >
             <input
-              class="c10"
+              class="c9"
               placeholder="SEARCH..."
               value=""
             />
             <div
-              class="c11"
+              class="c10"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <label
-                  class="c13"
+                  class="c12"
                 >
                   <input
-                    class="c14"
+                    class="c13"
                     type="checkbox"
                   />
                   <div
-                    class="c15 c16"
+                    class="c14 c15"
                   />
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 >
                   Advanced
                 </div>
@@ -840,17 +787,17 @@ exports[`failed 1`] = `
           style="line-height: 0px;"
         >
           <span
-            class="c18 c19 icon icon-info_outline "
+            class="c17 c18 icon icon-info_outline "
             color="light"
             style="cursor: pointer; font-size: 20px;"
           />
         </div>
       </div>
       <div
-        class="c20"
+        class="c19"
       >
         <div
-          class="c21"
+          class="c20"
           color="primary.contrastText"
         >
           SHOWING 
@@ -871,7 +818,7 @@ exports[`failed 1`] = `
     </div>
   </form>
   <table
-    class="c22"
+    class="c21"
   >
     <thead>
       <tr>
@@ -879,7 +826,7 @@ exports[`failed 1`] = `
           <a>
             Name
             <span
-              class="c18 c19 icon icon-chevron-up "
+              class="c17 c18 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -888,7 +835,7 @@ exports[`failed 1`] = `
           <a>
             Description
             <span
-              class="c18 c19 icon icon-chevrons-expand-vertical "
+              class="c17 c18 icon icon-chevrons-expand-vertical "
               color="light"
             />
           </a>
@@ -897,7 +844,7 @@ exports[`failed 1`] = `
           <a>
             Type
             <span
-              class="c18 c19 icon icon-chevrons-expand-vertical "
+              class="c17 c18 icon icon-chevrons-expand-vertical "
               color="light"
             />
           </a>
@@ -925,13 +872,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             cluster: root
           </div>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             env: aws
@@ -941,7 +888,7 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c24"
+            class="c23"
             kind="border"
           >
             Connect
@@ -960,13 +907,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             cluster: root
           </div>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             env: gcp
@@ -976,7 +923,7 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c24"
+            class="c23"
             kind="border"
           >
             Connect
@@ -995,13 +942,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             cluster: root
           </div>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             env: aws
@@ -1011,7 +958,7 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c24"
+            class="c23"
             kind="border"
           >
             Connect
@@ -1021,36 +968,36 @@ exports[`failed 1`] = `
     </tbody>
   </table>
   <nav
-    class="c25"
+    class="c24"
   >
     <div
-      class="c26"
+      class="c25"
       width="100%"
     >
       <div
-        class="c27"
+        class="c26"
       />
       <div
-        class="c20"
+        class="c19"
       >
         <button
-          class="c28"
+          class="c27"
           disabled=""
           title="Previous page"
         >
           <span
-            class="c18 c29 icon icon-arrow-left-circle "
+            class="c17 c28 icon icon-arrow-left-circle "
             color="light"
             font-size="3"
           />
         </button>
         <button
-          class="c28"
+          class="c27"
           disabled=""
           title="Next page"
         >
           <span
-            class="c18 c29 icon icon-arrow-right-circle "
+            class="c17 c28 icon icon-arrow-right-circle "
             color="light"
             font-size="3"
           />

--- a/packages/teleport/src/Desktops/Desktops.tsx
+++ b/packages/teleport/src/Desktops/Desktops.tsx
@@ -61,16 +61,13 @@ export function Desktops(props: State) {
     onLabelClick,
   } = props;
 
-  const hasNoDesktops =
-    attempt.status === 'success' &&
-    results.desktops.length === 0 &&
-    isSearchEmpty;
+  const hasNoDesktops = results.desktops.length === 0 && isSearchEmpty;
 
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Desktops</FeatureHeaderTitle>
-        {!hasNoDesktops && (
+        {attempt.status === 'success' && !hasNoDesktops && (
           <ButtonPrimary
             as="a"
             width="240px"
@@ -113,7 +110,7 @@ export function Desktops(props: State) {
           onLabelClick={onLabelClick}
         />
       )}
-      {hasNoDesktops && (
+      {attempt.status === 'success' && hasNoDesktops && (
         <Empty
           clusterId={clusterId}
           canCreate={canCreate && !isLeafCluster}

--- a/packages/teleport/src/Kubes/Kubes.tsx
+++ b/packages/teleport/src/Kubes/Kubes.tsx
@@ -64,14 +64,13 @@ export function Kubes(props: State) {
 
   const [showAddKube, setShowAddKube] = useState(false);
 
-  const hasNoKubes =
-    attempt.status === 'success' && results.kubes.length === 0 && isSearchEmpty;
+  const hasNoKubes = results.kubes.length === 0 && isSearchEmpty;
 
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Kubernetes</FeatureHeaderTitle>
-        {!hasNoKubes && (
+        {attempt.status === 'success' && !hasNoKubes && (
           <AgentButtonAdd
             onClick={() => setShowAddKube(true)}
             agent="kubernetes"
@@ -113,7 +112,7 @@ export function Kubes(props: State) {
           />
         </>
       )}
-      {hasNoKubes && (
+      {attempt.status === 'success' && hasNoKubes && (
         <Empty
           clusterId={clusterId}
           canCreate={canCreate && !isLeafCluster}

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -293,7 +293,7 @@ exports[`empty state 1`] = `
 `;
 
 exports[`failed 1`] = `
-.c4 {
+.c3 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -310,62 +310,17 @@ exports[`failed 1`] = `
   color: #FFFFFF;
 }
 
-.c4 a {
+.c3 a {
   color: #FFFFFF;
 }
 
-.c8 {
+.c7 {
   box-sizing: border-box;
   margin-right: 16px;
   width: 100%;
 }
 
-.c3 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  width: 240px;
-}
-
-.c3:active {
-  opacity: 0.56;
-}
-
-.c3:hover,
-.c3:focus {
-  background: #651FFF;
-}
-
-.c3:active {
-  background: #354AA4;
-}
-
-.c3:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c24 {
+.c23 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -393,40 +348,40 @@ exports[`failed 1`] = `
   padding: 0px 16px;
 }
 
-.c24:active {
+.c23:active {
   opacity: 0.56;
 }
 
-.c24:hover,
-.c24:focus {
+.c23:hover,
+.c23:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c24:active {
+.c23:active {
   opacity: 0.24;
 }
 
-.c24:disabled {
+.c23:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c29 {
+.c28 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
   font-size: 16px;
 }
 
-.c17 {
+.c16 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -435,7 +390,7 @@ exports[`failed 1`] = `
   margin: 0px;
 }
 
-.c21 {
+.c20 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -446,7 +401,7 @@ exports[`failed 1`] = `
   color: #FFFFFF;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
@@ -454,32 +409,32 @@ exports[`failed 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   display: flex;
   align-items: center;
 }
 
-.c20 {
+.c19 {
   box-sizing: border-box;
   display: flex;
 }
 
-.c26 {
+.c25 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
   justify-content: flex-end;
 }
 
-.c27 {
+.c26 {
   box-sizing: border-box;
   margin-right: 8px;
   display: flex;
   align-items: center;
 }
 
-.c22 {
+.c21 {
   background: #222C59;
   box-shadow: 0 4px 16px rgba(0,0,0,0.24);
   border-collapse: collapse;
@@ -488,39 +443,39 @@ exports[`failed 1`] = `
   width: 100%;
 }
 
-.c22 > thead > tr > th,
-.c22 > tbody > tr > th,
-.c22 > tfoot > tr > th,
-.c22 > thead > tr > td,
-.c22 > tbody > tr > td,
-.c22 > tfoot > tr > td {
+.c21 > thead > tr > th,
+.c21 > tbody > tr > th,
+.c21 > tfoot > tr > th,
+.c21 > thead > tr > td,
+.c21 > tbody > tr > td,
+.c21 > tfoot > tr > td {
   padding: 8px 8px;
   vertical-align: middle;
 }
 
-.c22 > thead > tr > th:first-child,
-.c22 > tbody > tr > th:first-child,
-.c22 > tfoot > tr > th:first-child,
-.c22 > thead > tr > td:first-child,
-.c22 > tbody > tr > td:first-child,
-.c22 > tfoot > tr > td:first-child {
+.c21 > thead > tr > th:first-child,
+.c21 > tbody > tr > th:first-child,
+.c21 > tfoot > tr > th:first-child,
+.c21 > thead > tr > td:first-child,
+.c21 > tbody > tr > td:first-child,
+.c21 > tfoot > tr > td:first-child {
   padding-left: 24px;
 }
 
-.c22 > thead > tr > th:last-child,
-.c22 > tbody > tr > th:last-child,
-.c22 > tfoot > tr > th:last-child,
-.c22 > thead > tr > td:last-child,
-.c22 > tbody > tr > td:last-child,
-.c22 > tfoot > tr > td:last-child {
+.c21 > thead > tr > th:last-child,
+.c21 > tbody > tr > th:last-child,
+.c21 > tfoot > tr > th:last-child,
+.c21 > thead > tr > td:last-child,
+.c21 > tbody > tr > td:last-child,
+.c21 > tfoot > tr > td:last-child {
   padding-right: 24px;
 }
 
-.c22 > tbody > tr > td {
+.c21 > tbody > tr > td {
   vertical-align: baseline;
 }
 
-.c22 > thead > tr > th {
+.c21 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
   cursor: pointer;
@@ -534,26 +489,26 @@ exports[`failed 1`] = `
   white-space: nowrap;
 }
 
-.c22 > thead > tr > th .c18 {
+.c21 > thead > tr > th .c17 {
   font-weight: bold;
   font-size: 8px;
   margin-left: 8px;
 }
 
-.c22 > tbody > tr > td {
+.c21 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
 }
 
-.c22 tbody tr {
+.c21 tbody tr {
   border-bottom: 1px solid #1C254D;
 }
 
-.c22 tbody tr:hover {
+.c21 tbody tr:hover {
   background-color: rgb(37,49,98);
 }
 
-.c5 {
+.c4 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -565,7 +520,7 @@ exports[`failed 1`] = `
   border-top-right-radius: 8px;
 }
 
-.c25 {
+.c24 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -577,7 +532,7 @@ exports[`failed 1`] = `
   border-bottom-left-radius: 8px;
 }
 
-.c23 {
+.c22 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -595,32 +550,32 @@ exports[`failed 1`] = `
   cursor: pointer;
 }
 
-.c28 {
+.c27 {
   background: none;
   border: none;
   cursor: pointer;
 }
 
-.c28 .c18 {
+.c27 .c17 {
   font-size: 20px;
   transition: all 0.3s;
   opacity: 0.5;
 }
 
-.c28:hover .c18,
-.c28:focus .c18 {
+.c27:hover .c17,
+.c27:focus .c17 {
   opacity: 1;
 }
 
-.c28:disabled {
+.c27:disabled {
   cursor: default;
 }
 
-.c28:disabled .c18 {
+.c27:disabled .c17 {
   opacity: 0.1;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   height: 100%;
   right: 0;
@@ -631,7 +586,7 @@ exports[`failed 1`] = `
   border-radius: 200px;
 }
 
-.c9 {
+.c8 {
   position: relative;
   display: flex;
   overflow: hidden;
@@ -641,7 +596,7 @@ exports[`failed 1`] = `
   background: #111B48;
 }
 
-.c10 {
+.c9 {
   border: none;
   outline: none;
   box-sizing: border-box;
@@ -656,27 +611,27 @@ exports[`failed 1`] = `
   padding-right: 184px;
 }
 
-.c10:hover,
-.c10:focus,
-.c10:active {
+.c9:hover,
+.c9:focus,
+.c9:active {
   background: #1C254D;
   box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
   color: rgba(255,255,255,0.87);
 }
 
-.c10::placeholder {
+.c9::placeholder {
   color: rgba(255,255,255,0.24);
   font-size: 12px;
 }
 
-.c13 {
+.c12 {
   position: relative;
   display: flex;
   align-items: center;
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   width: 32px;
   height: 12px;
   border-radius: 12px;
@@ -684,7 +639,7 @@ exports[`failed 1`] = `
   cursor: pointer;
 }
 
-.c16:before {
+.c15:before {
   content: '';
   position: absolute;
   top: 50%;
@@ -695,21 +650,21 @@ exports[`failed 1`] = `
   background: #651FFF;
 }
 
-.c14 {
+.c13 {
   opacity: 0;
   position: absolute;
   cursor: pointer;
 }
 
-.c14:checked + .c15 {
+.c13:checked + .c14 {
   background: #512FC9;
 }
 
-.c14:checked + .c15:before {
+.c13:checked + .c14:before {
   transform: translate(16px,-50%);
 }
 
-.c12 {
+.c11 {
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -770,18 +725,9 @@ exports[`failed 1`] = `
     >
       Kubernetes
     </div>
-    <button
-      class="c3"
-      kind="primary"
-      title=""
-      width="240px"
-    >
-      Add 
-      kubernetes
-    </button>
   </div>
   <div
-    class="c4"
+    class="c3"
     kind="danger"
   >
     <div>
@@ -789,47 +735,47 @@ exports[`failed 1`] = `
     </div>
   </div>
   <form
-    class="c5"
+    class="c4"
   >
     <div
-      class="c6"
+      class="c5"
       width="100%"
     >
       <div
-        class="c7"
+        class="c6"
         style="width: 70%;"
       >
         <div
-          class="c8"
+          class="c7"
           width="100%"
         >
           <div
-            class="c9"
+            class="c8"
           >
             <input
-              class="c10"
+              class="c9"
               placeholder="SEARCH..."
               value=""
             />
             <div
-              class="c11"
+              class="c10"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <label
-                  class="c13"
+                  class="c12"
                 >
                   <input
-                    class="c14"
+                    class="c13"
                     type="checkbox"
                   />
                   <div
-                    class="c15 c16"
+                    class="c14 c15"
                   />
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 >
                   Advanced
                 </div>
@@ -841,17 +787,17 @@ exports[`failed 1`] = `
           style="line-height: 0px;"
         >
           <span
-            class="c18 c19 icon icon-info_outline "
+            class="c17 c18 icon icon-info_outline "
             color="light"
             style="cursor: pointer; font-size: 20px;"
           />
         </div>
       </div>
       <div
-        class="c20"
+        class="c19"
       >
         <div
-          class="c21"
+          class="c20"
           color="primary.contrastText"
         >
           SHOWING 
@@ -872,7 +818,7 @@ exports[`failed 1`] = `
     </div>
   </form>
   <table
-    class="c22"
+    class="c21"
   >
     <thead>
       <tr>
@@ -880,7 +826,7 @@ exports[`failed 1`] = `
           <a>
             Name
             <span
-              class="c18 c19 icon icon-chevron-up "
+              class="c17 c18 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -902,13 +848,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
           </div>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             env: prod
@@ -918,7 +864,7 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c24"
+            class="c23"
             kind="border"
           >
             Connect
@@ -931,7 +877,7 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             env: staging
@@ -941,7 +887,7 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c24"
+            class="c23"
             kind="border"
           >
             Connect
@@ -954,13 +900,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             cluster-name: some-cluster-name
           </div>
           <div
-            class="c23"
+            class="c22"
             kind="secondary"
           >
             env: idk
@@ -970,7 +916,7 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c24"
+            class="c23"
             kind="border"
           >
             Connect
@@ -980,36 +926,36 @@ exports[`failed 1`] = `
     </tbody>
   </table>
   <nav
-    class="c25"
+    class="c24"
   >
     <div
-      class="c26"
+      class="c25"
       width="100%"
     >
       <div
-        class="c27"
+        class="c26"
       />
       <div
-        class="c20"
+        class="c19"
       >
         <button
-          class="c28"
+          class="c27"
           disabled=""
           title="Previous page"
         >
           <span
-            class="c18 c29 icon icon-arrow-left-circle "
+            class="c17 c28 icon icon-arrow-left-circle "
             color="light"
             font-size="3"
           />
         </button>
         <button
-          class="c28"
+          class="c27"
           disabled=""
           title="Next page"
         >
           <span
-            class="c18 c29 icon icon-arrow-right-circle "
+            class="c17 c28 icon icon-arrow-right-circle "
             color="light"
             font-size="3"
           />

--- a/packages/teleport/src/Nodes/Nodes.tsx
+++ b/packages/teleport/src/Nodes/Nodes.tsx
@@ -75,14 +75,13 @@ export function Nodes(props: State) {
     startSshSession(login, serverId);
   }
 
-  const hasNoNodes =
-    attempt.status === 'success' && results.nodes.length === 0 && isSearchEmpty;
+  const hasNoNodes = results.nodes.length === 0 && isSearchEmpty;
 
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Servers</FeatureHeaderTitle>
-        {!hasNoNodes && (
+        {attempt.status === 'success' && !hasNoNodes && (
           <Flex alignItems="center">
             <QuickLaunch width="280px" onPress={onSshEnter} mr={3} />
             <AgentButtonAdd
@@ -126,7 +125,7 @@ export function Nodes(props: State) {
           />
         </>
       )}
-      {hasNoNodes && (
+      {attempt.status === 'success' && hasNoNodes && (
         <Empty
           clusterId={clusterId}
           canCreate={canCreate && !isLeafCluster}

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -293,7 +293,7 @@ exports[`empty state 1`] = `
 `;
 
 exports[`failed 1`] = `
-.c8 {
+.c3 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -310,62 +310,17 @@ exports[`failed 1`] = `
   color: #FFFFFF;
 }
 
-.c8 a {
+.c3 a {
   color: #FFFFFF;
 }
 
-.c11 {
+.c7 {
   box-sizing: border-box;
   margin-right: 16px;
   width: 100%;
 }
 
-.c7 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  width: 240px;
-}
-
-.c7:active {
-  opacity: 0.56;
-}
-
-.c7:hover,
-.c7:focus {
-  background: #651FFF;
-}
-
-.c7:active {
-  background: #354AA4;
-}
-
-.c7:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c27 {
+.c23 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -394,33 +349,33 @@ exports[`failed 1`] = `
   height: 24px;
 }
 
-.c27:active {
+.c23:active {
   opacity: 0.56;
 }
 
-.c27:hover,
-.c27:focus {
+.c23:hover,
+.c23:focus {
   background: #2C3A73;
   border: 1px solid rgba(255,255,255,0.1);
   opacity: 1;
 }
 
-.c27:active {
+.c23:active {
   opacity: 0.24;
 }
 
-.c27:disabled {
+.c23:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c22 {
+.c18 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
 }
 
-.c28 {
+.c24 {
   display: inline-block;
   transition: color .3s;
   margin-left: 8px;
@@ -429,14 +384,14 @@ exports[`failed 1`] = `
   font-size: 14px;
 }
 
-.c33 {
+.c29 {
   display: inline-block;
   transition: color .3s;
   color: #FFFFFF;
   font-size: 16px;
 }
 
-.c20 {
+.c16 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -445,7 +400,7 @@ exports[`failed 1`] = `
   margin: 0px;
 }
 
-.c24 {
+.c20 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -456,13 +411,7 @@ exports[`failed 1`] = `
   color: #FFFFFF;
 }
 
-.c3 {
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-}
-
-.c10 {
+.c5 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
@@ -470,19 +419,25 @@ exports[`failed 1`] = `
   justify-content: space-between;
 }
 
-.c23 {
+.c6 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+}
+
+.c19 {
   box-sizing: border-box;
   display: flex;
 }
 
-.c30 {
+.c26 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
   justify-content: flex-end;
 }
 
-.c31 {
+.c27 {
   box-sizing: border-box;
   margin-right: 8px;
   display: flex;
@@ -530,65 +485,7 @@ exports[`failed 1`] = `
   padding-bottom: 24px;
 }
 
-.c4 {
-  box-sizing: border-box;
-  margin-right: 16px;
-  width: 280px;
-  display: flex;
-  align-items: center;
-  height: 32px;
-  border: 1px solid;
-  border-radius: 4px;
-  border-color: rgba(255,255,255,0.24);
-}
-
-.c5 {
-  opacity: 0.75;
-  font-size: 11px;
-  font-weight: 500;
-  padding: 0 8px;
-  border-bottom-left-radius: 4px;
-  border-top-left-radius: 4px;
-}
-
-.c6 {
-  appearance: none;
-  border: none;
-  border-radius: 4px;
-  box-sizing: border-box;
-  border-bottom-left-radius: unset;
-  border-top-left-radius: unset;
-  display: block;
-  outline: none;
-  width: 100%;
-  height: 100%;
-  box-shadow: none;
-  padding-left: 8px;
-  font-size: 12px;
-  color: rgba(255,255,255,0.87);
-  background-color: #222C59;
-}
-
-.c6::-ms-clear {
-  display: none;
-}
-
-.c6:read-only {
-  cursor: not-allowed;
-}
-
-.c6::placeholder {
-  opacity: 1;
-  color: rgba(255,255,255,0.24);
-  font-size: 12px;
-}
-
-.c6:hover,
-.c6:focus {
-  background: #2C3A73;
-}
-
-.c25 {
+.c21 {
   background: #222C59;
   box-shadow: 0 4px 16px rgba(0,0,0,0.24);
   border-collapse: collapse;
@@ -597,39 +494,39 @@ exports[`failed 1`] = `
   width: 100%;
 }
 
-.c25 > thead > tr > th,
-.c25 > tbody > tr > th,
-.c25 > tfoot > tr > th,
-.c25 > thead > tr > td,
-.c25 > tbody > tr > td,
-.c25 > tfoot > tr > td {
+.c21 > thead > tr > th,
+.c21 > tbody > tr > th,
+.c21 > tfoot > tr > th,
+.c21 > thead > tr > td,
+.c21 > tbody > tr > td,
+.c21 > tfoot > tr > td {
   padding: 8px 8px;
   vertical-align: middle;
 }
 
-.c25 > thead > tr > th:first-child,
-.c25 > tbody > tr > th:first-child,
-.c25 > tfoot > tr > th:first-child,
-.c25 > thead > tr > td:first-child,
-.c25 > tbody > tr > td:first-child,
-.c25 > tfoot > tr > td:first-child {
+.c21 > thead > tr > th:first-child,
+.c21 > tbody > tr > th:first-child,
+.c21 > tfoot > tr > th:first-child,
+.c21 > thead > tr > td:first-child,
+.c21 > tbody > tr > td:first-child,
+.c21 > tfoot > tr > td:first-child {
   padding-left: 24px;
 }
 
-.c25 > thead > tr > th:last-child,
-.c25 > tbody > tr > th:last-child,
-.c25 > tfoot > tr > th:last-child,
-.c25 > thead > tr > td:last-child,
-.c25 > tbody > tr > td:last-child,
-.c25 > tfoot > tr > td:last-child {
+.c21 > thead > tr > th:last-child,
+.c21 > tbody > tr > th:last-child,
+.c21 > tfoot > tr > th:last-child,
+.c21 > thead > tr > td:last-child,
+.c21 > tbody > tr > td:last-child,
+.c21 > tfoot > tr > td:last-child {
   padding-right: 24px;
 }
 
-.c25 > tbody > tr > td {
+.c21 > tbody > tr > td {
   vertical-align: baseline;
 }
 
-.c25 > thead > tr > th {
+.c21 > thead > tr > th {
   background: #111B48;
   color: #FFFFFF;
   cursor: pointer;
@@ -643,26 +540,26 @@ exports[`failed 1`] = `
   white-space: nowrap;
 }
 
-.c25 > thead > tr > th .c21 {
+.c21 > thead > tr > th .c17 {
   font-weight: bold;
   font-size: 8px;
   margin-left: 8px;
 }
 
-.c25 > tbody > tr > td {
+.c21 > tbody > tr > td {
   color: rgba(255,255,255,0.87);
   line-height: 16px;
 }
 
-.c25 tbody tr {
+.c21 tbody tr {
   border-bottom: 1px solid #1C254D;
 }
 
-.c25 tbody tr:hover {
+.c21 tbody tr:hover {
   background-color: rgb(37,49,98);
 }
 
-.c9 {
+.c4 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -674,7 +571,7 @@ exports[`failed 1`] = `
   border-top-right-radius: 8px;
 }
 
-.c29 {
+.c25 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -686,7 +583,7 @@ exports[`failed 1`] = `
   border-bottom-left-radius: 8px;
 }
 
-.c26 {
+.c22 {
   box-sizing: border-box;
   border-radius: 100px;
   display: inline-flex;
@@ -704,32 +601,32 @@ exports[`failed 1`] = `
   cursor: pointer;
 }
 
-.c32 {
+.c28 {
   background: none;
   border: none;
   cursor: pointer;
 }
 
-.c32 .c21 {
+.c28 .c17 {
   font-size: 20px;
   transition: all 0.3s;
   opacity: 0.5;
 }
 
-.c32:hover .c21,
-.c32:focus .c21 {
+.c28:hover .c17,
+.c28:focus .c17 {
   opacity: 1;
 }
 
-.c32:disabled {
+.c28:disabled {
   cursor: default;
 }
 
-.c32:disabled .c21 {
+.c28:disabled .c17 {
   opacity: 0.1;
 }
 
-.c14 {
+.c10 {
   position: absolute;
   height: 100%;
   right: 0;
@@ -740,7 +637,7 @@ exports[`failed 1`] = `
   border-radius: 200px;
 }
 
-.c12 {
+.c8 {
   position: relative;
   display: flex;
   overflow: hidden;
@@ -750,7 +647,7 @@ exports[`failed 1`] = `
   background: #111B48;
 }
 
-.c13 {
+.c9 {
   border: none;
   outline: none;
   box-sizing: border-box;
@@ -765,27 +662,27 @@ exports[`failed 1`] = `
   padding-right: 184px;
 }
 
-.c13:hover,
-.c13:focus,
-.c13:active {
+.c9:hover,
+.c9:focus,
+.c9:active {
   background: #1C254D;
   box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
   color: rgba(255,255,255,0.87);
 }
 
-.c13::placeholder {
+.c9::placeholder {
   color: rgba(255,255,255,0.24);
   font-size: 12px;
 }
 
-.c16 {
+.c12 {
   position: relative;
   display: flex;
   align-items: center;
   cursor: pointer;
 }
 
-.c19 {
+.c15 {
   width: 32px;
   height: 12px;
   border-radius: 12px;
@@ -793,7 +690,7 @@ exports[`failed 1`] = `
   cursor: pointer;
 }
 
-.c19:before {
+.c15:before {
   content: '';
   position: absolute;
   top: 50%;
@@ -804,21 +701,21 @@ exports[`failed 1`] = `
   background: #651FFF;
 }
 
-.c17 {
+.c13 {
   opacity: 0;
   position: absolute;
   cursor: pointer;
 }
 
-.c17:checked + .c18 {
+.c13:checked + .c14 {
   background: #512FC9;
 }
 
-.c17:checked + .c18:before {
+.c13:checked + .c14:before {
   transform: translate(16px,-50%);
 }
 
-.c15 {
+.c11 {
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -838,37 +735,9 @@ exports[`failed 1`] = `
     >
       Servers
     </div>
-    <div
-      class="c3"
-    >
-      <div
-        class="c4"
-        width="280px"
-      >
-        <div
-          class="c5"
-        >
-          SSH:
-        </div>
-        <input
-          class="c6"
-          color="text.primary"
-          placeholder="login@host:port"
-        />
-      </div>
-      <button
-        class="c7"
-        kind="primary"
-        title=""
-        width="240px"
-      >
-        Add 
-        server
-      </button>
-    </div>
   </div>
   <div
-    class="c8"
+    class="c3"
     kind="danger"
   >
     <div>
@@ -876,47 +745,47 @@ exports[`failed 1`] = `
     </div>
   </div>
   <form
-    class="c9"
+    class="c4"
   >
     <div
-      class="c10"
+      class="c5"
       width="100%"
     >
       <div
-        class="c3"
+        class="c6"
         style="width: 70%;"
       >
         <div
-          class="c11"
+          class="c7"
           width="100%"
         >
           <div
-            class="c12"
+            class="c8"
           >
             <input
-              class="c13"
+              class="c9"
               placeholder="SEARCH..."
               value=""
             />
             <div
-              class="c14"
+              class="c10"
             >
               <div
-                class="c15"
+                class="c11"
               >
                 <label
-                  class="c16"
+                  class="c12"
                 >
                   <input
-                    class="c17"
+                    class="c13"
                     type="checkbox"
                   />
                   <div
-                    class="c18 c19"
+                    class="c14 c15"
                   />
                 </label>
                 <div
-                  class="c20"
+                  class="c16"
                 >
                   Advanced
                 </div>
@@ -928,17 +797,17 @@ exports[`failed 1`] = `
           style="line-height: 0px;"
         >
           <span
-            class="c21 c22 icon icon-info_outline "
+            class="c17 c18 icon icon-info_outline "
             color="light"
             style="cursor: pointer; font-size: 20px;"
           />
         </div>
       </div>
       <div
-        class="c23"
+        class="c19"
       >
         <div
-          class="c24"
+          class="c20"
           color="primary.contrastText"
         >
           SHOWING 
@@ -959,7 +828,7 @@ exports[`failed 1`] = `
     </div>
   </form>
   <table
-    class="c25"
+    class="c21"
   >
     <thead>
       <tr>
@@ -967,7 +836,7 @@ exports[`failed 1`] = `
           <a>
             Hostname
             <span
-              class="c21 c22 icon icon-chevron-up "
+              class="c17 c18 icon icon-chevron-up "
               color="light"
             />
           </a>
@@ -997,13 +866,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1013,13 +882,13 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c27"
+            class="c23"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c21 c28 icon icon-caret-down "
+              class="c17 c24 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1035,13 +904,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1051,13 +920,13 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c27"
+            class="c23"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c21 c28 icon icon-caret-down "
+              class="c17 c24 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1073,13 +942,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1089,13 +958,13 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c27"
+            class="c23"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c21 c28 icon icon-caret-down "
+              class="c17 c24 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1111,13 +980,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1127,13 +996,13 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c27"
+            class="c23"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c21 c28 icon icon-caret-down "
+              class="c17 c24 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1149,13 +1018,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1165,13 +1034,13 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c27"
+            class="c23"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c21 c28 icon icon-caret-down "
+              class="c17 c24 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1192,13 +1061,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1208,13 +1077,13 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c27"
+            class="c23"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c21 c28 icon icon-caret-down "
+              class="c17 c24 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1235,13 +1104,13 @@ exports[`failed 1`] = `
         </td>
         <td>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             cluster: one
           </div>
           <div
-            class="c26"
+            class="c22"
             kind="secondary"
           >
             kernel: 4.15.0-51-generic
@@ -1251,13 +1120,13 @@ exports[`failed 1`] = `
           align="right"
         >
           <button
-            class="c27"
+            class="c23"
             height="24px"
             kind="border"
           >
             CONNECT
             <span
-              class="c21 c28 icon icon-caret-down "
+              class="c17 c24 icon icon-caret-down "
               color="text.secondary"
               font-size="2"
             />
@@ -1267,36 +1136,36 @@ exports[`failed 1`] = `
     </tbody>
   </table>
   <nav
-    class="c29"
+    class="c25"
   >
     <div
-      class="c30"
+      class="c26"
       width="100%"
     >
       <div
-        class="c31"
+        class="c27"
       />
       <div
-        class="c23"
+        class="c19"
       >
         <button
-          class="c32"
+          class="c28"
           disabled=""
           title="Previous page"
         >
           <span
-            class="c21 c33 icon icon-arrow-left-circle "
+            class="c17 c29 icon icon-arrow-left-circle "
             color="light"
             font-size="3"
           />
         </button>
         <button
-          class="c32"
+          class="c28"
           disabled=""
           title="Next page"
         >
           <span
-            class="c21 c33 icon icon-arrow-right-circle "
+            class="c17 c29 icon icon-arrow-right-circle "
             color="light"
             font-size="3"
           />

--- a/packages/teleport/src/Welcome/NewCredentials/NewPasswordlessDevice.tsx
+++ b/packages/teleport/src/Welcome/NewCredentials/NewPasswordlessDevice.tsx
@@ -16,7 +16,7 @@
 
 import React, { useState } from 'react';
 import { Text, Box, ButtonPrimary, ButtonText } from 'design';
-import { Danger } from 'design/Alert';
+import { Danger, Info } from 'design/Alert';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
@@ -55,6 +55,8 @@ export function NewPasswordlessDevice(props: Props & SliderProps<LoginFlow>) {
     switchFlow('local', applyNextAnimation);
   }
 
+  const isFirefox = navigator?.userAgent?.toLowerCase().includes('firefox');
+
   return (
     <Validation>
       {({ validator }) => (
@@ -64,6 +66,12 @@ export function NewPasswordlessDevice(props: Props & SliderProps<LoginFlow>) {
           </Text>
           {submitAttempt.status === 'failed' && (
             <Danger children={submitAttempt.statusText} />
+          )}
+          {isFirefox && (
+            <Info mt={3}>
+              Firefox may not support passwordless register. Please try Chrome
+              or Safari.
+            </Info>
           )}
           <FieldInput
             rule={requiredField('Device name is required')}

--- a/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -121,31 +121,40 @@ const SsoList = ({ attempt, authProviders, onLoginWithSso }: Props) => {
   );
 };
 
-const Passwordless = ({ onLoginWithWebauthn, attempt }: Props) => (
-  <Box px={5} pt={2} data-testid="passwordless" pb={1}>
-    <StyledPaswordlessBtn
-      mt={3}
-      py={2}
-      px={3}
-      width="100%"
-      onClick={() => onLoginWithWebauthn()}
-      disabled={attempt.isProcessing}
-    >
-      <Flex alignItems="center" justifyContent="space-between">
-        <Flex alignItems="center">
-          <Key mr={3} fontSize={16} />
-          <Box>
-            <Text typography="h6">Passwordless</Text>
-            <Text fontSize={1} color="text.secondary">
-              Follow the prompt from your browser
-            </Text>
-          </Box>
+const Passwordless = ({ onLoginWithWebauthn, attempt }: Props) => {
+  const isFirefox = navigator?.userAgent?.toLowerCase().includes('firefox');
+  return (
+    <Box px={5} pt={2} data-testid="passwordless" pb={1}>
+      {isFirefox && (
+        <Alerts.Info mt={3}>
+          Firefox may not support passwordless login. Please try Chrome or
+          Safari.
+        </Alerts.Info>
+      )}
+      <StyledPaswordlessBtn
+        mt={3}
+        py={2}
+        px={3}
+        width="100%"
+        onClick={() => onLoginWithWebauthn()}
+        disabled={attempt.isProcessing}
+      >
+        <Flex alignItems="center" justifyContent="space-between">
+          <Flex alignItems="center">
+            <Key mr={3} fontSize={16} />
+            <Box>
+              <Text typography="h6">Passwordless</Text>
+              <Text fontSize={1} color="text.secondary">
+                Follow the prompt from your browser
+              </Text>
+            </Box>
+          </Flex>
+          <ArrowForward fontSize={16} />
         </Flex>
-        <ArrowForward fontSize={16} />
-      </Flex>
-    </StyledPaswordlessBtn>
-  </Box>
-);
+      </StyledPaswordlessBtn>
+    </Box>
+  );
+};
 
 const LocalForm = ({
   isRecoveryEnabled,

--- a/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
+++ b/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
@@ -28,7 +28,7 @@ export default function useClusterLogin(props: Props) {
   const [shouldPromptSsoStatus, promptSsoStatus] = useState(false);
   const [shouldPromptHardwareKey, promptHardwareKey] = useState(false);
 
-  const [initAttempt, init] = useAsync(() => {
+  const [initAttempt, init, setInitAttempt] = useAsync(() => {
     return clustersService.getAuthSettings(clusterUri);
   });
 
@@ -75,7 +75,15 @@ export default function useClusterLogin(props: Props) {
   };
 
   useEffect(() => {
-    init();
+    init().then(resp => {
+      const [cfg, err] = resp;
+      if (!err && cfg.preferredMfa === 'u2f') {
+        const statusText = `the U2F API for hardware keys is deprecated, \
+        please notify your system administrator to update cluster \
+        settings to use WebAuthn as the second factor protocol.`;
+        setInitAttempt({ status: 'error', statusText });
+      }
+    });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
#### Description
- v10 teleterm: handles older auth cfg (v9) returning `u2f` as second factor. Instead of allowing users to continue with this deprecated option, we push users to change cluster settings to `webauthn`
- check if passwordless was enabled before rendering the option to add a passwordless device
- fix the brief rendering of buttons before final attempt state (success or failed), which may not include the buttons
- adds a soft warning to firefox users that passwordless may not be supported. I decided on a soft warning because firefox may provide support in the very near future. Currently in firefox:
   - upon register, if users try to add a passwordless device, they are in `soft lock`, firefox prompts but does nothing
   - upon login, it will just return an ambiguous error

firefox support watch:
https://bugzilla.mozilla.org/show_bug.cgi?id=1530370
https://bugzilla.mozilla.org/show_bug.cgi?id=1752089