### PR TITLE
Update teleterm protobuf files

### DIFF
--- a/packages/teleterm/src/services/tshd/v1/app_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/app_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_label_pb = require('../v1/label_pb.js');
 goog.object.extend(proto, v1_label_pb);

--- a/packages/teleterm/src/services/tshd/v1/auth_settings_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/auth_settings_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 goog.exportSymbol('proto.teleport.terminal.v1.AuthProvider', null, global);
 goog.exportSymbol('proto.teleport.terminal.v1.AuthSettings', null, global);

--- a/packages/teleterm/src/services/tshd/v1/cluster_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/cluster_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 goog.exportSymbol('proto.teleport.terminal.v1.ACL', null, global);
 goog.exportSymbol('proto.teleport.terminal.v1.Cluster', null, global);

--- a/packages/teleterm/src/services/tshd/v1/database_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/database_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_label_pb = require('../v1/label_pb.js');
 goog.object.extend(proto, v1_label_pb);

--- a/packages/teleterm/src/services/tshd/v1/gateway_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/gateway_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 goog.exportSymbol('proto.teleport.terminal.v1.Gateway', null, global);
 /**

--- a/packages/teleterm/src/services/tshd/v1/kube_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/kube_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_label_pb = require('../v1/label_pb.js');
 goog.object.extend(proto, v1_label_pb);

--- a/packages/teleterm/src/services/tshd/v1/label_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/label_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 goog.exportSymbol('proto.teleport.terminal.v1.Label', null, global);
 /**

--- a/packages/teleterm/src/services/tshd/v1/server_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/server_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var v1_label_pb = require('../v1/label_pb.js');
 goog.object.extend(proto, v1_label_pb);

--- a/packages/teleterm/src/services/tshd/v1/service_pb.js
+++ b/packages/teleterm/src/services/tshd/v1/service_pb.js
@@ -2,15 +2,18 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 goog.object.extend(proto, google_protobuf_empty_pb);


### PR DESCRIPTION
gravitational/teleport#14097 updated protoc version on the master branch.

That change wasn't backported so when backporting any tshd protobuf changes
to v10 or earlier we must regenerate the protobuf files in the backport
branch from now on.