### PR TITLE
Updates Babel build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,29 @@ proxy_service:
 ```
 
 Then start the dev server like `yarn start-teleport --target=https://proxy.127.0.0.1.nip.io:3080` and access it at https://proxy.127.0.0.1.nip.io:8080.
+
+### Adding Packages with `yarn`
+
+We use [Yarn Workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/) to manage dependencies.
+Typically you will want to add packages to the lowest level necessary, by running
+
+```
+yarn workspace <workspace-name> add <package-name>
+```
+
+The `<workspace-name>` of a given workspace is defined by its `"name"`. For example, if you wanted to add the package
+`caniuse-lite` to the workspace `packages/build`, you would run
+
+```
+yarn workspace @gravitational/build add caniuse-lite
+```
+
+After adding a package to a workspace, you should expect to find a new lockfile in the workspace's directory. In this
+example, the file `packages/build/yarn.lock` will have been created. This appears to be a bug in yarn workspaces, as
+we want to track all dependencies in a single lockfile at the workspace root (`yarn.lock` in the root of this repo). To
+fix this, you need to run the following:
+
+```
+rm packages/build/yarn.lock
+yarn install
+```

--- a/README.md
+++ b/README.md
@@ -170,28 +170,12 @@ proxy_service:
 
 Then start the dev server like `yarn start-teleport --target=https://proxy.127.0.0.1.nip.io:3080` and access it at https://proxy.127.0.0.1.nip.io:8080.
 
-### Adding Packages with `yarn`
+### Adding Packages/Dependencies
 
 We use [Yarn Workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/) to manage dependencies.
-Typically you will want to add packages to the lowest level necessary, by running
 
-```
-yarn workspace <workspace-name> add <package-name>
-```
+The easiest way to add a package is to add a line to the workspace's `package.json` file and then run `yarn install` from
+the root of this repository.
 
-The `<workspace-name>` of a given workspace is defined by its `"name"`. For example, if you wanted to add the package
-`caniuse-lite` to the workspace `packages/build`, you would run
-
-```
-yarn workspace @gravitational/build add caniuse-lite
-```
-
-After adding a package to a workspace, you should expect to find a new lockfile in the workspace's directory. In this
-example, the file `packages/build/yarn.lock` will have been created. This appears to be a bug in yarn workspaces, as
-we want to track all dependencies in a single lockfile at the workspace root (`yarn.lock` in the root of this repo). To
-fix this, you need to run the following:
-
-```
-rm packages/build/yarn.lock
-yarn install
-```
+Keep in mind that there should only be a single `yarn.lock` in this repository, here at the top level. If you add packages
+via `yarn workspace <workspace-name> add <package-name>`, it will create a `packages/<package-name>/yarn.lock` file, which should not be checked in.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ Then start the dev server like `yarn start-teleport --target=https://proxy.127.0
 
 ### Adding Packages/Dependencies
 
-We use [Yarn Workspaces](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/) to manage dependencies.
+We use Yarn Workspaces to manage dependencies.
+
+- [Introducing Workspaces](https://yarnpkg.com/blog/2017/08/02/introducing-workspaces)
+- [Workspaces Documentation](https://yarnpkg.com/en/docs/workspaces)
 
 The easiest way to add a package is to add a line to the workspace's `package.json` file and then run `yarn install` from
 the root of this repository.

--- a/packages/README.md
+++ b/packages/README.md
@@ -11,32 +11,3 @@ a stand-alone web application or library referenced by other packages.
 | `build`    | Collection of webpack and build scripts used to build Gravitational packages |
 | `design`   | Gravitational Design-System                                                  |
 | `shared`   | Shared code                                                                  |
-
-## Working with the packages
-
-The packages are managed by yarn via yarn workspaces.
-
-To learn more about workspaces, check these links:
-
-- [Workspaces in Yarn](https://yarnpkg.com/blog/2017/08/02/introducing-workspaces)
-- [Workspaces](https://yarnpkg.com/en/docs/workspaces)
-
-##### `yarn workspace <workspace_name> <command>` <a class="toc" id="toc-yarn-workspace" href="#toc-yarn-workspace"></a>
-
-This will run the chosen Yarn command in the selected workspace.
-
-Example:
-
-```sh
-yarn workspace awesome-package add react react-dom --dev
-```
-
-This will add `react` and `react-dom` as `devDependencies` in your `packages/awesome-package/package.json`.
-
-If you want to remove a package:
-
-```sh
-yarn workspace web-project remove some-package
-```
-
-The example above would remove `some-package` from `packages/web-project/package.json`.

--- a/packages/build/.babelrc.js
+++ b/packages/build/.babelrc.js
@@ -31,7 +31,16 @@ function makePresents(test = false) {
     ];
   }
 
-  return ['@babel/preset-env', ...presents];
+  return [
+    [
+      '@babel/preset-env',
+      {
+        targets:
+          'last 2 chrome version, last 2 edge version, last 2 firefox version, last 2 safari version',
+      },
+    ],
+    ...presents,
+  ];
 }
 
 module.exports = {


### PR DESCRIPTION
Makes supported browser versions explicit in our babel configuration, and allows us to use `async` within the app.

These changes result in a small reduction in bundle size:

oss: 2.38 MiB --> 2.19 MiB
enterprise 2.53 MiB --> 2.3 MiB

Backport to v9 / v10 required