### PR TITLE
deny any permission requests until needed

### DIFF
--- a/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -60,6 +60,13 @@ export class WindowsManager {
     window.webContents.on('context-menu', (_, props) => {
       this.popupUniversalContextMenu(window, props);
     });
+
+    window.webContents.session.setPermissionRequestHandler(
+      (webContents, permission, callback) => {
+        // deny all permissions requests, we currently do not require any
+        return callback(false);
+      }
+    );
   }
 
   private saveWindowState(window: BrowserWindow): void {


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport-private/issues/146
More info: https://github.com/gravitational/teleport-private/issues/96

For now, due to us not needing any explicit permissions that request this handler, we are just going to deny all until needed.

In the future, we will need a custom confirmation dialog to handle these requests, assuming we pass the request to the user.