### PR TITLE
Add section to README about audit events

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,11 @@ via `yarn workspace <workspace-name> add <package-name>`, it will create a `pack
 
 When a new event is added to Teleport, the web UI has to be updated to display it correctly:
 
-1. Add a new entry to [`eventCodes`](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/services/audit/types.ts).
-2. Add a new entry to [`RawEvents`](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/services/audit/types.ts) using the event you just created as the key. The fields should match the fields of the metadata fields on `events.proto` on Teleport repository.
-3. Add a new entry in [Formatters](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/services/audit/makeEvent.ts) to format the event on the events table. The `format` function will receive the event you added to `RawEvents` as parameter.
-4. Define an icon to the event on [`EventIconMap`](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/Audit/EventList/EventTypeCell.tsx).
-5. Add an entry to the [`events`](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/Audit/fixtures/index.ts) array so it will show up on the [`AllEvents` story](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/Audit/Audit.story.ts)
+1. Add a new entry to [`eventCodes`](https://github.com/gravitational/webapps/blob/8a0201667f045be7a46606189a6deccdaee2fe1f/packages/teleport/src/services/audit/types.ts).
+2. Add a new entry to [`RawEvents`](https://github.com/gravitational/webapps/blob/8a0201667f045be7a46606189a6deccdaee2fe1f/packages/teleport/src/services/audit/types.ts) using the event you just created as the key. The fields should match the fields of the metadata fields on `events.proto` on Teleport repository.
+3. Add a new entry in [Formatters](https://github.com/gravitational/webapps/blob/8a0201667f045be7a46606189a6deccdaee2fe1f/packages/teleport/src/services/audit/makeEvent.ts) to format the event on the events table. The `format` function will receive the event you added to `RawEvents` as parameter.
+4. Define an icon to the event on [`EventIconMap`](https://github.com/gravitational/webapps/blob/8a0201667f045be7a46606189a6deccdaee2fe1f/packages/teleport/src/Audit/EventList/EventTypeCell.tsx).
+5. Add an entry to the [`events`](https://github.com/gravitational/webapps/blob/8a0201667f045be7a46606189a6deccdaee2fe1f/packages/teleport/src/Audit/fixtures/index.ts) array so it will show up on the [`AllEvents` story](https://github.com/gravitational/webapps/blob/8a0201667f045be7a46606189a6deccdaee2fe1f/packages/teleport/src/Audit/Audit.story.tsx)
 6. Check fixture is rendered in storybook, then update snapshot for `Audit.story.test.tsx`
+
+You can see an example in [this pr](https://github.com/gravitational/webapps/pull/561).

--- a/README.md
+++ b/README.md
@@ -182,3 +182,14 @@ the root of this repository.
 
 Keep in mind that there should only be a single `yarn.lock` in this repository, here at the top level. If you add packages
 via `yarn workspace <workspace-name> add <package-name>`, it will create a `packages/<package-name>/yarn.lock` file, which should not be checked in.
+
+### Adding an Audit Event
+
+When a new event is added to Teleport, the web UI has to be updated to display it correctly:
+
+1. Add a new entry to [`eventCodes`](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/services/audit/types.ts).
+2. Add a new entry to [`RawEvents`](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/services/audit/types.ts) using the event you just created as the key. The fields should match the fields of the metadata fields on `events.proto` on Teleport repository.
+3. Add a new entry in [Formatters](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/services/audit/makeEvent.ts) to format the event on the events table. The `format` function will receive the event you added to `RawEvents` as parameter.
+4. Define an icon to the event on [`EventIconMap`](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/Audit/EventList/EventTypeCell.tsx).
+5. Add an entry to the [`events`](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/Audit/fixtures/index.ts) array so it will show up on the [`AllEvents` story](https://github.com/gravitational/webapps/blob/master/packages/teleport/src/Audit/Audit.story.ts)
+6. Check fixture is rendered in storybook, then update snapshot for `Audit.story.test.tsx`


### PR DESCRIPTION
As stated in https://github.com/gravitational/webapps/pull/970#pullrequestreview-1037970565, adding a new event is very common, but involves many parts that are easy to miss.

This PR adds a new section to the root README on how to add an audit event.