### PR TITLE
Fix the plugins for Connect so React Refresh works

### DIFF
--- a/packages/teleterm/webpack.renderer.dev.config.js
+++ b/packages/teleterm/webpack.renderer.dev.config.js
@@ -28,6 +28,10 @@ devCfg.devServer = {
 };
 
 devCfg.output.publicPath = '';
-devCfg.plugins = [configFactory.plugins.tsChecker(), configFactory.plugins.reactRefresh(), createHtmlPlugin({ isDev: true })];
+devCfg.plugins = [
+  configFactory.plugins.tsChecker(),
+  configFactory.plugins.reactRefresh(),
+  createHtmlPlugin({ isDev: true }),
+];
 
 module.exports = devCfg;

--- a/packages/teleterm/webpack.renderer.dev.config.js
+++ b/packages/teleterm/webpack.renderer.dev.config.js
@@ -28,6 +28,6 @@ devCfg.devServer = {
 };
 
 devCfg.output.publicPath = '';
-devCfg.plugins.push(createHtmlPlugin({ isDev: true }));
+devCfg.plugins = [configFactory.plugins.tsChecker(), configFactory.plugins.reactRefresh(), createHtmlPlugin({ isDev: true })];
 
 module.exports = devCfg;

--- a/packages/teleterm/webpack.renderer.dev.config.js
+++ b/packages/teleterm/webpack.renderer.dev.config.js
@@ -28,10 +28,9 @@ devCfg.devServer = {
 };
 
 devCfg.output.publicPath = '';
-devCfg.plugins = [
+devCfg.plugins.push(
   configFactory.plugins.tsChecker(),
-  configFactory.plugins.reactRefresh(),
-  createHtmlPlugin({ isDev: true }),
-];
+  configFactory.plugins.reactRefresh()
+);
 
 module.exports = devCfg;

--- a/packages/teleterm/webpack.renderer.extend.js
+++ b/packages/teleterm/webpack.renderer.extend.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const resolvepath = require('@gravitational/build/webpack/resolvepath');
 
@@ -13,7 +12,7 @@ function extend(cfg) {
   cfg.output.libraryTarget = 'umd';
   cfg.output.globalObject = 'this';
   cfg.resolve.alias['teleterm'] = path.join(__dirname, './src');
-  cfg.plugins = [new CleanWebpackPlugin(), createHtmlPlugin({ isDev })];
+  cfg.plugins = [createHtmlPlugin({ isDev })];
 
   return cfg;
 }

--- a/packages/teleterm/webpack.renderer.prod.config.js
+++ b/packages/teleterm/webpack.renderer.prod.config.js
@@ -1,5 +1,11 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
 const defaultCfg = require('@gravitational/build/webpack/webpack.prod.config');
 
 const { extend } = require('./webpack.renderer.extend');
 
-module.exports = extend(defaultCfg);
+const prodCfg = extend(defaultCfg);
+
+prodCfg.plugins.unshift(new CleanWebpackPlugin());
+
+module.exports = prodCfg;


### PR DESCRIPTION
@ravicious 

Change this back to overriding the plugins like it did before the latest Webpack changes, but also add `fork-ts-checker-webpack-plugin` (the reason why I had originally changed it to just push `createHtmlPlugin` onto the end, as I didn't realise Connect was overriding the default plugins from the base webpack config)