### PR TITLE
updated webPreferences config

### DIFF
--- a/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -41,6 +41,10 @@ export class WindowsManager {
       title: 'Teleport Connect Preview',
       icon: getAssetPath('icon.png'),
       webPreferences: {
+        devTools: this.settings.dev,
+        webgl: false,
+        enableWebSQL: false,
+        safeDialogs: true,
         contextIsolation: true,
         nodeIntegration: false,
         preload: path.join(__dirname, 'preload.js'),


### PR DESCRIPTION
Closes: https://github.com/gravitational/teleport-private/issues/148
More info: https://github.com/gravitational/teleport-private/issues/96

Notes:
- `enableRemoteModule` defaults to `false` from electron 10+, so we do not need to explicitly set it here. [source](https://www.electronjs.org/docs/latest/breaking-changes#default-changed-enableremotemodule-defaults-to-false)
- `sandbox: true` has much bigger consequences and would require quite a bit of work to enable. We should discuss the implications of this in a separate issue. [docs](https://www.electronjs.org/docs/latest/tutorial/sandbox). As usual, if I'm overthinking this let me know, but the app does not currently work if sandbox is true and the changes appear to be substantial. 