### PR TITLE
Add gap property to Flex

### DIFF
--- a/packages/design/src/Flex/Flex.jsx
+++ b/packages/design/src/Flex/Flex.jsx
@@ -20,6 +20,7 @@ import {
   justifyContent,
   flexWrap,
   flexDirection,
+  gap,
   propTypes,
 } from 'design/system';
 import theme from 'design/theme';
@@ -27,7 +28,7 @@ import Box from '../Box';
 
 const Flex = styled(Box)`
   display: flex;
-  ${alignItems} ${justifyContent} ${flexWrap} ${flexDirection};
+  ${alignItems} ${justifyContent} ${flexWrap} ${flexDirection} ${gap};
 `;
 
 Flex.defaultProps = {
@@ -40,6 +41,8 @@ Flex.propTypes = {
   ...propTypes.justifyContent,
   ...propTypes.flexWrap,
   ...propTypes.flexDirection,
+  ...propTypes.gap,
+
 };
 
 Flex.displayName = 'Flex';

--- a/packages/design/src/Flex/Flex.jsx
+++ b/packages/design/src/Flex/Flex.jsx
@@ -28,7 +28,11 @@ import Box from '../Box';
 
 const Flex = styled(Box)`
   display: flex;
-  ${alignItems} ${justifyContent} ${flexWrap} ${flexDirection} ${gap};
+  ${alignItems}
+  ${justifyContent}
+  ${flexWrap}
+  ${flexDirection}
+  ${gap};
 `;
 
 Flex.defaultProps = {
@@ -42,7 +46,6 @@ Flex.propTypes = {
   ...propTypes.flexWrap,
   ...propTypes.flexDirection,
   ...propTypes.gap,
-
 };
 
 Flex.displayName = 'Flex';

--- a/packages/design/src/Flex/Flex.story.js
+++ b/packages/design/src/Flex/Flex.story.js
@@ -23,8 +23,8 @@ export default {
 };
 
 export const Basic = () => (
-  <Flex>
-    <Box width={1 / 2} bg="pink" p={5} mr={5}>
+  <Flex gap={5}>
+    <Box width={1 / 2} bg="pink" p={5}>
       Box one
     </Box>
     <Box width={1 / 2} bg="orange" p={5}>
@@ -34,8 +34,8 @@ export const Basic = () => (
 );
 
 export const Wrapped = () => (
-  <Flex flexWrap="wrap">
-    <Box width={[1, 1 / 2]} bg="pink" p={5} mb={2}>
+  <Flex flexWrap="wrap" gap={2}>
+    <Box width={[1, 1 / 2]} bg="pink" p={5}>
       Box one
     </Box>
     <Box width={[1, 1 / 2]} bg="orange" p={5}>

--- a/packages/design/src/system/index.js
+++ b/packages/design/src/system/index.js
@@ -39,10 +39,22 @@ import {
   space,
   textAlign,
   width,
+  style,
 } from 'styled-system';
 
 import typography from './typography';
 import borderRadius from './borderRadius';
+
+const gap = style({
+  prop: 'gap',
+  cssProperty: 'gap',
+  // This makes gap use the space defined in the theme.
+  // https://github.com/styled-system/styled-system/blob/v3.1.11/src/index.js#L67
+  key: 'space',
+  transformValue: n => n + 'px',
+});
+
+propTypes.gap = gap.propTypes;
 
 export {
   alignItems,
@@ -57,6 +69,7 @@ export {
   flexWrap,
   fontSize,
   fontWeight,
+  gap,
   height,
   justifyContent,
   justifySelf,


### PR DESCRIPTION
This will help us stop adding margins on individual items.

styled-system doesn't seem to support gap yet [1] but we can just add it
ourselves.

This code works for styled-system v3.1.11 [2]. In the future we'll need
to simply replace `style` with `system` [3].

[1] https://github.com/styled-system/styled-system/issues/1159
[2] https://github.com/styled-system/styled-system/blob/v3.1.11/docs/custom-props.md
[3] https://styled-system.com/custom-props/