### PR TITLE
Remove unnecessary tranformValue for gap

### DIFF
--- a/packages/design/src/system/index.js
+++ b/packages/design/src/system/index.js
@@ -51,7 +51,6 @@ const gap = style({
   // This makes gap use the space defined in the theme.
   // https://github.com/styled-system/styled-system/blob/v3.1.11/src/index.js#L67
   key: 'space',
-  transformValue: n => n + 'px',
 });
 
 propTypes.gap = gap.propTypes;


### PR DESCRIPTION
It makes it impossible to specify gap as a specific value, for example "8px"
as it'll get transformed to "8pxpx".