### PR TITLE
Set TCP protocol explicitly

### DIFF
--- a/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -134,8 +134,8 @@ function requestChildProcessesAddresses(): ChildProcessAddresses {
   switch (process.platform) {
     case 'win32': {
       return {
-        tsh: 'localhost:0',
-        shared: 'localhost:0',
+        tsh: 'tcp://localhost:0',
+        shared: 'tcp://localhost:0',
       };
     }
     case 'linux':

--- a/packages/teleterm/src/sharedProcess/sharedProcess.ts
+++ b/packages/teleterm/src/sharedProcess/sharedProcess.ts
@@ -48,9 +48,12 @@ async function initializeServer(
   // @ts-expect-error we have a typed service
   server.addService(PtyHostService, createPtyHostService());
 
+  // grpc-js requires us to pass localhost:port for TCP connections,
+  const grpcServerAddress = address.replace('tcp://', '');
+
   try {
     server.bindAsync(
-      address,
+      grpcServerAddress,
       (await getServerCredentials(runtimeSettings)).shared,
       (error, port) => {
         sendBoundNetworkPortToStdout(port);


### PR DESCRIPTION
When protocol is not set, `resolveNetworkAddress` fails to match it. 