### PR TITLE
Remove pathname injection in 404 message

### DIFF
--- a/packages/teleport/src/components/Router/Router.jsx
+++ b/packages/teleport/src/components/Router/Router.jsx
@@ -26,7 +26,10 @@ import * as RouterDOM from 'react-router-dom';
 import { NotFound } from 'design/CardError';
 
 const NoMatch = ({ location }) => (
-  <NotFound alignSelf="baseline" message="The requested path could not be found." />
+  <NotFound
+    alignSelf="baseline"
+    message="The requested path could not be found."
+  />
 );
 
 // Adds default not found handler

--- a/packages/teleport/src/components/Router/Router.jsx
+++ b/packages/teleport/src/components/Router/Router.jsx
@@ -26,7 +26,7 @@ import * as RouterDOM from 'react-router-dom';
 import { NotFound } from 'design/CardError';
 
 const NoMatch = ({ location }) => (
-  <NotFound alignSelf="baseline" message={location.pathname} />
+  <NotFound alignSelf="baseline" message="The requested path could not be found." />
 );
 
 // Adds default not found handler


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport-private/issues/150
More info: https://github.com/gravitational/teleport-private/issues/96

Replaces the requested pathname with a static message for the NotFound component. This removes the ability to display arbitrary text in the pathname and reduces the vector for a phishing attack [more here](https://owasp.org/www-community/attacks/Content_Spoofing) 

My notes on the approach:
I went with the 'easiest' solution for now. If we had used this message in other places, or had more context around the pathname message itself such as `The path: PATHNAME_HERE could not be found.` then we would want to abstract this out into some sort of template. I don't see it used anywhere else in the codebase this way, so for now a static message would suffice. This can be expanded later into an error code map or something, but no reason to do that now if this is the only possible outcome. I may be missing something though, so please point out the use cases I missed!

