### PR TITLE
CI: Fail if an update to yarn.lock is needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,14 @@ COPY README.md packages/webapps.e/telepor[t]/package.json web-apps/packages/weba
 
 # download and install npm dependencies
 WORKDIR web-apps
-RUN yarn install
+# Install JavaScript dependencies and manually check if yarn.lock needs an update.
+# Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
+# https://github.com/yarnpkg/yarn/issues/4098
+RUN sha384sum yarn.lock > yarn-lock-sha \
+  && yarn install \
+  && sha384sum --check yarn-lock-sha || \
+  { echo "yarn.lock needs an update; run yarn install, verify that correct dependencies were installed \
+and commit the updated version of yarn.lock"; exit 1; }
 
 # copy the rest of the files and run yarn build command
 COPY  . .

--- a/yarn.lock
+++ b/yarn.lock
@@ -10412,22 +10412,6 @@ node-gyp@8.4.1:
     tar "^6.1.2"
     which "^2.0.2"
 
-node-gyp@8.4.1:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
-  integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
-  dependencies:
-    env-paths "^2.2.0"
-    glob "^7.1.4"
-    graceful-fs "^4.2.6"
-    make-fetch-happen "^9.1.0"
-    nopt "^5.0.0"
-    npmlog "^6.0.0"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.2"
-    which "^2.0.2"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
Normally we'd use `yarn install --frozen-lockfile` but yarn has a bug where it ignores this flag when workspaces are set up. https://github.com/yarnpkg/yarn/issues/4098

We can't use git as suggested under that issue because Docker isn't inside a git repo at that point.

* [Example of a failed run](https://console.cloud.google.com/cloud-build/builds/1d47366e-0eef-4532-a492-81c03ca51904;step=1?project=ci-account).
* [Example of a successful run](https://console.cloud.google.com/cloud-build/builds/46011d80-e02a-4921-b080-2e38b3de915e;step=2?project=ci-account) – the cache is working as expected.