### PR TITLE
[v10] Dockerfile: Check yarn.lock only on CI servers (#1076)

### DIFF
--- a/.cloudbuild/ci/build.yaml
+++ b/.cloudbuild/ci/build.yaml
@@ -24,6 +24,8 @@ steps:
       - build
       - '--build-arg'
       - NPM_SCRIPT=type-check-and-lint
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .
 
   - name: gcr.io/cloud-builders/docker
@@ -33,6 +35,8 @@ steps:
       - build
       - '--build-arg'
       - NPM_SCRIPT=build-teleport
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .
 
   - name: gcr.io/cloud-builders/docker
@@ -42,4 +46,6 @@ steps:
       - build
       - '--build-arg'
       - NPM_SCRIPT=build-and-package-term
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .

--- a/.cloudbuild/ci/test.yaml
+++ b/.cloudbuild/ci/test.yaml
@@ -20,4 +20,6 @@ steps:
       - build
       - '--build-arg'
       - NPM_SCRIPT=test
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
       - .

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,12 @@ COPY README.md packages/webapps.e/telepor[t]/package.json web-apps/packages/weba
 
 # download and install npm dependencies
 WORKDIR web-apps
-# Install JavaScript dependencies and manually check if yarn.lock needs an update.
-# Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
-# https://github.com/yarnpkg/yarn/issues/4098
-RUN cp yarn.lock yarn-before-install.lock \
-  && yarn install \
-  && git diff --no-index --exit-code yarn-before-install.lock yarn.lock || \
-  { echo "yarn.lock needs an update. Run yarn install, verify that correct dependencies were installed \
-and commit the updated version of yarn.lock. Make sure you have the packages/webapps.e submodule \
-cloned first."; exit 1; }
+ARG YARN_FROZEN_LOCKFILE
+RUN if [ -n "$YARN_FROZEN_LOCKFILE" ]; then \
+      ./packages/build/scripts/yarn-install-frozen-lockfile.sh; \
+    else \
+      yarn install; \
+    fi
 
 # copy the rest of the files and run yarn build command
 COPY  . .

--- a/packages/build/scripts/yarn-install-frozen-lockfile.sh
+++ b/packages/build/scripts/yarn-install-frozen-lockfile.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+# Install JavaScript dependencies and manually check if yarn.lock needs an update.
+# Yarn v1 doesn't respect the --frozen-lockfile flag when using workspaces.
+# https://github.com/yarnpkg/yarn/issues/4098
+
+message="yarn.lock needs an update. Run yarn install, verify that correct dependencies were \
+installed and commit the updated version of yarn.lock. Make sure you have the packages/webapps.e \
+submodule initialized and updated first."
+
+cp yarn.lock yarn-before-install.lock
+yarn install
+git diff --no-index --exit-code yarn-before-install.lock yarn.lock ||
+  { echo "$message" ; exit 1; }


### PR DESCRIPTION
Backport #1076.

Since the webpack changes weren't merged into teleport-v10 yet, I had a cherry-pick conflict in Dockerfile. The overall changes amounted to just adding that single build arg though.