### PR TITLE
Allow only one instance of Connect

### DIFF
--- a/packages/teleterm/src/main.ts
+++ b/packages/teleterm/src/main.ts
@@ -16,7 +16,7 @@ import { WindowsManager } from 'teleterm/mainProcess/windowsManager';
 if (app.requestSingleInstanceLock()) {
   initializeApp();
 } else {
-  console.log('Attempted to open a second instance of the app.');
+  console.log('Attempted to open a second instance of the app, exiting.');
   // All windows will be closed immediately without asking the user,
   // and the before-quit and will-quit events will not be emitted.
   app.exit(1);

--- a/packages/teleterm/src/main.ts
+++ b/packages/teleterm/src/main.ts
@@ -16,6 +16,7 @@ import { WindowsManager } from 'teleterm/mainProcess/windowsManager';
 if (app.requestSingleInstanceLock()) {
   initializeApp();
 } else {
+  console.log('Attempted to open a second instance of the app.');
   // All windows will be closed immediately without asking the user,
   // and the before-quit and will-quit events will not be emitted.
   app.exit(1);

--- a/packages/teleterm/src/main.ts
+++ b/packages/teleterm/src/main.ts
@@ -13,118 +13,132 @@ import { ConfigServiceImpl } from 'teleterm/services/config';
 import { createFileStorage } from 'teleterm/services/fileStorage';
 import { WindowsManager } from 'teleterm/mainProcess/windowsManager';
 
-const settings = getRuntimeSettings();
-const logger = initMainLogger(settings);
-const fileStorage = createFileStorage({
-  filePath: path.join(settings.userDataDir, 'app_state.json'),
-});
-const configService = new ConfigServiceImpl();
-const windowsManager = new WindowsManager(fileStorage, settings);
+if (app.requestSingleInstanceLock()) {
+  initializeApp();
+} else {
+  // All windows will be closed immediately without asking the user,
+  // and the before-quit and will-quit events will not be emitted.
+  app.exit(1);
+}
 
-process.on('uncaughtException', error => {
-  logger.error('', error);
-  app.quit();
-});
+function initializeApp(): void {
+  const settings = getRuntimeSettings();
+  const logger = initMainLogger(settings);
+  const fileStorage = createFileStorage({
+    filePath: path.join(settings.userDataDir, 'app_state.json'),
+  });
+  const configService = new ConfigServiceImpl();
+  const windowsManager = new WindowsManager(fileStorage, settings);
 
-// init main process
-const mainProcess = MainProcess.create({
-  settings,
-  logger,
-  configService,
-  fileStorage,
-});
-
-app.on(
-  'certificate-error',
-  (event, webContents, url, error, certificate, callback) => {
-    // allow certs errors for localhost:8080
-    if (
-      settings.dev &&
-      new URL(url).host === 'localhost:8080' &&
-      error === 'net::ERR_CERT_AUTHORITY_INVALID'
-    ) {
-      event.preventDefault();
-      callback(true);
-    } else {
-      callback(false);
-      console.error(error);
-    }
-  }
-);
-
-app.on('will-quit', () => {
-  fileStorage.putAllSync();
-  globalShortcut.unregisterAll();
-  mainProcess.dispose();
-});
-
-app.whenReady().then(() => {
-  if (mainProcess.settings.dev) {
-    // allow restarts on F6
-    globalShortcut.register('F6', () => {
-      mainProcess.dispose();
-      const [bin, ...args] = process.argv;
-      const child = spawn(bin, args, {
-        env: process.env,
-        detached: true,
-        stdio: 'inherit',
-      });
-      child.unref();
-      app.quit();
-    });
-  }
-
-  windowsManager.createWindow();
-});
-
-// Limit navigation capabilities to reduce the attack surface.
-// See TEL-Q122-19 from "Teleport Core Testing Q1 2022" security audit.
-//
-// See also points 12, 13 and 14 from the Electron's security tutorial.
-// https://github.com/electron/electron/blob/v17.2.0/docs/tutorial/security.md#12-verify-webview-options-before-creation
-app.on('web-contents-created', (_, contents) => {
-  contents.on('will-navigate', (event, navigationUrl) => {
-    logger.warn(`Navigation to ${navigationUrl} blocked by 'will-navigate'`);
-    event.preventDefault();
+  process.on('uncaughtException', error => {
+    logger.error('', error);
+    app.quit();
   });
 
-  // The usage of webview is blocked by default, but let's include the handler just in case.
-  // https://github.com/electron/electron/blob/v17.2.0/docs/api/webview-tag.md#enabling
-  contents.on('will-attach-webview', (event, _, params) => {
-    logger.warn(
-      `Opening a webview to ${params.src} blocked by 'will-attach-webview'`
-    );
-    event.preventDefault();
+  // init main process
+  const mainProcess = MainProcess.create({
+    settings,
+    logger,
+    configService,
+    fileStorage,
   });
 
-  contents.setWindowOpenHandler(details => {
-    const url = new URL(details.url);
-
-    function isUrlSafe(): boolean {
-      if (url.host === 'goteleport.com') {
-        return true;
-      }
+  app.on(
+    'certificate-error',
+    (event, webContents, url, error, certificate, callback) => {
+      // allow certs errors for localhost:8080
       if (
-        url.host === 'github.com' &&
-        url.pathname.startsWith('/gravitational/')
+        settings.dev &&
+        new URL(url).host === 'localhost:8080' &&
+        error === 'net::ERR_CERT_AUTHORITY_INVALID'
       ) {
-        return true;
+        event.preventDefault();
+        callback(true);
+      } else {
+        callback(false);
+        console.error(error);
       }
     }
+  );
 
-    // Open links to documentation and GitHub issues in the external browser.
-    // They need to have `target` set to `_blank`.
-    if (isUrlSafe()) {
-      shell.openExternal(url.toString());
-    } else {
-      logger.warn(
-        `Opening a new window to ${url} blocked by 'setWindowOpenHandler'`
-      );
+  app.on('will-quit', () => {
+    fileStorage.putAllSync();
+    globalShortcut.unregisterAll();
+    mainProcess.dispose();
+  });
+
+  app.on('second-instance', () => {
+    windowsManager.focusWindow();
+  });
+
+  app.whenReady().then(() => {
+    if (mainProcess.settings.dev) {
+      // allow restarts on F6
+      globalShortcut.register('F6', () => {
+        mainProcess.dispose();
+        const [bin, ...args] = process.argv;
+        const child = spawn(bin, args, {
+          env: process.env,
+          detached: true,
+          stdio: 'inherit',
+        });
+        child.unref();
+        app.quit();
+      });
     }
 
-    return { action: 'deny' };
+    windowsManager.createWindow();
   });
-});
+
+  // Limit navigation capabilities to reduce the attack surface.
+  // See TEL-Q122-19 from "Teleport Core Testing Q1 2022" security audit.
+  //
+  // See also points 12, 13 and 14 from the Electron's security tutorial.
+  // https://github.com/electron/electron/blob/v17.2.0/docs/tutorial/security.md#12-verify-webview-options-before-creation
+  app.on('web-contents-created', (_, contents) => {
+    contents.on('will-navigate', (event, navigationUrl) => {
+      logger.warn(`Navigation to ${navigationUrl} blocked by 'will-navigate'`);
+      event.preventDefault();
+    });
+
+    // The usage of webview is blocked by default, but let's include the handler just in case.
+    // https://github.com/electron/electron/blob/v17.2.0/docs/api/webview-tag.md#enabling
+    contents.on('will-attach-webview', (event, _, params) => {
+      logger.warn(
+        `Opening a webview to ${params.src} blocked by 'will-attach-webview'`
+      );
+      event.preventDefault();
+    });
+
+    contents.setWindowOpenHandler(details => {
+      const url = new URL(details.url);
+
+      function isUrlSafe(): boolean {
+        if (url.host === 'goteleport.com') {
+          return true;
+        }
+        if (
+          url.host === 'github.com' &&
+          url.pathname.startsWith('/gravitational/')
+        ) {
+          return true;
+        }
+      }
+
+      // Open links to documentation and GitHub issues in the external browser.
+      // They need to have `target` set to `_blank`.
+      if (isUrlSafe()) {
+        shell.openExternal(url.toString());
+      } else {
+        logger.warn(
+          `Opening a new window to ${url} blocked by 'setWindowOpenHandler'`
+        );
+      }
+
+      return { action: 'deny' };
+    });
+  });
+}
 
 function initMainLogger(settings: types.RuntimeSettings) {
   const service = createLoggerService({

--- a/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -13,6 +13,7 @@ export class WindowsManager {
   private storageKey = 'windowState';
   private selectionContextMenu: Menu;
   private inputContextMenu: Menu;
+  private window?: BrowserWindow;
 
   constructor(
     private fileStorage: FileStorage,
@@ -74,6 +75,20 @@ export class WindowsManager {
         return callback(false);
       }
     );
+
+    this.window = window;
+  }
+
+  focusWindow(): void {
+    if (!this.window) {
+      return;
+    }
+
+    if (this.window.isMinimized()) {
+      this.window.restore();
+    }
+
+    this.window.focus();
   }
 
   private saveWindowState(window: BrowserWindow): void {


### PR DESCRIPTION
To my surprise, you can open the second instance of the app on Windows (on macOS it is not possible when you run the app from Finder). More information [here](https://www.electronjs.org/docs/latest/api/app#apprequestsingleinstancelockadditionaldata).

I was wondering how to implement it and IMO the best option is to only initialize the app, if we know that it's the first instance. Otherwise, some side effects from main process/file storage/logger/etc can occur.  

This change doesn't mean that we can have only one window in the app - when the `app.on('second-instance')` callback is invoked we can simply open a new window. 
By doing it this way, both windows will talk to the same `main` and `shared` process. 

When you try to open the second instance in development you will see the following message in the terminal (I don't know if we can do any better):
```
Starting inspector on 127.0.0.1:9229 failed: address already in use
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```