### PR TITLE
Add error callback to `handleRequest()` method on devserver

### DIFF
--- a/packages/build/devserver/index.js
+++ b/packages/build/devserver/index.js
@@ -114,7 +114,7 @@ function serveIndexHtml(req, res) {
 
   function handleRequest() {
     proxyServer.web(req, res, getTargetOptions(), (err, req, res) => {
-      const msg = `error handling request: ${err.message}. Is the target running an accessible at ${target}?`;
+      const msg = `error handling request: ${err.message}. Is the target running and accessible at ${target}?`;
       console.log(msg);
       res.write(msg);
       res.end();

--- a/packages/build/devserver/index.js
+++ b/packages/build/devserver/index.js
@@ -115,7 +115,7 @@ function serveIndexHtml(req, res) {
   function handleRequest() {
     proxyServer.web(req, res, getTargetOptions(), (err, req, res) => {
       const msg = `error handling request: ${err.message}. Is the target running and accessible at ${target}?`;
-      console.log(msg);
+      console.error(msg);
       res.write(msg);
       res.end();
     });

--- a/packages/build/devserver/index.js
+++ b/packages/build/devserver/index.js
@@ -27,7 +27,9 @@ const argv = require('optimist')
   .usage('Usage: $0 -target [url] -config [config]')
   .demand(['target', 'config']).argv;
 
-const target = argv.target.startsWith('https') ? argv.target : `https://${argv.target}`;
+const target = argv.target.startsWith('https')
+  ? argv.target
+  : `https://${argv.target}`;
 const urlObj = uri.parse(target);
 const webpackConfig = require(argv.config);
 
@@ -43,7 +45,7 @@ const PORT = 8080;
 // init webpack compiler
 const compiler = initCompiler({ webpackConfig });
 
-compiler.callWhenReady(function() {
+compiler.callWhenReady(function () {
   console.log(
     '\x1b[33m',
     `DevServer is ready to serve: https://localhost:${PORT}/web/`,
@@ -85,19 +87,18 @@ const devServer = new WebpackDevServer(
     },
     hot: true,
     headers: {
-      'X-Custom-Header': 'yes'
+      'X-Custom-Header': 'yes',
     },
   },
   compiler.webpackCompiler
 );
 
-
 // create a dedicated proxy server to proxy cherry-picked requests
 // to the remote target
 const proxyServer = httpProxy.createProxyServer();
 process.on('SIGINT', () => {
-  proxyServer.close()
-})
+  proxyServer.close();
+});
 
 // serveIndexHtml proxies all requests skipped by webpack-dev-server to
 // targeted server, these are requests to index.html (app entry point)
@@ -112,7 +113,12 @@ function serveIndexHtml(req, res) {
   }
 
   function handleRequest() {
-    proxyServer.web(req, res, getTargetOptions());
+    proxyServer.web(req, res, getTargetOptions(), (err, req, res) => {
+      const msg = `error handling request: ${err.message}. Is the target running an accessible at ${target}?`;
+      console.log(msg);
+      res.write(msg);
+      res.end();
+    });
   }
 
   if (!compiler.isLocalIndexHtmlReady()) {
@@ -126,7 +132,8 @@ devServer.start().then(() => {
   devServer.app.use(modifyIndexHtmlMiddleware(compiler));
   devServer.app.get('/*', serveIndexHtml);
   devServer.server.on('upgrade', (req, socket) => {
-    if (req.url === '/ws') {  // webpack WS (hot reloads endpoint)
+    if (req.url === '/ws') {
+      // webpack WS (hot reloads endpoint)
       return;
     }
     console.log('proxying ws', req.url);
@@ -134,8 +141,8 @@ devServer.start().then(() => {
       target: 'wss://' + PROXY_TARGET,
       secure: false,
     });
-    proxyServer.on('error', (err) => {
-      console.error('ws error:', err)
-    } )
+    proxyServer.on('error', err => {
+      console.error('ws error:', err);
+    });
   });
 });


### PR DESCRIPTION
This PR adds an error callback to the `proxyServer.web` call on the devserver. This way, the server won't crash when the target is not running.

The goal is to improve DX and not have to restart the dev server if you restart teleport (or if you run the web UI before running teleport), which can take several seconds.