### PR TITLE
Add `c-` prefix to the OS field of the feedback form

### DIFF
--- a/packages/teleterm/src/ui/StatusBar/ShareFeedback/useShareFeedback.ts
+++ b/packages/teleterm/src/ui/StatusBar/ShareFeedback/useShareFeedback.ts
@@ -27,7 +27,10 @@ export function useShareFeedback() {
     preValidateForm();
 
     const formData = new FormData();
-    formData.set('OS', ctx.mainProcessClient.getRuntimeSettings().platform);
+    const { platform } = ctx.mainProcessClient.getRuntimeSettings();
+    // The `c-` prefix is added on purpose to differentiate feedback forms sent from Connect.
+    const os = `c-${platform}`;
+    formData.set('OS', os);
     formData.set('email', formValues.email);
     formData.set('company', formValues.company);
     formData.set('use-case', formValues.feedback);


### PR DESCRIPTION
[As discussed with Ben](https://gravitational.slack.com/archives/C03FJA391M3/p1658326366770589?thread_ts=1658326270.992069&cid=C03FJA391M3), we want to add this prefix so that dev rel cann differentiate feedback forms sent from Connect.