### PR TITLE
Fix typo in malformed packet error

### DIFF
--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -352,16 +352,16 @@ exports[`list of all events 1`] = `
           class="c6"
           color="primary.contrastText"
         >
-          SHOWING 
+          SHOWING
           <strong>
             1
           </strong>
-           - 
+           -
           <strong>
             85
           </strong>
            of
-           
+
           <strong>
             85
           </strong>
@@ -489,7 +489,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          Recived Malfored packed from [alice] in [master] on database [sqlserver02]
+          Recived malformed packet from [alice] in [master] on database [sqlserver02]
         </td>
         <td
           style="min-width: 120px;"
@@ -2191,7 +2191,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [foo] has ended a non-interactive session [9d92ad96-a45c-4add-463cc7bc48b1] on node [ip-172-31-30-254] 
+          User [foo] has ended a non-interactive session [9d92ad96-a45c-4add-463cc7bc48b1] on node [ip-172-31-30-254]
         </td>
         <td
           style="min-width: 120px;"
@@ -4252,16 +4252,16 @@ exports[`loaded audit log screen 1`] = `
           class="c11"
           color="primary.contrastText"
         >
-          SHOWING 
+          SHOWING
           <strong>
             1
           </strong>
-           - 
+           -
           <strong>
             5
           </strong>
            of
-           
+
           <strong>
             5
           </strong>

--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -352,16 +352,16 @@ exports[`list of all events 1`] = `
           class="c6"
           color="primary.contrastText"
         >
-          SHOWING
+          SHOWING 
           <strong>
             1
           </strong>
-           -
+           - 
           <strong>
             85
           </strong>
            of
-
+           
           <strong>
             85
           </strong>
@@ -2191,7 +2191,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [foo] has ended a non-interactive session [9d92ad96-a45c-4add-463cc7bc48b1] on node [ip-172-31-30-254]
+          User [foo] has ended a non-interactive session [9d92ad96-a45c-4add-463cc7bc48b1] on node [ip-172-31-30-254] 
         </td>
         <td
           style="min-width: 120px;"
@@ -4252,16 +4252,16 @@ exports[`loaded audit log screen 1`] = `
           class="c11"
           color="primary.contrastText"
         >
-          SHOWING
+          SHOWING 
           <strong>
             1
           </strong>
-           -
+           - 
           <strong>
             5
           </strong>
            of
-
+           
           <strong>
             5
           </strong>

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -400,7 +400,7 @@ export const formatters: Formatters = {
     type: 'db.session.malformed_packet"',
     desc: 'Database Malformed Packet',
     format: ({ user, db_service, db_name }) =>
-      `Recived Malfored packed from [${user}] in [${db_name}] on database [${db_service}]`,
+      `Recived malformed packet from [${user}] in [${db_name}] on database [${db_service}]`,
   },
   [eventCodes.DATABASE_CREATED]: {
     type: 'db.create',


### PR DESCRIPTION
`Malfored packed` -> `malformed packet`

All other changes are my editor trimming excess whitespace on save.