### PR TITLE
Use git diff to show the difference after yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ WORKDIR web-apps
 RUN cp yarn.lock yarn-before-install.lock \
   && yarn install \
   && git diff --no-index --exit-code yarn-before-install.lock yarn.lock || \
-  { echo "yarn.lock needs an update; run yarn install, verify that correct dependencies were installed \
-and commit the updated version of yarn.lock"; exit 1; }
+  { echo "yarn.lock needs an update. Run yarn install, verify that correct dependencies were installed \
+and commit the updated version of yarn.lock. Make sure you have the packages/webapps.e submodule \
+cloned first."; exit 1; }
 
 # copy the rest of the files and run yarn build command
 COPY  . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ WORKDIR web-apps
 # Install JavaScript dependencies and manually check if yarn.lock needs an update.
 # Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
 # https://github.com/yarnpkg/yarn/issues/4098
-RUN sha384sum yarn.lock > yarn-lock-sha \
+RUN cp yarn.lock yarn-before-install.lock \
   && yarn install \
-  && sha384sum --check yarn-lock-sha || \
+  && git diff --no-index --exit-code yarn-before-install.lock yarn.lock || \
   { echo "yarn.lock needs an update; run yarn install, verify that correct dependencies were installed \
 and commit the updated version of yarn.lock"; exit 1; }
 


### PR DESCRIPTION
This is better than doing using checksums because you get immediate feedback about what went wrong.

[Example of a failed run](https://console.cloud.google.com/cloud-build/builds;region=global/fc219309-61e5-4796-94aa-407caf06af52;step=1?project=ci-account).