### PR TITLE
Fix git push

### DIFF
--- a/.github/workflows/update-webassets.yaml
+++ b/.github/workflows/update-webassets.yaml
@@ -45,9 +45,9 @@ jobs:
           cd dist/e
           git add -A
           git commit -m "Update webassets.e from gravitational/webapps@$GITHUB_SHA"
-          git push
+          git push origin HEAD:$GITHUB_REF_NAME
 
           cd ..
           git add -A
           git commit -m "Update webassets from gravitational/webapps@$GITHUB_SHA"
-          git push
+          git push origin HEAD:$GITHUB_REF_NAME


### PR DESCRIPTION
The checkout action leaves the branch in a detached head state.