### PR TITLE
Fix menu bug

### DIFF
--- a/packages/teleport/src/Account/ChangePassword/ChangePassword.tsx
+++ b/packages/teleport/src/Account/ChangePassword/ChangePassword.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Text } from 'design';
+import { Text, Box } from 'design';
 import PasswordForm from 'shared/components/FormPassword';
 import useChangePassword, { State } from './useChangePassword';
 
@@ -31,7 +31,7 @@ export function ChangePassword({
   auth2faType,
 }: State) {
   return (
-    <>
+    <Box mt={3}>
       <Text typography="h3" mb={3}>
         Change Password
       </Text>
@@ -41,6 +41,6 @@ export function ChangePassword({
         onChangePass={changePassword}
         onChangePassWithWebauthn={changePasswordWithWebauthn}
       />
-    </>
+    </Box>
   );
 }

--- a/packages/teleport/src/stores/index.ts
+++ b/packages/teleport/src/stores/index.ts
@@ -1,3 +1,3 @@
-import StoreNav from './storeNav';
+import StoreNav, { defaultNavState } from './storeNav';
 import StoreUserContext from './storeUserContext';
-export { StoreNav, StoreUserContext };
+export { StoreNav, StoreUserContext, defaultNavState };

--- a/packages/teleport/src/stores/storeNav.ts
+++ b/packages/teleport/src/stores/storeNav.ts
@@ -17,15 +17,15 @@ limitations under the License.
 import { Store } from 'shared/libs/stores';
 import { NavGroup } from 'teleport/types';
 
-const defaultState = {
+export const defaultNavState = {
   sideNav: [] as NavItem[],
   topNav: [] as NavItem[],
   topMenu: [] as NavItem[],
 };
 
-export default class StoreNav extends Store<typeof defaultState> {
+export default class StoreNav extends Store<typeof defaultNavState> {
   state = {
-    ...defaultState,
+    ...defaultNavState,
   };
 
   addTopMenuItem(item: NavItem) {

--- a/packages/teleport/src/teleportContext.tsx
+++ b/packages/teleport/src/teleportContext.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { StoreNav, StoreUserContext } from './stores';
+import { StoreNav, StoreUserContext, defaultNavState } from './stores';
 import cfg from 'teleport/config';
 import * as types from './types';
 import AuditService from './services/audit';
@@ -57,7 +57,9 @@ class TeleportContext implements types.Context {
 
   init() {
     return userService.fetchUserContext().then(user => {
+      this.storeNav.setState(defaultNavState);
       this.storeUser.setState(user);
+      this.features = [];
     });
   }
 


### PR DESCRIPTION
#### Description
There was a bug where if you click to dashboard from a different screen e.g `from console view`, the menu `features` gets registered each time we come back to the dashboard screen. So you'll see like doubled, tripled, etc amount of repeated features. This PR resets the `features` each time we `init` the Main to prevent repeated registering.

Also adds trivial missing margin to Password component that was affecting the OSS version of UI.

#### Related PR
https://github.com/gravitational/webapps.e/pull/335