### PR TITLE
useDocumentGateway: Default to '' rather than '0'

### DIFF
--- a/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
+++ b/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
@@ -30,7 +30,11 @@ export default function useGateway(doc: types.DocumentGateway) {
   // The port to show as default in the input field in case creating a gateway fails.
   // This is typically the case if someone reopens the app and the port of the gateway is already
   // occupied.
-  const defaultPort = doc.port || '0';
+  //
+  // This needs a default value as otherwise React will complain about switching an uncontrolled
+  // input to a controlled one once `doc.port` gets set. The backend will handle converting an empty
+  // string to '0'.
+  const defaultPort = doc.port || '';
   const gateway = ctx.clustersService.findGateway(doc.gatewayUri);
   const connected = !!gateway;
   const rootCluster = ctx.clustersService.findRootClusterByResource(


### PR DESCRIPTION
If '0' is provided as the default and the initial call to create a gateway
fails, the user will be presented with an input that says 0. 0 is an invalid
value though that this input will not accept.

An empty string, on the other hand, is a perfectly valid value (the input
doesn't have the `required` attribute). In that scenario, the backend will
default the value to '0' and pick a random port.