### PR TITLE
wrap switchTab in a conditional

### DIFF
--- a/packages/teleterm/src/ui/TabHost/useTabShortcuts.test.tsx
+++ b/packages/teleterm/src/ui/TabHost/useTabShortcuts.test.tsx
@@ -186,6 +186,16 @@ test('close active tab', () => {
   expect(docsService.close).toHaveBeenCalledWith(documentToClose.uri);
 });
 
+test('should ignore close command if no tabs are open', () => {
+  const { emitKeyboardShortcutEvent, docsService } = getTestSetup({
+    documents: [],
+  });
+
+  emitKeyboardShortcutEvent({ type: 'tab-close' });
+
+  expect(docsService.close).not.toHaveBeenCalled();
+});
+
 test('open new tab', () => {
   const { emitKeyboardShortcutEvent, docsService } = getTestSetup({
     documents: [],
@@ -258,5 +268,14 @@ describe('open next/previous tab', () => {
     expect(docsService.open).toHaveBeenCalledWith(
       docsService.getDocuments()[docsService.getDocuments().length - 1].uri
     );
+  });
+
+  test('do not switch tabs if tabs do not exist', () => {
+    const { emitKeyboardShortcutEvent, docsService } = getTestSetup({
+      documents: [],
+    });
+    emitKeyboardShortcutEvent({ type: 'tab-next' });
+
+    expect(docsService.open).not.toHaveBeenCalled();
   });
 });

--- a/packages/teleterm/src/ui/TabHost/useTabShortcuts.ts
+++ b/packages/teleterm/src/ui/TabHost/useTabShortcuts.ts
@@ -61,16 +61,19 @@ function buildTabsShortcuts(
   const handleTabSwitch = (direction: 'previous' | 'next') => () => {
     const activeDoc = documentService.getActive();
     const allDocuments = documentService.getDocuments();
-    if (allDocuments.length > 0) {
-      const activeDocIndex = allDocuments.indexOf(activeDoc);
-      const getPreviousIndex = () =>
-        (activeDocIndex - 1 + allDocuments.length) % allDocuments.length;
-      const getNextIndex = () => (activeDocIndex + 1) % allDocuments.length;
-      const indexToOpen =
-        direction === 'previous' ? getPreviousIndex() : getNextIndex();
 
-      documentService.open(allDocuments[indexToOpen].uri);
+    if (allDocuments.length === 0) {
+      return;
     }
+
+    const activeDocIndex = allDocuments.indexOf(activeDoc);
+    const getPreviousIndex = () =>
+      (activeDocIndex - 1 + allDocuments.length) % allDocuments.length;
+    const getNextIndex = () => (activeDocIndex + 1) % allDocuments.length;
+    const indexToOpen =
+      direction === 'previous' ? getPreviousIndex() : getNextIndex();
+
+    documentService.open(allDocuments[indexToOpen].uri);
   };
   return {
     'tab-1': handleTabIndex(0),

--- a/packages/teleterm/src/ui/TabHost/useTabShortcuts.ts
+++ b/packages/teleterm/src/ui/TabHost/useTabShortcuts.ts
@@ -61,14 +61,16 @@ function buildTabsShortcuts(
   const handleTabSwitch = (direction: 'previous' | 'next') => () => {
     const activeDoc = documentService.getActive();
     const allDocuments = documentService.getDocuments();
-    const activeDocIndex = allDocuments.indexOf(activeDoc);
-    const getPreviousIndex = () =>
-      (activeDocIndex - 1 + allDocuments.length) % allDocuments.length;
-    const getNextIndex = () => (activeDocIndex + 1) % allDocuments.length;
-    const indexToOpen =
-      direction === 'previous' ? getPreviousIndex() : getNextIndex();
+    if (allDocuments.length > 0) {
+      const activeDocIndex = allDocuments.indexOf(activeDoc);
+      const getPreviousIndex = () =>
+        (activeDocIndex - 1 + allDocuments.length) % allDocuments.length;
+      const getNextIndex = () => (activeDocIndex + 1) % allDocuments.length;
+      const indexToOpen =
+        direction === 'previous' ? getPreviousIndex() : getNextIndex();
 
-    documentService.open(allDocuments[indexToOpen].uri);
+      documentService.open(allDocuments[indexToOpen].uri);
+    }
   };
   return {
     'tab-1': handleTabIndex(0),


### PR DESCRIPTION
Closes https://github.com/gravitational/webapps.e/issues/344

Solution:
Check if `allDocuments` has a length before doing any index searching. This will reduce any extra compute if no tabs exist, as well as ensure that `[index].uri` exists when it gets there