### PR TITLE
fowards path parameter to app access authentication

### DIFF
--- a/packages/teleport/src/AppLauncher/useAppLauncher.ts
+++ b/packages/teleport/src/AppLauncher/useAppLauncher.ts
@@ -48,9 +48,7 @@ function resolveRedirectUrl(params: UrlLauncherParams) {
   const port = location.port ? ':' + location.port : '';
   const state = getUrlParameter('state', location.search);
   const arn = getUrlParameter('awsrole', location.search);
-  /*
-     capture and pass any requested App Access path during the `x-teleport-auth` process
-  */
+  // redirectPath captures and pass any requested App Access path during the `x-teleport-auth` process
   const redirectPath = getUrlParameter('path', location.search);
 
   // no state value: let the target app know of a new auth exchange
@@ -63,8 +61,8 @@ function resolveRedirectUrl(params: UrlLauncherParams) {
       if (params.publicAddr) {
         url.searchParams.set('addr', params.publicAddr);
       }
-      if (arn) {
-        url.searchParams.set('awsrole', decodeURIComponent(arn));
+      if (params.arn) {
+        url.searchParams.set('awsrole', decodeURIComponent(params.arn));
       }
       if (redirectPath) {
         url.searchParams.set('path', redirectPath);

--- a/packages/teleport/src/AppLauncher/useAppLauncher.ts
+++ b/packages/teleport/src/AppLauncher/useAppLauncher.ts
@@ -47,6 +47,7 @@ function resolveRedirectUrl(params: UrlLauncherParams) {
   const location = window.location;
   const port = location.port ? ':' + location.port : '';
   const state = getUrlParameter('state', location.search);
+  const path = getUrlParameter('path', location.search);
   const arn = getUrlParameter('awsrole', location.search);
 
   // no state value: let the target app know of a new auth exchange
@@ -62,7 +63,9 @@ function resolveRedirectUrl(params: UrlLauncherParams) {
       if (params.arn) {
         url.searchParams.set('awsrole', decodeURIComponent(params.arn));
       }
-
+      if (path) {
+        url.searchParams.set('path', path);
+      }
       return url.toString();
     });
   }
@@ -75,6 +78,9 @@ function resolveRedirectUrl(params: UrlLauncherParams) {
     const url = new URL(`https://${result.fqdn}${port}/x-teleport-auth`);
     url.searchParams.set('state', state);
     url.hash = `#value=${result.value}`;
+    if (path) {
+      url.searchParams.set('path', path);
+    }
     return url.toString();
   });
 }

--- a/packages/teleport/src/AppLauncher/useAppLauncher.ts
+++ b/packages/teleport/src/AppLauncher/useAppLauncher.ts
@@ -47,8 +47,11 @@ function resolveRedirectUrl(params: UrlLauncherParams) {
   const location = window.location;
   const port = location.port ? ':' + location.port : '';
   const state = getUrlParameter('state', location.search);
-  const path = getUrlParameter('path', location.search);
   const arn = getUrlParameter('awsrole', location.search);
+  /*
+     capture and pass any requested App Access path during the `x-teleport-auth` process
+  */
+  const redirectPath = getUrlParameter('path', location.search);
 
   // no state value: let the target app know of a new auth exchange
   if (!state) {
@@ -60,11 +63,11 @@ function resolveRedirectUrl(params: UrlLauncherParams) {
       if (params.publicAddr) {
         url.searchParams.set('addr', params.publicAddr);
       }
-      if (params.arn) {
-        url.searchParams.set('awsrole', decodeURIComponent(params.arn));
+      if (arn) {
+        url.searchParams.set('awsrole', decodeURIComponent(arn));
       }
-      if (path) {
-        url.searchParams.set('path', path);
+      if (redirectPath) {
+        url.searchParams.set('path', redirectPath);
       }
       return url.toString();
     });
@@ -78,8 +81,8 @@ function resolveRedirectUrl(params: UrlLauncherParams) {
     const url = new URL(`https://${result.fqdn}${port}/x-teleport-auth`);
     url.searchParams.set('state', state);
     url.hash = `#value=${result.value}`;
-    if (path) {
-      url.searchParams.set('path', path);
+    if (redirectPath) {
+      url.searchParams.set('path', redirectPath);
     }
     return url.toString();
   });


### PR DESCRIPTION
**The Problem**:
When a user navigates to an app url with a path included like https://app1.teleport.example.com/my/path without authentication, the path is lost during the authentication process and eventually just gets the root path instead.

This isn't a problem when launching from the Apps dashboard because 1, they are already authenticated, and 2, the launch button sends to the root path anyway. So the problem usually persists when someone is either sharing a link with a path included to a coworker, or when visiting a bookmark or whatever. 

The current redirect URI only includes the host name (in this example above, it would be app1.teleport.example.com) because the /web/launch/:fqdn URI expects only the name of the app.

**The Solution**:
Because we cannot just simply pass the entire path to the redirect_uri, we have to [include it as a query parameter](https://github.com/gravitational/teleport/blob/michaelmyers/preserve-app-access-url/lib/web/app/handler.go#L340). However, there is a bunch of redirects that happen between the Login screen and the final destination so we have to preserve that parameter the whole way through the process. Admittedly, most of this [will happen in the api](https://github.com/gravitational/teleport/blob/michaelmyers/preserve-app-access-url/lib/web/app/redirect.go#L49-L88) (not yet merged in). The code contained in this PR will help keep the `path` parameter during the `x-teleport-auth` api calls. [(seen here)](https://github.com/gravitational/teleport/blob/michaelmyers/preserve-app-access-url/lib/web/app/fragment.go#L56-L62) 

**Steps to reproduce**:
Add an app to your teleport config if not already included
```yaml
app_service:
  enabled: 'yes'
  apps:
    - name: 'app1'
      uri: 'http://localhost:8000'
      public_addr: 'app1.your.teleport.url'
```

Make sure an app is running, for example `python3 -m http.server 8000`, and be sure to be unauthenticated.

Visit `https://app1.your.teleport.url/example/path`

In the current codebase, after authenticating, you'll lose the path and end up at `https://app1.your.teleport.url`.


If you wanna check the teleport core side, make sure to [checkout the branch](https://github.com/gravitational/teleport/tree/michaelmyers/preserve-app-access-url)