### PR TITLE
yarn.lock: Remove unnecessary @types/google-protobuf entry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ WORKDIR web-apps
 # Install JavaScript dependencies and manually check if yarn.lock needs an update.
 # Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
 # https://github.com/yarnpkg/yarn/issues/4098
-RUN sha384sum yarn.lock > yarn-lock-sha \
+RUN cp yarn.lock yarn-before-install.lock \
   && yarn install \
-  && sha384sum --check yarn-lock-sha || \
+  && git diff --no-index --exit-code yarn-before-install.lock yarn.lock || \
   { echo "yarn.lock needs an update; run yarn install, verify that correct dependencies were installed \
 and commit the updated version of yarn.lock"; exit 1; }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2672,7 +2672,7 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/google-protobuf@^3.10.0", "@types/google-protobuf@^3.7.2":
+"@types/google-protobuf@^3.10.0":
   version "3.15.6"
   resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.6.tgz#674a69493ef2c849b95eafe69167ea59079eb504"
   integrity sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==


### PR DESCRIPTION
If you make a fresh clone of webapps and run yarn, yarn would make this
change to the yarn.lock. This means our script in Dockerfile would fail
as yarn.lock got modified.