### PR TITLE
Change page size in Connect to 15

### DIFF
--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Applications/Applications.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Applications/Applications.tsx
@@ -83,7 +83,7 @@ export function AppList(props: State) {
           },
         ]}
         emptyText="No Applications Found"
-        pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
+        pagination={{ pageSize: 15, pagerPosition: 'bottom' }}
       />
     </>
   );

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/Databases.tsx
@@ -63,7 +63,7 @@ function DatabaseList(props: State) {
             ),
           },
         ]}
-        pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
+        pagination={{ pageSize: 15, pagerPosition: 'bottom' }}
         emptyText="No Databases Found"
       />
     </>

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Kubes/Kubes.tsx
@@ -28,7 +28,7 @@ export default function Container() {
 }
 
 function KubeList(props: State) {
-  const { kubes = [], pageSize = 100, connect, syncStatus } = props;
+  const { kubes = [], pageSize = 15, connect, syncStatus } = props;
 
   return (
     <>

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/Servers.tsx
@@ -65,7 +65,7 @@ function ServerList(props: State) {
         ]}
         emptyText="No Nodes Found"
         data={servers}
-        pagination={{ pageSize: 100, pagerPosition: 'bottom' }}
+        pagination={{ pageSize: 15, pagerPosition: 'bottom' }}
       />
     </>
   );


### PR DESCRIPTION
Closes gravitational/webapps.e#343.

Just like in the Web UI, Connect is able to easily accommodate 15 resources
on the screen without vertical scroll in both 1920x1080 and 3024x1964,
as long as labels for the resources span just a single line.

1920x1080 remains the most popular screen size on desktop [1] and 1440x900
seems to be the most popular size on macOS [2].

On 1440x900 the pagination controls are not shown on the screen.

[1] https://gs.statcounter.com/screen-resolution-stats/desktop/north-america/#monthly-202105-202205
[2] https://web.archive.org/web/20220630103803/https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam?platform=mac

# Screenshots

1920x1080

![1920-1080](https://user-images.githubusercontent.com/27113/176657831-a3dfd9b8-fda0-445f-aa51-11ce71bbfa04.png)

3024x1964

<img width="812" alt="3024-1964" src="https://user-images.githubusercontent.com/27113/176657909-791cbfa9-575c-440f-9c60-694667758005.png">

1440x900

![1440-900](https://user-images.githubusercontent.com/27113/176657987-78f6b03c-0ad6-45ef-b0ef-661ab40a3dba.png)

