### PR TITLE
enable secure keyboard entry during password and OTP

### DIFF
--- a/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -108,6 +108,14 @@ export default class MainProcess {
       event.returnValue = this.settings;
     });
 
+    ipcMain.on('set-secure-keyboard-entry', (event, enabled) => {
+      const isMac = this.settings.platform === 'darwin';
+      if (isMac) {
+        app.setSecureKeyboardEntryEnabled(enabled);
+        this.logger.info(`Secure keyboard entry: ${enabled}`);
+      }
+    });
+
     subscribeToTerminalContextMenuEvent();
     subscribeToTabContextMenuEvent();
     subscribeToConfigServiceEvents(this.configService);

--- a/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -4,6 +4,7 @@ import { MainProcessClient } from './types';
 import { createConfigServiceClient } from '../services/config';
 import { openTabContextMenu } from './contextMenus/tabContextMenu';
 import { createFileStorageClient } from 'teleterm/services/fileStorage';
+import { setSecureKeyboardEntry } from './secureKeyboardEntry';
 
 export default function createMainProcessClient(): MainProcessClient {
   return {
@@ -14,5 +15,6 @@ export default function createMainProcessClient(): MainProcessClient {
     openTabContextMenu,
     configService: createConfigServiceClient(),
     fileStorage: createFileStorageClient(),
+    setSecureKeyboardEntry,
   };
 }

--- a/packages/teleterm/src/mainProcess/secureKeyboardEntry.ts
+++ b/packages/teleterm/src/mainProcess/secureKeyboardEntry.ts
@@ -1,0 +1,5 @@
+import { ipcRenderer } from 'electron';
+
+export function setSecureKeyboardEntry(enabled): void {
+  return ipcRenderer.send('set-secure-keyboard-entry', enabled);
+}

--- a/packages/teleterm/src/mainProcess/types.ts
+++ b/packages/teleterm/src/mainProcess/types.ts
@@ -27,6 +27,7 @@ export type MainProcessClient = {
   openTabContextMenu(options: TabContextMenuOptions): void;
   configService: ConfigService;
   fileStorage: FileStorage;
+  setSecureKeyboardEntry(boolean): void;
 };
 
 export type Platform = NodeJS.Platform;

--- a/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -38,6 +38,7 @@ export function ClusterLoginPresentation({
   loggedInUserName,
   shouldPromptSsoStatus,
   shouldPromptHardwareKey,
+  setSecureKeyboardEntry,
 }: State) {
   return (
     <>
@@ -68,6 +69,7 @@ export function ClusterLoginPresentation({
             onLogin={onLoginWithLocal}
             onAbort={onAbort}
             loginAttempt={loginAttempt}
+            setSecureKeyboardEntry={setSecureKeyboardEntry}
             shouldPromptSsoStatus={shouldPromptSsoStatus}
             shouldPromptHardwareKey={shouldPromptHardwareKey}
           />

--- a/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
+++ b/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
@@ -46,6 +46,7 @@ export default function LoginForm(props: Props) {
     isLocalAuthEnabled = true,
     shouldPromptSsoStatus,
     shouldPromptHardwareKey,
+    setSecureKeyboardEntry,
   } = props;
 
   const isProcessing = loginAttempt.status === 'processing';
@@ -145,6 +146,8 @@ export default function LoginForm(props: Props) {
                   placeholder="Password"
                   mb={0}
                   width="100%"
+                  onFocus={() => setSecureKeyboardEntry(true)}
+                  onBlur={() => setSecureKeyboardEntry(false)}
                 />
               </Box>
               {auth2faType !== 'off' && (
@@ -176,6 +179,8 @@ export default function LoginForm(props: Props) {
                         onChange={e => setToken(e.target.value)}
                         placeholder="123 456"
                         mb={0}
+                        onFocus={() => setSecureKeyboardEntry(true)}
+                        onBlur={() => setSecureKeyboardEntry(false)}
                       />
                     )}
                   </Flex>
@@ -235,6 +240,7 @@ type Props = {
   auth2faType?: types.Auth2faType;
   authProviders: types.AuthProvider[];
   loggedInUserName?: string;
+  setSecureKeyboardEntry(boolean): void;
   onAbort(): void;
   onLoginWithSso(provider: types.AuthProvider): void;
   onLogin(

--- a/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
+++ b/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
@@ -22,12 +22,13 @@ import { getClusterName } from 'teleterm/ui/utils';
 
 export default function useClusterLogin(props: Props) {
   const { onSuccess, clusterUri } = props;
-  const { clustersService } = useAppContext();
+  const { clustersService, mainProcessClient } = useAppContext();
   const cluster = clustersService.findCluster(clusterUri);
   const refAbortCtrl = useRef<types.tsh.TshAbortController>(null);
   const [shouldPromptSsoStatus, promptSsoStatus] = useState(false);
   const [shouldPromptHardwareKey, promptHardwareKey] = useState(false);
   const loggedInUserName = cluster.loggedInUser?.name || null;
+  const { setSecureKeyboardEntry } = mainProcessClient;
 
   const [initAttempt, init] = useAsync(async () => {
     const authSettings = await clustersService.getAuthSettings(clusterUri);
@@ -109,6 +110,7 @@ export default function useClusterLogin(props: Props) {
     onAbort,
     loginAttempt,
     initAttempt,
+    setSecureKeyboardEntry,
   };
 }
 


### PR DESCRIPTION
Closes: https://github.com/gravitational/teleport-private/issues/155
More info: https://github.com/gravitational/teleport-private/issues/96

Problem: 
We currently do not leverage `secureKeyboardEntry` for mac devices. A quick rundown is, we can have our app 'take over' the keyboard event process to remove the chance for other processes to intercept our input. However, we must be cautious and [use secure keyboard entry fairly](https://developer.apple.com/library/archive/technotes/tn2150/_index.html)

Solution:
I've added a new ipc listener for `set-secure-keyboard-entry` and added a service for it in the `mainProcessClient` and then hooked into it with the `useClusterLogin` hook. We _could_ abstract this to an entire service on its own but, I don't see another time we'd use this functionality outside of cluster login. This is the first time I'm doing any sort of larger 'data flow' type of deal so, please let me know if you'd like this in different files/folders/exports. I don't mind switching it up!

A way to test this is using `ioreg -l -w 0 | grep kCGSSessionSecureInputPID` which will return back empty if no secure keyboard entry is enabled anywhere on the system. To test this outside of Connect,:
1. open a window of `Terminal` on macos 
2. in the top menu, choose `Terminal > Secure Keyboard Entry`. This will enable it for your window and you can again 
3. run `ioreg -l -w 0 | grep kCGSSessionSecureInputPID` and see a result. 
	-- The important key being `"kCGSSessionSecureInputPID"=YOUR_TERMINAL_PID_HERE`
4. Disable secure keyboard entry in the terminal (i forgot this step on accident and boy howdy did it take me too long to figure out what was going on!!).

Similarly, to test inside Connect, follow the steps above, but for step 3, add a `sleep 5 &&` in front of the command and then tab into the Connect password field. You should see your Connect PID is in charge now (and then unfocus the input and try again).