### PR TITLE
[v10] Remove building native deps from `yarn build-term`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "tdd": "jest --watch",
     "package-term": "yarn workspace @gravitational/teleterm package",
     "build-term": "yarn workspace @gravitational/teleterm build",
+    "build-native-deps-for-term": "yarn workspace @gravitational/teleterm build-native-deps",
     "build-and-package-term": "yarn build-term && yarn package-term",
     "start-term": "yarn workspace @gravitational/teleterm start",
     "start-teleport": "yarn workspace @gravitational/teleport start",

--- a/packages/teleterm/README.md
+++ b/packages/teleterm/README.md
@@ -30,28 +30,34 @@ Prepare Webapps repo
 $ git clone https://github.com/gravitational/webapps.git
 $ cd webapps
 $ yarn install
-$ yarn build-term
-$ yarn package-term
+$ yarn build-and-package-term
 ```
 
 The installable file can be found in `/webapps/packages/teleterm/build/release/`
 
 ### Development
 
-**Make sure to run `yarn build-term` first** (as described above) before attempting to launch the
-app in the development mode. That's because Electron is running its own version of Node. That
-command will fetch native packages that were built for that specific version of Node.
-
-To launch `teleterm` in the development mode:
+**Make sure to run `yarn build-native-deps-for-term` first** before attempting to launch the app in
+development mode. That's because Electron is running its own version of Node. That command will
+fetch or build native packages that were made for that specific version of Node.
 
 ```sh
 $ cd webapps
 
-## TELETERM_TSH_PATH is the environment variable that points to local tsh binary
+$ yarn install
+$ yarn build-native-deps-for-term
+```
+
+To launch `teleterm` in development mode:
+
+```sh
+$ cd webapps
+
+## TELETERM_TSH_PATH has to point to a tsh binary, typically from the teleport repo.
 $ TELETERM_TSH_PATH=$PWD/../teleport/build/tsh yarn start-term
 ```
 
-For quick restarts, that restarts all processes and `tsh` daemon, press `F6`.
+For a quick restart which restarts all processes and the `tsh` daemon, press `F6`.
 
 ### Tips
 

--- a/packages/teleterm/package.json
+++ b/packages/teleterm/package.json
@@ -13,10 +13,10 @@
     "start": "webpack serve --config webpack.renderer.dev.config.js --progress",
     "start-main": "webpack build --config webpack.main.config.js --mode=development --progress --watch",
     "start-electron": "electron build/app/dist/main/main.js",
-    "build": "yarn build-natives && yarn build-main && yarn build-renderer",
+    "build": "yarn build-main && yarn build-renderer",
     "build-main": "webpack build --config webpack.main.config.js --progress --mode=production",
     "build-renderer": "webpack build --config webpack.renderer.prod.config.js --progress",
-    "build-natives": "electron-builder install-app-deps",
+    "build-native-deps": "electron-builder install-app-deps",
     "package": "electron-builder build --publish never -c.extraMetadata.name=teleconnect",
     "generate-grpc-shared": "npx -y --target_arch=x64 --package=grpc_tools_node_protoc_ts@5.3.2 --package=grpc-tools@1.11.2 -- grpc_tools_node_protoc -I=src/sharedProcess/api/proto --ts_out=service=grpc-node,mode=grpc-js:src/sharedProcess/api/protogen --grpc_out=grpc_js:src/sharedProcess/api/protogen --js_out=import_style=commonjs,binary:src/sharedProcess/api/protogen src/sharedProcess/api/proto/*.proto"
   },


### PR DESCRIPTION
Backport #1058