### PR TITLE
Dockerfile: Check yarn.lock only on CI servers

### DIFF
--- a/.cloudbuild/ci/build.yaml
+++ b/.cloudbuild/ci/build.yaml
@@ -21,6 +21,8 @@ steps:
     id: install-deps
     args:
       - build
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .
 
   - name: gcr.io/cloud-builders/docker
@@ -30,6 +32,8 @@ steps:
       - build
       - '--build-arg'
       - NPM_SCRIPT=lint
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .
 
   - name: gcr.io/cloud-builders/docker
@@ -39,6 +43,8 @@ steps:
       - build
       - '--build-arg'
       - NPM_SCRIPT=build-teleport
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .
 
   - name: gcr.io/cloud-builders/docker
@@ -48,4 +54,6 @@ steps:
       - build
       - '--build-arg'
       - NPM_SCRIPT=build-and-package-term
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .

--- a/.cloudbuild/ci/test.yaml
+++ b/.cloudbuild/ci/test.yaml
@@ -20,4 +20,6 @@ steps:
       - build
       - '--build-arg'
       - NPM_SCRIPT=test
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,12 @@ COPY README.md packages/webapps.e/telepor[t]/package.json web-apps/packages/weba
 
 # download and install npm dependencies
 WORKDIR web-apps
-# Install JavaScript dependencies and manually check if yarn.lock needs an update.
-# Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
-# https://github.com/yarnpkg/yarn/issues/4098
-RUN cp yarn.lock yarn-before-install.lock \
-  && yarn install \
-  && git diff --no-index --exit-code yarn-before-install.lock yarn.lock || \
-  { echo "yarn.lock needs an update. Run yarn install, verify that correct dependencies were installed \
-and commit the updated version of yarn.lock. Make sure you have the packages/webapps.e submodule \
-cloned first."; exit 1; }
+ARG YARN_FROZEN_LOCKFILE
+RUN if [ -n "$YARN_FROZEN_LOCKFILE" ]; then \
+      ./packages/build/scripts/yarn-install-frozen-lockfile.sh; \
+    else \
+      yarn install; \
+    fi
 
 # copy the rest of the files and run yarn build command
 COPY  . .

--- a/packages/build/scripts/yarn-install-frozen-lockfile.sh
+++ b/packages/build/scripts/yarn-install-frozen-lockfile.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+# Install JavaScript dependencies and manually check if yarn.lock needs an update.
+# Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
+# https://github.com/yarnpkg/yarn/issues/4098
+
+message="yarn.lock needs an update. Run yarn install, verify that correct dependencies were \
+installed and commit the updated version of yarn.lock. Make sure you have the packages/webapps.e \
+submodule initialized and updated first."
+
+cp yarn.lock yarn-before-install.lock
+yarn install
+git diff --no-index --exit-code yarn-before-install.lock yarn.lock ||
+  { echo "$message" ; exit 1; }


### PR DESCRIPTION
This change makes it so that yarn.lock is checked only on CI servers and not when just running `make build-teleport`.

We advise people in the readme in the teleport repo to clone webapps and run `make build-teleport`. This shouldn't really check yarn.lock and currently fails because yarn outputs different lock depending on whether you have webapps.e cloned or not.

* [Example of a failed run](https://console.cloud.google.com/cloud-build/builds/d8a12af7-d2c5-476a-8258-50c7c2e8d569?project=ci-account).
* [Example of a successful run](https://console.cloud.google.com/cloud-build/builds/0de2b703-653f-4db2-8d3b-6b2df77aefe9;step=2?project=ci-account). Subsequent steps use cache.