### PR TITLE
added a content-security-policy

### DIFF
--- a/packages/teleterm/webpack.renderer.extend.js
+++ b/packages/teleterm/webpack.renderer.extend.js
@@ -28,7 +28,7 @@ function createHtmlPlugin() {
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="referrer" content="no-referrer" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; font-src 'self' data:">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod https://usage.teleport.dev; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; font-src 'self' data:">
       </head>
       <body>
         <div id="app"></div>

--- a/packages/teleterm/webpack.renderer.extend.js
+++ b/packages/teleterm/webpack.renderer.extend.js
@@ -28,6 +28,7 @@ function createHtmlPlugin() {
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="referrer" content="no-referrer" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; font-src 'self' data:">
       </head>
       <body>
         <div id="app"></div>

--- a/packages/teleterm/webpack.renderer.extend.js
+++ b/packages/teleterm/webpack.renderer.extend.js
@@ -28,7 +28,7 @@ function createHtmlPlugin() {
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="referrer" content="no-referrer" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; font-src 'self' data:">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; font-src 'self' data:">
       </head>
       <body>
         <div id="app"></div>

--- a/packages/teleterm/webpack.renderer.extend.js
+++ b/packages/teleterm/webpack.renderer.extend.js
@@ -28,7 +28,7 @@ function createHtmlPlugin() {
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="referrer" content="no-referrer" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; font-src 'self' data:">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; font-src 'self' data:">
       </head>
       <body>
         <div id="app"></div>


### PR DESCRIPTION
Closes: https://github.com/gravitational/teleport-private/issues/147
More info: https://github.com/gravitational/teleport-private/issues/96

Due to electron not being able to set HTTP request headers in production (because files are sent using the `file://` protocol), we can define a Content-Security-Policy in our "index.html" page.

This csp mostly matches the webui csp, with the exception of `font-src` where I've added `data:` to keep our icons working.

Note about `connect-src`: Adding in the urls `https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod` and `https://usage.teleport.dev` are required for the feedback form to work on dev (insecure) and prod respectively 