### PR TITLE
Add directory sharing to the ACL

### DIFF
--- a/packages/teleport/src/Main/fixtures/index.ts
+++ b/packages/teleport/src/Main/fixtures/index.ts
@@ -44,6 +44,7 @@ export const fullAcl: Acl = {
   nodes: fullAccess,
   clipboardSharingEnabled: true,
   desktopSessionRecordingEnabled: true,
+  directorySharingEnabled: true,
 };
 
 export const userContext = makeUserContext({

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -28,6 +28,8 @@ import { RecordingType } from 'teleport/services/recordings';
 import generateResourcePath from './generateResourcePath';
 
 const cfg = {
+  // TODO(isaiah): remove after feature is finished.
+  enableDirectorySharing: false, // note to reviewers: should be false in any PRs.
   isEnterprise: false,
   isCloud: false,
   tunnelPublicAddress: '',

--- a/packages/teleport/src/services/user/makeAcl.ts
+++ b/packages/teleport/src/services/user/makeAcl.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { Acl } from './types';
+import cfg from 'teleport/config';
 
 export default function makeAcl(json): Acl {
   json = json || {};
@@ -43,6 +44,12 @@ export default function makeAcl(json): Acl {
     json.desktopSessionRecording !== undefined
       ? json.desktopSessionRecording
       : true;
+  // Behaves like clipboardSharingEnabled, see
+  // https://github.com/gravitational/teleport/pull/12684#issue-1237830087
+  const directorySharingEnabled =
+    (json.directorySharing !== undefined ? json.directorySharing : true) &&
+    cfg.enableDirectorySharing;
+
   const nodes = json.nodes || defaultAccess;
 
   return {
@@ -64,6 +71,7 @@ export default function makeAcl(json): Acl {
     clipboardSharingEnabled,
     desktopSessionRecordingEnabled,
     nodes,
+    directorySharingEnabled,
   };
 }
 

--- a/packages/teleport/src/services/user/types.ts
+++ b/packages/teleport/src/services/user/types.ts
@@ -46,6 +46,7 @@ export interface Access {
 }
 
 export interface Acl {
+  directorySharingEnabled: boolean;
   desktopSessionRecordingEnabled: boolean;
   clipboardSharingEnabled: boolean;
   windowsLogins: string[];

--- a/packages/teleport/src/services/user/user.test.ts
+++ b/packages/teleport/src/services/user/user.test.ts
@@ -157,6 +157,7 @@ test('undefined values in context response gives proper default values', async (
       },
       clipboardSharingEnabled: true,
       desktopSessionRecordingEnabled: true,
+      directorySharingEnabled: false,
     },
     cluster: {
       clusterId: 'aws',


### PR DESCRIPTION
The setting is also modulated by the `enableDirectorySharing` config variable while the feature is still in development.

Corresponds with https://github.com/gravitational/teleport/pull/14103

v9 and v10 backport required