### PR TITLE
Connect: Wait for tshd gRPC server to start

### DIFF
--- a/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -1,13 +1,10 @@
 import { ChildProcess, fork, spawn } from 'child_process';
-
 import path from 'path';
 
 import { app, ipcMain, Menu, MenuItemConstructorOptions } from 'electron';
 
 import { FileStorage, Logger, RuntimeSettings } from 'teleterm/types';
-
 import { subscribeToFileStorageEvents } from 'teleterm/services/fileStorage';
-
 import createLoggerService from 'teleterm/services/logger';
 import { ChildProcessAddresses } from 'teleterm/mainProcess/types';
 
@@ -18,6 +15,7 @@ import {
 
 import { subscribeToTerminalContextMenuEvent } from './contextMenus/terminalContextMenu';
 import { subscribeToTabContextMenuEvent } from './contextMenus/tabContextMenu';
+import { resolveNetworkAddress } from './resolveNetworkAddress';
 
 type Options = {
   settings: RuntimeSettings;
@@ -116,60 +114,15 @@ export default class MainProcess {
 
   private _initResolvingChildProcessAddresses(): void {
     this.resolvedChildProcessAddresses = Promise.all([
-      this.resolveNetworkAddress(
+      resolveNetworkAddress(
         this.settings.tshd.requestedNetworkAddress,
         this.tshdProcess
       ),
-      this.resolveNetworkAddress(
+      resolveNetworkAddress(
         this.settings.sharedProcess.requestedNetworkAddress,
         this.sharedProcess
       ),
     ]).then(([tsh, shared]) => ({ tsh, shared }));
-  }
-
-  private resolveNetworkAddress(
-    requestedAddress: string,
-    process: ChildProcess
-  ): Promise<string> {
-    if (new URL(requestedAddress).protocol === 'unix:') {
-      return Promise.resolve(requestedAddress);
-    }
-
-    // TCP case
-    return new Promise((resolve, reject) => {
-      process.stdout.setEncoding('utf-8');
-      let chunks = '';
-      const timeout = setTimeout(() => {
-        rejectOnError(
-          new Error(
-            `Could not resolve address (${requestedAddress}) for process ${process.spawnfile}. The operation timed out.`
-          )
-        );
-      }, 10_000); // 10s
-
-      const removeListeners = () => {
-        process.stdout.off('data', findAddressInChunk);
-        process.off('error', rejectOnError);
-        clearTimeout(timeout);
-      };
-
-      const findAddressInChunk = (chunk: string) => {
-        chunks += chunk;
-        const matchResult = chunks.match(/\{CONNECT_GRPC_PORT:\s(\d+)}/);
-        if (matchResult) {
-          resolve(`localhost:${matchResult[1]}`);
-          removeListeners();
-        }
-      };
-
-      const rejectOnError = (error: Error) => {
-        reject(error);
-        removeListeners();
-      };
-
-      process.stdout.on('data', findAddressInChunk);
-      process.on('error', rejectOnError);
-    });
   }
 
   private _initIpc() {

--- a/packages/teleterm/src/mainProcess/resolveNetworkAddress.test.ts
+++ b/packages/teleterm/src/mainProcess/resolveNetworkAddress.test.ts
@@ -1,0 +1,103 @@
+import { fork, spawn } from 'child_process';
+import path from 'path';
+
+import { resolveNetworkAddress } from './resolveNetworkAddress';
+
+// Hardcoded in testProcess.js.
+const PORT = '1337';
+
+it('returns an error when supplied an unknown protocol', async () => {
+  const process = fork(path.join(__dirname, 'testProcess.js'), {
+    silent: true,
+  });
+
+  try {
+    const result = resolveNetworkAddress(
+      'unknown-protocol://localhost:1237',
+      process
+    );
+
+    await expect(result).rejects.toThrow('Unknown protocol unknown-protocol');
+  } finally {
+    process.kill();
+  }
+});
+
+const testSuites = [
+  {
+    name: 'UDS',
+    requestedAddress: 'unix:///tmp/test',
+    expectedNetworkAddress: 'unix:///tmp/test',
+  },
+  {
+    name: 'TCP',
+    requestedAddress: 'tcp://localhost:0',
+    expectedNetworkAddress: `localhost:${PORT}`,
+  },
+];
+
+describe.each(testSuites)(
+  'for $name process',
+  ({ requestedAddress, expectedNetworkAddress }) => {
+    it(`waits for the process to output the matching string`, async () => {
+      const process = fork(path.join(__dirname, 'testProcess.js'), {
+        silent: true,
+      });
+
+      try {
+        const actualNetworkAddress = await resolveNetworkAddress(
+          requestedAddress,
+          process
+        );
+
+        expect(actualNetworkAddress).toEqual(expectedNetworkAddress);
+      } finally {
+        process.kill();
+      }
+    });
+
+    it(`times out if the process doesn't return the match in time`, async () => {
+      const process = fork(path.join(__dirname, 'testProcess.js'), ['100'], {
+        silent: true,
+      });
+
+      try {
+        await expect(
+          resolveNetworkAddress(requestedAddress, process, 10)
+        ).rejects.toThrow('operation timed out');
+      } finally {
+        process.kill();
+      }
+    });
+
+    it(`returns an error if the process exits without returning a match`, async () => {
+      const process = fork(
+        path.join(__dirname, 'testProcess.js'),
+        ['10', 'exit-prematurely'],
+        {
+          silent: true,
+        }
+      );
+
+      try {
+        await expect(
+          resolveNetworkAddress(requestedAddress, process)
+        ).rejects.toThrow('the process exited with code 1');
+      } finally {
+        process.kill();
+      }
+    });
+
+    it(`returns an error if the process fails to start`, async () => {
+      const process = spawn(path.join(__dirname, 'testProcess-nonExistent.js'));
+
+      try {
+        await expect(
+          resolveNetworkAddress('tcp://localhost:0', process)
+        ).rejects.toThrow('testProcess-nonExistent.js ENOENT');
+      } finally {
+        process.kill();
+      }
+    });
+  }
+);

--- a/packages/teleterm/src/mainProcess/resolveNetworkAddress.ts
+++ b/packages/teleterm/src/mainProcess/resolveNetworkAddress.ts
@@ -4,7 +4,8 @@ const TCP_PORT_MATCH = /\{CONNECT_GRPC_PORT:\s(\d+)}/;
 
 export async function resolveNetworkAddress(
   requestedAddress: string,
-  process: ChildProcess
+  process: ChildProcess,
+  timeoutMs = 10_000 // 10s
 ): Promise<string> {
   // UDS
   if (new URL(requestedAddress).protocol === 'unix:') {
@@ -15,7 +16,8 @@ export async function resolveNetworkAddress(
   const matchResult = await waitForMatchInStdout(
     TCP_PORT_MATCH,
     requestedAddress,
-    process
+    process,
+    timeoutMs
   );
   return `localhost:${matchResult[1]}`;
 }
@@ -23,7 +25,8 @@ export async function resolveNetworkAddress(
 function waitForMatchInStdout(
   regex: RegExp,
   requestedAddress: string,
-  process: ChildProcess
+  process: ChildProcess,
+  timeoutMs: number
 ): Promise<RegExpMatchArray> {
   return new Promise((resolve, reject) => {
     process.stdout.setEncoding('utf-8');
@@ -35,7 +38,7 @@ function waitForMatchInStdout(
           `Could not resolve address (${requestedAddress}) for process ${process.spawnfile}. The operation timed out.`
         )
       );
-    }, 10_000); // 10s
+    }, timeoutMs);
 
     const removeListeners = () => {
       process.stdout.off('data', findAddressInChunk);

--- a/packages/teleterm/src/mainProcess/resolveNetworkAddress.ts
+++ b/packages/teleterm/src/mainProcess/resolveNetworkAddress.ts
@@ -1,0 +1,63 @@
+import { ChildProcess } from 'child_process';
+
+const TCP_PORT_MATCH = /\{CONNECT_GRPC_PORT:\s(\d+)}/;
+
+export async function resolveNetworkAddress(
+  requestedAddress: string,
+  process: ChildProcess
+): Promise<string> {
+  // UDS
+  if (new URL(requestedAddress).protocol === 'unix:') {
+    return requestedAddress;
+  }
+
+  // TCP
+  const matchResult = await waitForMatchInStdout(
+    TCP_PORT_MATCH,
+    requestedAddress,
+    process
+  );
+  return `localhost:${matchResult[1]}`;
+}
+
+function waitForMatchInStdout(
+  regex: RegExp,
+  requestedAddress: string,
+  process: ChildProcess
+): Promise<RegExpMatchArray> {
+  return new Promise((resolve, reject) => {
+    process.stdout.setEncoding('utf-8');
+    let chunks = '';
+
+    const timeout = setTimeout(() => {
+      rejectOnError(
+        new Error(
+          `Could not resolve address (${requestedAddress}) for process ${process.spawnfile}. The operation timed out.`
+        )
+      );
+    }, 10_000); // 10s
+
+    const removeListeners = () => {
+      process.stdout.off('data', findAddressInChunk);
+      process.off('error', rejectOnError);
+      clearTimeout(timeout);
+    };
+
+    const findAddressInChunk = (chunk: string) => {
+      chunks += chunk;
+      const matchResult = chunks.match(regex);
+      if (matchResult) {
+        resolve(matchResult);
+        removeListeners();
+      }
+    };
+
+    const rejectOnError = (error: Error) => {
+      reject(error);
+      removeListeners();
+    };
+
+    process.stdout.on('data', findAddressInChunk);
+    process.on('error', rejectOnError);
+  });
+}

--- a/packages/teleterm/src/mainProcess/resolveNetworkAddress.ts
+++ b/packages/teleterm/src/mainProcess/resolveNetworkAddress.ts
@@ -1,25 +1,42 @@
 import { ChildProcess } from 'child_process';
 
 const TCP_PORT_MATCH = /\{CONNECT_GRPC_PORT:\s(\d+)}/;
+// Both the shared process and the tshd output the string no matter if TCP or UDS is used as a
+// transport method.
+const UDS_MATCH = /\{CONNECT_GRPC_PORT:/;
 
 export async function resolveNetworkAddress(
   requestedAddress: string,
   process: ChildProcess,
   timeoutMs = 10_000 // 10s
 ): Promise<string> {
-  // UDS
-  if (new URL(requestedAddress).protocol === 'unix:') {
-    return requestedAddress;
-  }
+  const protocol = new URL(requestedAddress).protocol;
 
-  // TCP
-  const matchResult = await waitForMatchInStdout(
-    TCP_PORT_MATCH,
-    requestedAddress,
-    process,
-    timeoutMs
-  );
-  return `localhost:${matchResult[1]}`;
+  switch (protocol) {
+    case 'unix:': {
+      // In case of UDS, we know the address upfront. Still, we wait for the process to emit the
+      // message so that we know the server was started and accepts connections.
+      await waitForMatchInStdout(
+        UDS_MATCH,
+        requestedAddress,
+        process,
+        timeoutMs
+      );
+      return requestedAddress;
+    }
+    case 'tcp:': {
+      const matchResult = await waitForMatchInStdout(
+        TCP_PORT_MATCH,
+        requestedAddress,
+        process,
+        timeoutMs
+      );
+      return `localhost:${matchResult[1]}`;
+    }
+    default: {
+      throw new Error(`Unknown protocol ${protocol}`);
+    }
+  }
 }
 
 function waitForMatchInStdout(

--- a/packages/teleterm/src/mainProcess/testProcess.js
+++ b/packages/teleterm/src/mainProcess/testProcess.js
@@ -1,0 +1,19 @@
+const process = require('process');
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+(async () => {
+  const waitTime = parseInt(process.argv[2]);
+  if (waitTime) {
+    await sleep(waitTime);
+  }
+
+  const shouldExit = process.argv[3];
+  if (shouldExit) {
+    process.exit(1);
+  }
+
+  console.log('Lorem ipsum dolor sit amet');
+  console.log('{CONNECT_GRPC_PORT: 1337}');
+  console.log('Lorem ipsum dolor sit amet');
+})();


### PR DESCRIPTION
Closes gravitational/webapps.e#124.

The problem this PR solves is described here: https://github.com/gravitational/webapps.e/issues/124#issuecomment-1192354642. I also improved the function so that if the child process exits, the function rejects immediately instead of waiting for the timeout.

---

This PR is based on the `gzdunek/add-windows-support` branch because Grzegorz made changes on that branch which massively helped with implementing this solution. As such, the code from this PR needs tsh compiled off `gzdunek/add-windows-support`.

To reproduce the problem on `gzdunek/add-windows-support`, add `time.Sleep(time.Second * 3)` just before `net.Listen` in `lib/teleterm/apiserver/apiserver.go`.