### PR TITLE
Add dash to Windows artifact name

### DIFF
--- a/packages/teleterm/package.json
+++ b/packages/teleterm/package.json
@@ -96,6 +96,7 @@
       "target": [
         "nsis"
       ],
+      "artifactName": "${productName} Setup-${version}.${ext}",
       "extraResources": [
         {
           "from": "../../../teleport/build/tsh.exe",


### PR DESCRIPTION
Default `artfictName`: `${productName} Setup ${version}.${ext}`.
By adding a dash, @tcsc won't have to change the Houston filename parser.