### PR TITLE
Add warning dialog for unsupported browsers for directory sharing

### DIFF
--- a/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
@@ -79,6 +79,9 @@ const props: State = {
     authenticate: () => {},
     setState: () => {},
   },
+  directorySharingBrowserErr: false,
+  setDirectorySharingBrowserErr: () => {},
+  isUsingChrome: true,
 };
 
 export const Processing = () => (

--- a/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -43,6 +43,8 @@ declare global {
 
 export function DesktopSession(props: State) {
   const {
+    directorySharingBrowserErr,
+    setDirectorySharingBrowserErr,
     clipboardState,
     fetchAttempt,
     tdpConnection,
@@ -62,14 +64,11 @@ export function DesktopSession(props: State) {
   // onDialogClose is called when a user
   // dismisses a non-fatal error dialog.
   const onDialogClose = () => {
-    // This setTdpConnection call will cause the useEffect below
-    // to calculate the errorDialog state.
+    // The following state-setting calls will
+    // cause the useEffect below to calculate the
+    // errorDialog state.
+
     setTdpConnection(prevState => {
-      // onDialogClose should only be called when
-      // the user dismisses a non-fatal error dialog,
-      // and prevState.status === '' means non-fatal
-      // error dialog, so the below if statement should
-      // always be true.
       if (prevState.status === '') {
         // If prevState.status was a non-fatal error,
         // we assume that the TDP connection remains open.
@@ -77,6 +76,8 @@ export function DesktopSession(props: State) {
       }
       return prevState;
     });
+
+    setDirectorySharingBrowserErr(false);
   };
 
   const computeErrorDialog = () => {
@@ -100,9 +101,16 @@ export function DesktopSession(props: State) {
       errorText = clipboardState.errorText || 'clipboard sharing failed';
     } else if (unknownConnectionError) {
       errorText = 'Session disconnected for an unknown reason.';
+    } else if (directorySharingBrowserErr) {
+      errorText =
+        'Your user role supports directory sharing over desktop access, \
+      however this feature is only available by default on some chromium \
+      based browsers like Google Chrome or Microsoft Edge. Brave users can \
+      use the feature by navigating to brave://flags/#file-system-access-api \
+      and selecting "Enable". Please switch to a supported browser.';
     }
     const open = errorText !== '';
-    const fatal = tdpConnection.status !== '';
+    const fatal = !(tdpConnection.status === '' || directorySharingBrowserErr);
 
     return { open, text: errorText, fatal };
   };
@@ -197,6 +205,7 @@ function Session(props: PropsWithChildren<State>) {
     canShareDirectory,
     isSharingDirectory,
     setIsSharingDirectory,
+    setDirectorySharingBrowserErr,
     onPngFrame,
     onClipboardData,
     onTdpError,
@@ -229,16 +238,20 @@ function Session(props: PropsWithChildren<State>) {
     clipboardSuccess;
 
   const onShareDirectory = () => {
-    window
-      .showDirectoryPicker()
-      .then(sharedDirHandle => {
-        setIsSharingDirectory(true);
-        tdpClient.addSharedDirectory(sharedDirHandle);
-        tdpClient.sendSharedDirectoryAnnounce();
-      })
-      .catch(() => {
-        setIsSharingDirectory(false);
-      });
+    try {
+      window
+        .showDirectoryPicker()
+        .then(sharedDirHandle => {
+          setIsSharingDirectory(true);
+          tdpClient.addSharedDirectory(sharedDirHandle);
+          tdpClient.sendSharedDirectoryAnnounce();
+        })
+        .catch(() => {
+          setIsSharingDirectory(false);
+        });
+    } catch (e) {
+      setDirectorySharingBrowserErr(true);
+    }
   };
 
   return (

--- a/packages/teleport/src/DesktopSession/useDesktopSession.tsx
+++ b/packages/teleport/src/DesktopSession/useDesktopSession.tsx
@@ -47,6 +47,8 @@ export default function useDesktopSession() {
 
   const [canShareDirectory, setCanShareDirectory] = useState(false);
   const [isSharingDirectory, setIsSharingDirectory] = useState(false);
+  const [directorySharingBrowserErr, setDirectorySharingBrowserErr] =
+    useState(false);
 
   const { username, desktopName, clusterId } = useParams<UrlDesktopParams>();
 
@@ -155,7 +157,10 @@ export default function useDesktopSession() {
     setClipboardState,
     canShareDirectory,
     isSharingDirectory,
+    directorySharingBrowserErr,
+    setDirectorySharingBrowserErr,
     setIsSharingDirectory,
+    isUsingChrome,
     fetchAttempt,
     tdpConnection,
     wsConnection,


### PR DESCRIPTION
Adds logic for popping up a non-fatal dialog when the user attempts to initiate directory sharing on an unsupported browser.

Requires backport to v9/v10

## How to test manually

#### `webapps`
1. Change the value below to `true` https://github.com/gravitational/webapps/blob/becfad38776a68e0d8be634476f24cead7890ffc/packages/teleport/src/config.ts#L32
2. run the development server like `yarn start-teleport --target=https://ec2-35-171-27-185.compute-1.amazonaws.com/`
3. See https://gravitational.slack.com/archives/C02DQ1C2BMW/p1657807702085829 for a username/password combo


## What to expect
**Due to an arbitrary choice in the ordering of a particular if-else-if statement, you must be logged in as a user with clipboard access disabled to test this change manually**

From a browser which doesn't support the File Access API (Safari/FF):

Go to the top right `...` menu and click `Share Directory`

<img width="420" alt="image" src="https://user-images.githubusercontent.com/13578537/179849344-7a614aed-3c45-4c86-896b-f67a1f870168.png">

You should see a non-fatal warning dialog

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/13578537/184470757-6de5daa9-7c7c-4731-b5d7-32ea3ff47805.png">