### PR TITLE
Create LoginTrait Component

### DIFF
--- a/packages/teleport/src/Discover/AgentConnect.tsx
+++ b/packages/teleport/src/Discover/AgentConnect.tsx
@@ -18,7 +18,9 @@ import React from 'react';
 import styled from 'styled-components';
 import { Flex, ButtonPrimary, ButtonSecondary, Text, Box } from 'design';
 import * as Icons from 'design/Icon';
-import { State, AgentKind } from './useDiscover';
+import type { AgentStepProps, AgentStepComponent } from './Shared';
+import type { AgentKind } from './useDiscover';
+import { LoginTrait } from './LoginTrait';
 
 // agentStepTitles defines the titles per steps defined by enum `AgentStep`.
 //
@@ -37,7 +39,7 @@ export const agentStepTitles: string[] = [
 // We use the enum `AgentStep` numerical values to access the list's value,
 // so the list's order and length must be equal to the enum.
 export const agentViews: Record<AgentKind, AgentStepComponent[]> = {
-  app: [GatherReqs, InstallTeleport, RoleConfig],
+  app: [GatherReqs, InstallTeleport, LoginTrait, RoleConfig],
   db: [],
   desktop: [],
   kube: [],
@@ -199,23 +201,3 @@ const AgentButton = styled(Flex)(
    text-align: center;
  `
 );
-
-type AgentStepProps = {
-  // attempt defines fetch attempt states when we make api calls.
-  attempt: State['attempt'];
-  // joinToken defines fields related to a fetched token.
-  joinToken: State['joinToken'];
-  // agentMeta describes fields specific to an agent kind.
-  agentMeta: State['agentMeta'];
-  // updateAgentMeta updates the data specific to agent kinds
-  // as needed as we move through the step.
-  updateAgentMeta: State['updateAgentMeta'];
-  // nextStep increments the `currentStep` to go to the next step.
-  nextStep: State['nextStep'];
-  // prevStep decrements the `currentStep` to go to the prev step.
-  prevStep: State['prevStep'];
-  // createJoinToken makes a fetch api call to get a joinToken.
-  createJoinToken: State['createJoinToken'];
-};
-
-type AgentStepComponent = (props: AgentStepProps) => JSX.Element;

--- a/packages/teleport/src/Discover/AgentConnect.tsx
+++ b/packages/teleport/src/Discover/AgentConnect.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Flex, ButtonPrimary, ButtonSecondary, Text, Box } from 'design';
 import * as Icons from 'design/Icon';
-import type { AgentStepProps, AgentStepComponent } from './Shared';
+import type { AgentStepProps, AgentStepComponent } from './types';
 import type { AgentKind } from './useDiscover';
 import { LoginTrait } from './LoginTrait';
 

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from 'design/utils/testing';
+import { Loaded, Empty, Failed } from './LoginTrait.story';
+
+test('loaded', () => {
+  const { container } = render(<Loaded />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('loaded empty state', () => {
+  const { container } = render(<Empty />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('failed', () => {
+  const { container } = render(<Failed />);
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
@@ -24,7 +24,7 @@ export default {
 
 export const Loaded = () => <LoginTrait {...props} />;
 
-export const Empty = () => <LoginTrait {...props} loginMap={{}} />;
+export const Empty = () => <LoginTrait {...props} logins={[]} />;
 
 export const Processing = () => (
   <LoginTrait {...props} attempt={{ status: 'processing' }} />
@@ -42,12 +42,7 @@ const props: State = {
     status: 'success',
     statusText: '',
   },
-  loginMap: {
-    root: true,
-    foo: false,
-    george_washington_really_long_name_testing: true,
-  },
+  logins: ['root', 'llama', 'george_washington_really_long_name_testing'],
   nextStep: () => null,
-  toggleLoginSelect: () => null,
   addLogin: () => null,
 };

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { LoginTrait } from './LoginTrait';
+import { State } from './useLoginTrait';
+
+export default {
+  title: 'Teleport/Discover/LoginTrait',
+};
+
+export const Loaded = () => <LoginTrait {...props} />;
+
+export const Empty = () => <LoginTrait {...props} loginMap={{}} />;
+
+export const Processing = () => (
+  <LoginTrait {...props} attempt={{ status: 'processing' }} />
+);
+
+export const Failed = () => (
+  <LoginTrait
+    {...props}
+    attempt={{ status: 'failed', statusText: 'some error message' }}
+  />
+);
+
+const props: State = {
+  attempt: {
+    status: 'success',
+    statusText: '',
+  },
+  loginMap: {
+    root: true,
+    foo: false,
+    george_washington_really_long_name_testing: true,
+  },
+  nextStep: () => null,
+  toggleLoginSelect: () => null,
+  addLogin: () => null,
+};

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+// eslint-disable-next-line import/named
+import { RenderResult } from '@testing-library/react';
+import { render, screen, act, fireEvent } from 'design/utils/testing';
+import type { User } from 'teleport/services/user';
+import { DiscoverContext } from '../discoverContext';
+import ContextProvider from '../discoverContextProvider';
+import LoginTrait from './LoginTrait';
+
+describe('login trait comp behavior', () => {
+  const ctx = new DiscoverContext();
+  const userSvc = ctx.userService;
+
+  let Component;
+
+  beforeEach(() => {
+    Component = (
+      <ContextProvider value={ctx}>
+        <LoginTrait
+          // TODO we don't need all of this
+          attempt={null}
+          joinToken={null}
+          createJoinToken={null}
+          agentMeta={null}
+          updateAgentMeta={null}
+          nextStep={null}
+          prevStep={null}
+        />
+      </ContextProvider>
+    );
+  });
+
+  test('add a new login', async () => {
+    jest.spyOn(userSvc, 'fetchUser').mockResolvedValue(mockUser);
+
+    let r: RenderResult;
+    await act(async () => {
+      r = render(Component);
+    });
+
+    // Expect no checkboxes to be rendered.
+    const checkboxes = r.container.querySelectorAll('input[type=checkbox]');
+    expect(checkboxes).toHaveLength(0);
+
+    // Test adding a new login name.
+    fireEvent.click(screen.getByText(/add new/i));
+    const inputEl = screen.getByPlaceholderText('name');
+    fireEvent.change(inputEl, { target: { value: 'banana' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(screen.getByText('banana')).toBeInTheDocument();
+  });
+
+  test('rendering of init logins', async () => {
+    jest.spyOn(userSvc, 'fetchUser').mockResolvedValue({
+      ...mockUser,
+      traits: {
+        ...mockUser.traits,
+        logins: ['apple', 'banana'],
+      },
+    });
+
+    let r: RenderResult;
+    await act(async () => {
+      r = render(Component);
+    });
+
+    // Test init logins to be rendered.
+    let checkboxes: NodeListOf<HTMLInputElement> =
+      r.container.querySelectorAll('input:checked');
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0].name).toBe('apple');
+    expect(checkboxes[1].name).toBe('banana');
+
+    // Test init logins to be rendered with a new login name.
+    fireEvent.click(screen.getByText(/add new/i));
+    const inputEl = screen.getByPlaceholderText('name');
+    fireEvent.change(inputEl, { target: { value: 'carrot' } });
+    fireEvent.click(screen.getByText('Add'));
+
+    checkboxes = r.container.querySelectorAll('input:checked');
+    expect(checkboxes).toHaveLength(3);
+    expect(checkboxes[0].name).toBe('apple');
+    expect(checkboxes[1].name).toBe('banana');
+    expect(checkboxes[2].name).toBe('carrot');
+  });
+});
+
+const mockUser: User = {
+  name: 'foo',
+  roles: [],
+  traits: {
+    logins: [],
+    dbUsers: [],
+    dbNames: [],
+    kubeUsers: [],
+    kubeGroups: [],
+    windowsLogins: [],
+    awsRoleArns: [],
+  },
+};

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
@@ -15,8 +15,7 @@
  */
 
 import React from 'react';
-// eslint-disable-next-line import/named
-import { RenderResult } from '@testing-library/react';
+import type { RenderResult } from '@testing-library/react';
 import { render, screen, act, fireEvent } from 'design/utils/testing';
 import type { User } from 'teleport/services/user';
 import { DiscoverContext } from '../discoverContext';
@@ -106,8 +105,8 @@ const mockUser: User = {
   roles: [],
   traits: {
     logins: [],
-    dbUsers: [],
-    dbNames: [],
+    databaseUsers: [],
+    databaseNames: [],
     kubeUsers: [],
     kubeGroups: [],
     windowsLogins: [],

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.tsx
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import { Flex, ButtonPrimary, ButtonText, Text, Box, Indicator } from 'design';
+import { Danger } from 'design/Alert';
+import * as Icons from 'design/Icon';
+import FieldInput from 'shared/components/FieldInput';
+import Validation from 'shared/components/Validation';
+import { Header, CancelButton } from '../Shared';
+import type { AgentStepProps } from '../Shared';
+import { useDiscoverContext } from '../discoverContextProvider';
+import { useLoginTrait, State } from './useLoginTrait';
+
+export default function Container(props: AgentStepProps) {
+  const ctx = useDiscoverContext();
+  const state = useLoginTrait({ ctx, props });
+
+  return <LoginTrait {...state} />;
+}
+
+export function LoginTrait({
+  attempt,
+  nextStep,
+  loginMap,
+  toggleLoginSelect,
+  addLogin,
+}: State) {
+  const [newLogin, setNewLogin] = useState('');
+  const [showInputBox, setShowInputBox] = useState(false);
+
+  return (
+    <Box>
+      <Header>Set Up Access</Header>
+      {attempt.status === 'processing' && (
+        <Box textAlign="center" m={10}>
+          <Indicator />
+        </Box>
+      )}
+      {attempt.status === 'failed' && <Danger>{attempt.statusText}</Danger>}
+      {attempt.status === 'success' && (
+        <>
+          <Text bold mb={2}>
+            Select or Add Linux Principles
+          </Text>
+          <Box mb={6}>
+            {Object.keys(loginMap).map((login, index) => {
+              return (
+                <Flex
+                  key={index}
+                  p={2}
+                  mb={1}
+                  borderRadius={2}
+                  width="300px"
+                  alignItems="center"
+                  borderColor="colors.primary.light"
+                  css={`
+                    border: 1px solid
+                      ${props => props.theme.colors.primary.light};
+                  `}
+                >
+                  <input
+                    type="checkbox"
+                    name={login}
+                    checked={loginMap[login]}
+                    css={`
+                      margin-right: 10px;
+                      accent-color: ${props =>
+                        props.theme.colors.secondary.main};
+                      &:hover {
+                        cursor: pointer;
+                      }
+                    `}
+                    onChange={() => toggleLoginSelect(login)}
+                  />
+                  <label
+                    htmlFor={login}
+                    css={`
+                      width: 250px;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                    `}
+                  >
+                    {login}
+                  </label>
+                </Flex>
+              );
+            })}
+            {showInputBox && (
+              <Flex alignItems="end" mt={3}>
+                <Validation>
+                  <FieldInput
+                    placeholder="name"
+                    autoFocus
+                    width="200px"
+                    value={newLogin}
+                    type="text"
+                    onChange={e => setNewLogin(e.target.value.trim())}
+                    mr={3}
+                    mb={0}
+                  />
+                  <ButtonPrimary
+                    size="small"
+                    mb={2}
+                    disabled={newLogin.length === 0}
+                    onClick={() => {
+                      addLogin(newLogin);
+                      setNewLogin('');
+                      setShowInputBox(false);
+                    }}
+                  >
+                    Add
+                  </ButtonPrimary>
+                </Validation>
+              </Flex>
+            )}
+            {!showInputBox && (
+              <ButtonText
+                mt={2}
+                onClick={() => setShowInputBox(true)}
+                css={`
+                  line-height: normal;
+                  padding-left: 4px;
+                `}
+              >
+                <Icons.Add
+                  css={`
+                    font-weight: bold;
+                    letter-spacing: 4px;
+                    &:after {
+                      content: ' ';
+                    }
+                  `}
+                />
+                Add New Principle
+              </ButtonText>
+            )}
+          </Box>
+          <ButtonPrimary
+            width="165px"
+            onClick={() => {
+              let checkedLogins = Object.keys(loginMap).filter(login =>
+                loginMap[login] ? login : false
+              );
+              nextStep(checkedLogins);
+            }}
+            mr={3}
+          >
+            Proceed
+          </ButtonPrimary>
+          <CancelButton />
+        </>
+      )}
+    </Box>
+  );
+}

--- a/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
@@ -298,15 +298,16 @@ exports[`loaded 1`] = `
       width="300px"
     >
       <input
+        checked=""
         class="c5"
-        name="foo"
+        name="llama"
         type="checkbox"
       />
       <label
         class="c6"
-        for="foo"
+        for="llama"
       >
-        foo
+        llama
       </label>
     </div>
     <div

--- a/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
@@ -1,0 +1,579 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`failed 1`] = `
+.c2 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  box-sizing: border-box;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.24);
+  margin: 0 0 24px 0;
+  min-height: 40px;
+  padding: 8px 16px;
+  overflow: auto;
+  word-break: break-word;
+  line-height: 1.5;
+  background: #f50057;
+  color: #FFFFFF;
+}
+
+.c2 a {
+  color: #FFFFFF;
+}
+
+.c0 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 32px;
+  margin: 0px;
+  margin-bottom: 24px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+    kind="danger"
+  >
+    some error message
+  </div>
+</div>
+`;
+
+exports[`loaded 1`] = `
+.c0 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 40px;
+}
+
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: none;
+  text-transform: none;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 8px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: none;
+  text-decoration: underline;
+}
+
+.c7:disabled {
+  background: none;
+  color: rgba(255,255,255,0.3);
+}
+
+.c11 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c11:active {
+  opacity: 0.56;
+}
+
+.c11:hover,
+.c11:focus {
+  background: #651FFF;
+}
+
+.c11:active {
+  background: #354AA4;
+}
+
+.c11:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c12 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c12:active {
+  opacity: 0.56;
+}
+
+.c12:hover,
+.c12:focus {
+  background: #2C3A73;
+}
+
+.c12:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c9 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 32px;
+  margin: 0px;
+  margin-bottom: 24px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+  margin-bottom: 8px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-bottom: 4px;
+  padding: 8px;
+  width: 300px;
+  border-radius: 4px;
+  border-color: colors.primary.light;
+  display: flex;
+  align-items: center;
+  border: 1px solid #222C59;
+}
+
+.c5 {
+  margin-right: 10px;
+  accent-color: #512FC9;
+}
+
+.c5:hover {
+  cursor: pointer;
+}
+
+.c6 {
+  width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c8 {
+  line-height: normal;
+  padding-left: 4px;
+}
+
+.c10 {
+  font-weight: bold;
+  letter-spacing: 4px;
+}
+
+.c10:after {
+  content: ' ';
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select or Add Linux Principles
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4"
+      width="300px"
+    >
+      <input
+        checked=""
+        class="c5"
+        name="root"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="root"
+      >
+        root
+      </label>
+    </div>
+    <div
+      class="c4"
+      width="300px"
+    >
+      <input
+        class="c5"
+        name="foo"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="foo"
+      >
+        foo
+      </label>
+    </div>
+    <div
+      class="c4"
+      width="300px"
+    >
+      <input
+        checked=""
+        class="c5"
+        name="george_washington_really_long_name_testing"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="george_washington_really_long_name_testing"
+      >
+        george_washington_really_long_name_testing
+      </label>
+    </div>
+    <button
+      class="c7 c8"
+      kind="text"
+    >
+      <span
+        class="c9 icon icon-add c10"
+        color="light"
+      />
+      Add New Principle
+    </button>
+  </div>
+  <button
+    class="c11"
+    kind="primary"
+    width="165px"
+  >
+    Proceed
+  </button>
+  <button
+    class="c12"
+    kind="secondary"
+    width="165px"
+  >
+    Go To Dashboard
+  </button>
+</div>
+`;
+
+exports[`loaded empty state 1`] = `
+.c0 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 40px;
+}
+
+.c4 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: none;
+  text-transform: none;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 8px;
+}
+
+.c4:active {
+  opacity: 0.56;
+}
+
+.c4:hover,
+.c4:focus {
+  background: none;
+  text-decoration: underline;
+}
+
+.c4:disabled {
+  background: none;
+  color: rgba(255,255,255,0.3);
+}
+
+.c8 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c8:active {
+  opacity: 0.56;
+}
+
+.c8:hover,
+.c8:focus {
+  background: #651FFF;
+}
+
+.c8:active {
+  background: #354AA4;
+}
+
+.c8:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c9 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c9:active {
+  opacity: 0.56;
+}
+
+.c9:hover,
+.c9:focus {
+  background: #2C3A73;
+}
+
+.c9:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c6 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 32px;
+  margin: 0px;
+  margin-bottom: 24px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+  margin-bottom: 8px;
+}
+
+.c5 {
+  line-height: normal;
+  padding-left: 4px;
+}
+
+.c7 {
+  font-weight: bold;
+  letter-spacing: 4px;
+}
+
+.c7:after {
+  content: ' ';
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select or Add Linux Principles
+  </div>
+  <div
+    class="c3"
+  >
+    <button
+      class="c4 c5"
+      kind="text"
+    >
+      <span
+        class="c6 icon icon-add c7"
+        color="light"
+      />
+      Add New Principle
+    </button>
+  </div>
+  <button
+    class="c8"
+    kind="primary"
+    width="165px"
+  >
+    Proceed
+  </button>
+  <button
+    class="c9"
+    kind="secondary"
+    width="165px"
+  >
+    Go To Dashboard
+  </button>
+</div>
+`;

--- a/packages/teleport/src/Discover/LoginTrait/index.ts
+++ b/packages/teleport/src/Discover/LoginTrait/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import LoginTrait from './LoginTrait';
+export { LoginTrait };

--- a/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
+++ b/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+import useAttempt from 'shared/hooks/useAttemptNext';
+import type { User } from 'teleport/services/user';
+import { DiscoverContext } from '../discoverContext';
+import type { AgentStepProps } from '../Shared';
+
+export function useLoginTrait({ ctx, props }: Props) {
+  const [user, setUser] = useState<User>();
+  const { attempt, run, setAttempt, handleError } = useAttempt('processing');
+  const [loginMap, setLoginMap] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    run(() =>
+      ctx.userService.fetchUser(ctx.username).then(user => {
+        setUser(user);
+        let loginMap = {};
+        user.traits.logins.forEach(login => (loginMap[login] = true));
+        setLoginMap(loginMap);
+      })
+    );
+  }, []);
+
+  function nextStep(logins: string[]) {
+    setAttempt({ status: 'processing' });
+    ctx.userService
+      .updateUser({
+        ...user,
+        traits: { ...user.traits, logins },
+      })
+      .then(props.nextStep)
+      .catch(handleError);
+  }
+
+  function toggleLoginSelect(login: string) {
+    const newMap = { ...loginMap };
+    newMap[login] = !loginMap[login];
+    setLoginMap(newMap);
+  }
+
+  function addLogin(login: string) {
+    setLoginMap({
+      ...loginMap,
+      [login]: true,
+    });
+  }
+
+  return {
+    attempt,
+    nextStep,
+    loginMap,
+    toggleLoginSelect,
+    addLogin,
+  };
+}
+
+type Props = {
+  ctx: DiscoverContext;
+  props: AgentStepProps;
+};
+
+export type State = ReturnType<typeof useLoginTrait>;

--- a/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
+++ b/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
@@ -18,20 +18,18 @@ import { useState, useEffect } from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import type { User } from 'teleport/services/user';
 import { DiscoverContext } from '../discoverContext';
-import type { AgentStepProps } from '../Shared';
+import type { AgentStepProps } from '../types';
 
 export function useLoginTrait({ ctx, props }: Props) {
   const [user, setUser] = useState<User>();
   const { attempt, run, setAttempt, handleError } = useAttempt('processing');
-  const [loginMap, setLoginMap] = useState<Record<string, boolean>>({});
+  const [logins, setLogins] = useState<string[]>([]);
 
   useEffect(() => {
     run(() =>
       ctx.userService.fetchUser(ctx.username).then(user => {
         setUser(user);
-        let loginMap = {};
-        user.traits.logins.forEach(login => (loginMap[login] = true));
-        setLoginMap(loginMap);
+        setLogins(user.traits.logins);
       })
     );
   }, []);
@@ -47,24 +45,14 @@ export function useLoginTrait({ ctx, props }: Props) {
       .catch(handleError);
   }
 
-  function toggleLoginSelect(login: string) {
-    const newMap = { ...loginMap };
-    newMap[login] = !loginMap[login];
-    setLoginMap(newMap);
-  }
-
   function addLogin(login: string) {
-    setLoginMap({
-      ...loginMap,
-      [login]: true,
-    });
+    setLogins([...logins, login]);
   }
 
   return {
     attempt,
     nextStep,
-    loginMap,
-    toggleLoginSelect,
+    logins,
     addLogin,
   };
 }

--- a/packages/teleport/src/Discover/Shared.tsx
+++ b/packages/teleport/src/Discover/Shared.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import { Text, ButtonSecondary } from 'design';
-import { State } from './useDiscover';
 import cfg from 'teleport/config';
 import history from 'teleport/services/history';
 
@@ -40,25 +39,3 @@ export const CancelButton: React.FC = () => (
     Go To Dashboard
   </ButtonSecondary>
 );
-
-export type AgentStepProps = {
-  // attempt defines fetch attempt states when we make api calls.
-  attempt: State['attempt'];
-  // joinToken defines fields related to a fetched token.
-  joinToken: State['joinToken'];
-  // agentMeta describes fields specific to an agent kind.
-  agentMeta: State['agentMeta'];
-  // updateAgentMeta updates the data specific to agent kinds
-  // as needed as we move through the step.
-  updateAgentMeta: State['updateAgentMeta'];
-  // nextStep increments the `currentStep` to go to the next step.
-  nextStep: State['nextStep'];
-  // prevStep decrements the `currentStep` to go to the prev step.
-  // TODO (anyone): I think we established there will be no previous
-  // button, but I don't remember.
-  prevStep: State['prevStep'];
-  // createJoinToken makes a fetch api call to get a joinToken.
-  createJoinToken: State['createJoinToken'];
-};
-
-export type AgentStepComponent = (props: AgentStepProps) => JSX.Element;

--- a/packages/teleport/src/Discover/Shared.tsx
+++ b/packages/teleport/src/Discover/Shared.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Text, ButtonSecondary } from 'design';
+import { State } from './useDiscover';
+import cfg from 'teleport/config';
+import history from 'teleport/services/history';
+
+export const Header: React.FC = ({ children }) => (
+  <Text mb={4} typography="h4" bold>
+    {children}
+  </Text>
+);
+
+// CancelButton is clicked when user wants to cancel connecting resource
+// which at the moment just means to go back to dashboard.
+// Later implementation, this could mean go back to main discover
+// menu (TBD).
+export const CancelButton: React.FC = () => (
+  <ButtonSecondary
+    mr={3}
+    mt={3}
+    width="165px"
+    onClick={() => history.push(cfg.routes.root, true)}
+  >
+    Go To Dashboard
+  </ButtonSecondary>
+);
+
+export type AgentStepProps = {
+  // attempt defines fetch attempt states when we make api calls.
+  attempt: State['attempt'];
+  // joinToken defines fields related to a fetched token.
+  joinToken: State['joinToken'];
+  // agentMeta describes fields specific to an agent kind.
+  agentMeta: State['agentMeta'];
+  // updateAgentMeta updates the data specific to agent kinds
+  // as needed as we move through the step.
+  updateAgentMeta: State['updateAgentMeta'];
+  // nextStep increments the `currentStep` to go to the next step.
+  nextStep: State['nextStep'];
+  // prevStep decrements the `currentStep` to go to the prev step.
+  // TODO (anyone): I think we established there will be no previous
+  // button, but I don't remember.
+  prevStep: State['prevStep'];
+  // createJoinToken makes a fetch api call to get a joinToken.
+  createJoinToken: State['createJoinToken'];
+};
+
+export type AgentStepComponent = (props: AgentStepProps) => JSX.Element;

--- a/packages/teleport/src/Discover/types.ts
+++ b/packages/teleport/src/Discover/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { State } from './useDiscover';
+
+export type AgentStepProps = {
+  // attempt defines fetch attempt states when we make api calls.
+  attempt: State['attempt'];
+  // joinToken defines fields related to a fetched token.
+  joinToken: State['joinToken'];
+  // agentMeta describes fields specific to an agent kind.
+  agentMeta: State['agentMeta'];
+  // updateAgentMeta updates the data specific to agent kinds
+  // as needed as we move through the step.
+  updateAgentMeta: State['updateAgentMeta'];
+  // nextStep increments the `currentStep` to go to the next step.
+  nextStep: State['nextStep'];
+  // prevStep decrements the `currentStep` to go to the prev step.
+  // TODO (anyone): I think we established there will be no previous
+  // button, but I don't remember.
+  prevStep: State['prevStep'];
+  // createJoinToken makes a fetch api call to get a joinToken.
+  createJoinToken: State['createJoinToken'];
+};
+
+export type AgentStepComponent = (props: AgentStepProps) => JSX.Element;

--- a/packages/teleport/src/Teleport.tsx
+++ b/packages/teleport/src/Teleport.tsx
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// eslint-disable-next-line import/named
-import { History } from 'history';
+import type { History } from 'history';
 import React from 'react';
 import ThemeProvider from 'design/ThemeProvider';
 import { Router, Route, Switch } from 'teleport/components/Router';

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -138,7 +138,7 @@ const cfg = {
       '/v1/webapi/sites/:clusterId/kubernetes?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?',
 
     usersPath: '/v1/webapi/users',
-    usersDelete: '/v1/webapi/users/:username',
+    userWithUsernamePath: '/v1/webapi/users/:username',
     createPrivilegeTokenPath: '/v1/webapi/users/privilege/token',
 
     rolesPath: '/v1/webapi/roles/:name?',
@@ -356,8 +356,8 @@ const cfg = {
     return cfg.api.usersPath;
   },
 
-  getUsersDeleteUrl(username = '') {
-    return generatePath(cfg.api.usersDelete, { username });
+  getUserWithUsernameUrl(username: string) {
+    return generatePath(cfg.api.userWithUsernamePath, { username });
   },
 
   getTerminalSessionUrl({ clusterId, sid }: UrlParams) {

--- a/packages/teleport/src/services/history/history.ts
+++ b/packages/teleport/src/services/history/history.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// eslint-disable-next-line import/named
-import { createBrowserHistory, History } from 'history';
+import { createBrowserHistory } from 'history';
+import type { History } from 'history';
 import { matchPath } from 'react-router';
 import cfg from 'teleport/config';
 

--- a/packages/teleport/src/services/user/makeUser.ts
+++ b/packages/teleport/src/services/user/makeUser.ts
@@ -14,16 +14,26 @@
  * limitations under the License.
  */
 
-import { at } from 'lodash';
 import { User } from './types';
 
 export default function makeUser(json): User {
-  const [name, roles, authType] = at(json, ['name', 'roles', 'authType']);
+  json = json || {};
+  const { name, roles, authType, traits = {} } = json;
+
   return {
     name,
     roles: roles ? roles.sort() : [],
     authType: authType === 'local' ? 'teleport local user' : authType,
     isLocal: authType === 'local',
+    traits: {
+      logins: traits.logins || [],
+      dbUsers: traits.dbUsers || [],
+      dbNames: traits.dbNames || [],
+      kubeUsers: traits.kubeUsers || [],
+      kubeGroups: traits.kubeGroups || [],
+      windowsLogins: traits.windowsLogins || [],
+      awsRoleArns: traits.awsRoleArns || [],
+    },
   };
 }
 

--- a/packages/teleport/src/services/user/makeUser.ts
+++ b/packages/teleport/src/services/user/makeUser.ts
@@ -16,7 +16,7 @@
 
 import { User } from './types';
 
-export default function makeUser(json): User {
+export default function makeUser(json: any): User {
   json = json || {};
   const { name, roles, authType, traits = {} } = json;
 
@@ -27,8 +27,8 @@ export default function makeUser(json): User {
     isLocal: authType === 'local',
     traits: {
       logins: traits.logins || [],
-      dbUsers: traits.dbUsers || [],
-      dbNames: traits.dbNames || [],
+      databaseUsers: traits.databaseUsers || [],
+      databaseNames: traits.databaseNames || [],
       kubeUsers: traits.kubeUsers || [],
       kubeGroups: traits.kubeGroups || [],
       windowsLogins: traits.windowsLogins || [],

--- a/packages/teleport/src/services/user/types.ts
+++ b/packages/teleport/src/services/user/types.ts
@@ -85,11 +85,11 @@ export interface UserTraits {
   // logins is the list of logins that this user is allowed to
   // start SSH sessions with.
   logins: string[];
-  // dbUsers is the list of db usernames that this user is
+  // databaseUsers is the list of db usernames that this user is
   // allowed to open db connections as.
-  dbUsers: string[];
-  // dbNames is the list of db names that this user can connect to.
-  dbNames: string[];
+  databaseUsers: string[];
+  // databaseNames is the list of db names that this user can connect to.
+  databaseNames: string[];
   // kubeUsers is the list of allowed kube logins.
   kubeUsers: string[];
   // kubeGroups is the list of allowed kube groups for a kube cluster.

--- a/packages/teleport/src/services/user/types.ts
+++ b/packages/teleport/src/services/user/types.ts
@@ -68,10 +68,37 @@ export interface Acl {
 }
 
 export interface User {
+  // name is the teleport username.
   name: string;
+  // roles is the list of roles user is assigned to.
   roles: string[];
+  // authType describes how the user authenticated
+  // e.g. locally or with a SSO provider.
   authType?: string;
+  // isLocal is true if json.authType was 'local'.
   isLocal?: boolean;
+  traits?: UserTraits;
+}
+
+// UserTraits contain fields that define traits for local accounts.
+export interface UserTraits {
+  // logins is the list of logins that this user is allowed to
+  // start SSH sessions with.
+  logins: string[];
+  // dbUsers is the list of db usernames that this user is
+  // allowed to open db connections as.
+  dbUsers: string[];
+  // dbNames is the list of db names that this user can connect to.
+  dbNames: string[];
+  // kubeUsers is the list of allowed kube logins.
+  kubeUsers: string[];
+  // kubeGroups is the list of allowed kube groups for a kube cluster.
+  kubeGroups: string[];
+  // windowsLogins is the list of logins that this user
+  // is allowed to start desktop sessions.
+  windowsLogins: string[];
+  // awsRoleArns is a list of aws roles this user is allowed to assume.
+  awsRoleArns: string[];
 }
 
 export interface ResetToken {

--- a/packages/teleport/src/services/user/user.test.ts
+++ b/packages/teleport/src/services/user/user.test.ts
@@ -193,8 +193,8 @@ test('fetch users, null response values gives empty array', async () => {
       roles: [],
       traits: {
         awsRoleArns: [],
-        dbNames: [],
-        dbUsers: [],
+        databaseNames: [],
+        databaseUsers: [],
         kubeGroups: [],
         kubeUsers: [],
         logins: [],

--- a/packages/teleport/src/services/user/user.test.ts
+++ b/packages/teleport/src/services/user/user.test.ts
@@ -186,6 +186,20 @@ test('fetch users, null response values gives empty array', async () => {
 
   response = await user.fetchUsers();
   expect(response).toStrictEqual([
-    { authType: '', isLocal: false, name: '', roles: [] },
+    {
+      authType: '',
+      isLocal: false,
+      name: '',
+      roles: [],
+      traits: {
+        awsRoleArns: [],
+        dbNames: [],
+        dbUsers: [],
+        kubeGroups: [],
+        kubeUsers: [],
+        logins: [],
+        windowsLogins: [],
+      },
+    },
   ]);
 });

--- a/packages/teleport/src/services/user/user.ts
+++ b/packages/teleport/src/services/user/user.ts
@@ -40,6 +40,10 @@ const service = {
       });
   },
 
+  fetchUser(username: string) {
+    return api.get(cfg.getUserWithUsernameUrl(username)).then(makeUser);
+  },
+
   fetchUsers() {
     return api.get(cfg.getUsersUrl()).then(makeUsers);
   },
@@ -59,7 +63,7 @@ const service = {
   },
 
   deleteUser(name: string) {
-    return api.delete(cfg.getUsersDeleteUrl(name));
+    return api.delete(cfg.getUserWithUsernameUrl(name));
   },
 };
 

--- a/packages/teleterm/src/ui/uri.ts
+++ b/packages/teleterm/src/ui/uri.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// eslint-disable-next-line import/named
-import { RouteProps, matchPath, generatePath } from 'react-router';
+import { matchPath, generatePath } from 'react-router';
+import type { RouteProps } from 'react-router';
 
 export const paths = {
   rootCluster: '/clusters/:rootClusterId',


### PR DESCRIPTION
#### Description
part of https://github.com/gravitational/teleport/issues/13997

I made this component specific to `logins` (ssh) for the first phase. There were too many unknowns to make it generic for all traits (if that's even reasonable to do).

- Create a LoginTrait component that allows user's to add or remove new login principles
- Added trait fields to User response
- Created a shared file that exports shared/common components predicted to be used in each step

#### Dependent PR
- [ ] requires this small modification: https://github.com/gravitational/teleport/pull/14611

#### Demo
It starts with existing traits that I added earlier.

![login-trait-demo](https://user-images.githubusercontent.com/43280172/179682728-d78d4570-a921-4be5-8d43-1729f3a35dbb.gif)
