### PR TITLE
Update "Connect with GUI" section, add universal context menu

### DIFF
--- a/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Rectangle, screen } from 'electron';
+import { BrowserWindow, Menu, Rectangle, screen } from 'electron';
 import { getAssetPath } from 'teleterm/mainProcess/runtimeSettings';
 import path from 'path';
 import { FileStorage } from 'teleterm/services/fileStorage';
@@ -43,6 +43,17 @@ export class WindowsManager {
     } else {
       window.loadFile(path.join(__dirname, '../renderer/index.html'));
     }
+
+    // Taken from https://github.com/electron/electron/issues/4068#issuecomment-274159726
+    // selectall was removed from menus because it doesn't make sense in our context.
+    window.webContents.on('context-menu', (_, props) => {
+      const { selectionText, isEditable } = props;
+      if (isEditable) {
+        inputContextMenu.popup({ window });
+      } else if (selectionText && selectionText.trim() !== '') {
+        selectionContextMenu.popup({ window });
+      }
+    });
   }
 
   private saveWindowState(window: BrowserWindow): void {
@@ -96,3 +107,14 @@ export class WindowsManager {
     };
   }
 }
+
+const selectionContextMenu = Menu.buildFromTemplate([{ role: 'copy' }]);
+
+const inputContextMenu = Menu.buildFromTemplate([
+  { role: 'undo' },
+  { role: 'redo' },
+  { type: 'separator' },
+  { role: 'cut' },
+  { role: 'copy' },
+  { role: 'paste' },
+]);

--- a/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -136,7 +136,7 @@ export function DocumentGateway(props: State) {
       </Text>
       <Text>
         To connect with a GUI database client, configure the client to connect
-        to <code>{gateway.localAddress}</code> on port{' '}
+        to host <code>{gateway.localAddress}</code> on port{' '}
         <code>{gateway.localPort}</code>.
       </Text>
       <Text>

--- a/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -100,7 +100,7 @@ export function DocumentGateway(props: State) {
   }
 
   return (
-    <Box maxWidth="580px" mx="auto" mt="4" px="5">
+    <Box maxWidth="590px" mx="auto" mt="4" px="5">
       <Flex justifyContent="space-between" mb="4">
         <Text typography="h3" color="text.secondary">
           Database Connection
@@ -109,7 +109,9 @@ export function DocumentGateway(props: State) {
           Close Connection
         </ButtonSecondary>
       </Flex>
-      <Text typography="h4">Connect with CLI</Text>
+      <Text typography="h4" mb={1}>
+        Connect with CLI
+      </Text>
       <Flex>
         <Validation>
           <ConfigInput
@@ -131,22 +133,22 @@ export function DocumentGateway(props: State) {
           Could not change the database name: {changeDbNameAttempt.statusText}
         </Alerts.Danger>
       )}
-      <Text typography="h4" mt={3}>
+      <Text typography="h4" mt={3} mb={1}>
         Connect with GUI
       </Text>
       <Text>
-        To connect with a GUI database client, configure the client to connect
-        to host <code>{gateway.localAddress}</code> on port{' '}
+        Configure the GUI database client to connect to host{' '}
+        <code>{gateway.localAddress}</code> on port{' '}
         <code>{gateway.localPort}</code>.
       </Text>
       <Text>
         The connection is made through an authenticated proxy so no extra
-        credentials are necessary. See our{' '}
+        credentials are necessary. See{' '}
         <Link
           href="https://goteleport.com/docs/database-access/guides/gui-clients/"
           target="_blank"
         >
-          documentation
+          the documentation
         </Link>{' '}
         for more details.
       </Text>
@@ -185,7 +187,6 @@ function CliCommand({
       justifyContent="space-between"
       borderRadius={2}
       bg={'primary.dark'}
-      mb={2}
     >
       <Flex
         mr="2"

--- a/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -135,14 +135,9 @@ export function DocumentGateway(props: State) {
         Connect with GUI
       </Text>
       <Text>
-        To connect with a GUI database client, see our{' '}
-        <Link
-          href="https://goteleport.com/docs/database-access/guides/gui-clients/"
-          target="_blank"
-        >
-          documentation
-        </Link>{' '}
-        for instructions.
+        To connect with a GUI database client, configure the client to connect
+        to <code>{gateway.localAddress}</code> on port{' '}
+        <code>{gateway.localPort}</code>.
       </Text>
     </Box>
   );

--- a/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -139,6 +139,17 @@ export function DocumentGateway(props: State) {
         to <code>{gateway.localAddress}</code> on port{' '}
         <code>{gateway.localPort}</code>.
       </Text>
+      <Text>
+        The connection is made through an authenticated proxy so no extra
+        credentials are necessary. See our{' '}
+        <Link
+          href="https://goteleport.com/docs/database-access/guides/gui-clients/"
+          target="_blank"
+        >
+          documentation
+        </Link>{' '}
+        for more details.
+      </Text>
     </Box>
   );
 }


### PR DESCRIPTION
Closes gravitational/webapps.e#304.

---

Since the "Connect with GUI" section now includes the port number, I figured it'd be nice to be able to copy it with a context menu. Before this it was still possible to just copy it with Cmd + C, but I'm not sure how clear this was for the users.

The universal context menu can be overridden by overriding the `contextmenu` event handler.

Since the menu is "universal" and doesn't need any extra dependencies (it's just an array of objects), I decided to define it in `windowsManager.ts` rather than in `packages/teleterm/src/mainProcess/contextMenus`. The latter holds more complex menus that require IPC and some dependencies being passed in to the function.

---

Also, I found out that we should be able to add "Select All" to the terminal context menu so I created an issue for it (gravitational/webapps.e#334).