### PR TITLE
disable DocumentCluster sync button when syncing

### DIFF
--- a/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
@@ -90,7 +90,12 @@ export function Cluster() {
         </Text>
         <Flex>
           <ClusterSearch onChange={clusterCtx.changeSearchValue} />
-          <ButtonPrimary ml={2} size="small" onClick={clusterCtx.sync}>
+          <ButtonPrimary
+            disabled={state.syncing}
+            ml={2}
+            size="small"
+            onClick={clusterCtx.sync}
+          >
             Sync
           </ButtonPrimary>
         </Flex>

--- a/packages/teleterm/src/ui/DocumentCluster/clusterContext.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/clusterContext.tsx
@@ -28,6 +28,7 @@ type State = {
   searchValue: string;
   leaf: boolean;
   leafConnected: boolean;
+  syncing: boolean;
   status: 'requires_login' | 'not_found' | '';
   statusText: string;
 };
@@ -47,6 +48,7 @@ class ClusterContext extends Store<State> {
     searchValue: '',
     leaf: false,
     leafConnected: false,
+    syncing: false,
     status: '',
     statusText: '',
   };
@@ -77,6 +79,7 @@ class ClusterContext extends Store<State> {
 
   sync = async () => {
     try {
+      this.setState({ syncing: true });
       await retryWithRelogin(
         this.appCtx,
         this.documentUri,
@@ -88,6 +91,8 @@ class ClusterContext extends Store<State> {
         title: `Could not synchronize cluster ${this.state.clusterName}`,
         description: e.message,
       });
+    } finally {
+      this.setState({ syncing: false });
     }
   };
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/webapps.e/issues/207

Problem:
The current Sync button shows no indication that anything is syncing.

Solution:
Listen to state changes for when syncing starts/stops and disable the button accordingly. 

https://user-images.githubusercontent.com/5201977/178826490-c26bb14a-1fcb-4fdf-ad59-70cd4005ec3a.mp4

Thoughts:
There is a method currently named `getSyncStatus()` which I originally wanted to use although I'm not quite sure its the best use for it. I think that function has some race-y conditions as well due to the "sync" status being returned if any of the services are in a 'syncing' state. But imagine a scenario where one service starts syncing (button disabled), stops (button enabled), then the next service starts syncing for some reason (button disabled again? flickering button?).

The `getSyncStatus()` method is great for grabbing the individual status of each service which is the only use of it in the codebase I've seen. For example `getSyncStatus().dbs` would return the status of that individual service. I like this in that context.

Regardless, the Sync button (and any button that performs an action) should have its state abstracted to the highest order call of that 'action'. To use another example, if I add a "todo" on a todo website and click Save, I don't want my save button determined by the state of the web server, the authentication, the database action, etc etc all individually, I just want the state of my button to be "i made my request, and now the request is done". 

Long story longer, I added `syncing` state to the clusterContext which is changed when the `sync` function is called.

Ok rambling over, please let me know if I'm over thinking this.
