### PR TITLE
Add support for Connect builds with Touch ID

### DIFF
--- a/packages/teleterm/README.md
+++ b/packages/teleterm/README.md
@@ -19,7 +19,7 @@ or
 /Applications/Teleport\ Connect.app/Contents/MacOS/Teleport\ Connect --insecure
 ```
 
-## Building and Packaging
+## Building and packaging
 
 Teleport Connect consists of two main components: the `tsh` tool and the Electron app. Our build
 scripts assume that the `webapps` repo and the `teleport` repo are in the same folder.
@@ -53,6 +53,9 @@ $ yarn build-and-package-term
 
 The installable file can be found in `/webapps/packages/teleterm/build/release/`
 
+For more details on how Connect is built for different platform, see the [Build
+process](#build-process) section.
+
 ## Development
 
 **Make sure to run `yarn build-native-deps-for-term` first** before attempting to launch the app in
@@ -71,13 +74,11 @@ To launch `teleterm` in development mode:
 ```sh
 $ cd webapps
 
-## TELETERM_TSH_PATH has to point to a tsh binary, typically from the teleport repo.
-$ TELETERM_TSH_PATH=$PWD/../teleport/build/tsh yarn start-term
+## CONNECT_TSH_BIN_PATH has to point to a tsh binary, typically from the teleport repo.
+$ CONNECT_TSH_BIN_PATH=$PWD/../teleport/build/tsh yarn start-term
 ```
 
 For a quick restart which restarts all processes and the `tsh` daemon, press `F6`.
-
-## Tips
 
 ### Generating tshd gRPC protobuf files
 
@@ -120,6 +121,66 @@ $ rm -rf ./packages/teleterm/src/services/tshd/v1/ && cp -R ../teleport/lib/tele
 Run `generate-grpc-shared` script from `teleterm/package.json`.
 It generates protobuf files from `*.proto` files in `sharedProcess/api/proto`.
 Resulting files can be found in `sharedProcess/api/protogen`.
+
+## Build process
+
+`yarn package-term` is ran as a part of `yarn build-and-package-term` and is responsible for
+packaging the app code for distribution.
+
+On all platforms, with the exception of production builds on macOS, the `CONNECT_TSH_BIN_PATH` env
+var is used to provide the path to the tsh binary that will be included in the package.
+
+See [Teleport Connect build
+process](https://gravitational.slab.com/posts/teleport-connect-build-process-fu6da5ld) on Slab for
+bulid process documentation that is specific to Gravitational.
+
+### macOS
+
+To make a fully-fledged build on macOS with Touch ID support, you need two things:
+
+* a signed version of tsh.app
+* an Apple Developer ID certificate in your Keychain
+
+When running `yarn build-and-package-term`, you need to provide three environment variables:
+
+* `APPLE_USERNAME`
+* `APPLE_PASSWORD`
+* `CONNECT_TSH_APP_PATH`
+* `CSC_NAME` (optional)
+
+The details behind those vars are described below.
+
+#### tsh.app
+
+Unlike other platforms, macOS needs the whole tsh.app to be bundled with Connect, not just the tsh
+binary. This is in order to support Touch ID and provide access to the same Secure Enclave keys.
+That is, if you add Touch ID as MFA through tsh, we want tsh.app bundled with Connect to have access
+to the same keys.
+
+Since Connect piggybacks on tsh for authn, this amounts to just copying a signed & notarized version
+of tsh.app into `Teleport Connect.app/Contents/MacOS`. All interactions with Secure Enclave are done
+through tsh at the moment, so Connect doesn't need to do anything extra, other than skipping signing
+of tsh.app during the build process (as we expect it to be already signed).
+
+The path to a signed version of tsh.app should be provided through the `CONNECT_TSH_APP_PATH` env
+variable.
+
+#### Signing & notarizing
+
+Signing & notarizing is required if the application is supposed to be ran on devices other than the
+one that packaged it. See [electron-builder's docs](https://www.electron.build/code-signing) for a
+general overview and [Teleport Connect build
+process](https://gravitational.slab.com/posts/teleport-connect-build-process-fu6da5ld) Slab page for
+Gravitational-specific nuances.
+
+For the most part, the device that's doing the signing & notarizing needs to have access to an Apple
+Developer ID (certificate + private key). electron-builder should automatically discover it if
+Keychain is unlocked. The `CSC_NAME` env var can be additionally provided to point electron-builder
+towards the specific Dev ID we want to use if multiple are available. `CSC_NAME` can either be SHA-1
+of the cert or its name.
+
+On top of that, you must provide the credentials to the account associated with the Apple Dev ID
+through the `APPLE_USERNAME` & `APPLE_PASSWORD` env vars.
 
 ## Architecture
 

--- a/packages/teleterm/electron-builder-config.js
+++ b/packages/teleterm/electron-builder-config.js
@@ -1,3 +1,23 @@
+const { env, platform } = require('process');
+
+const isMac = platform === 'darwin';
+
+// The following checks make no sense when cross-building because they check the platform of the
+// host and not the platform we're building for.
+//
+// However, at the moment we don't cross-build Connect and these checks protect us from undesired
+// behavior.
+if (
+  isMac &&
+  Boolean(env.CONNECT_TSH_APP_PATH) === Boolean(env.CONNECT_TSH_BIN_PATH)
+) {
+  throw new Error(
+    'You must provide CONNECT_TSH_APP_PATH xor CONNECT_TSH_BIN_PATH'
+  );
+} else if (!env.CONNECT_TSH_BIN_PATH) {
+  throw new Error('You must provide CONNECT_TSH_BIN_PATH');
+}
+
 /**
  * @type { import('electron-builder').Configuration }
  */
@@ -13,13 +33,28 @@ module.exports = {
     type: 'distribution',
     hardenedRuntime: true,
     gatekeeperAssess: false,
+    // If CONNECT_TSH_APP_PATH is provided, we assume that tsh.app is already signed.
+    signIgnore: env.CONNECT_TSH_APP_PATH && ['tsh.app'],
     icon: 'assets/icon-mac.png',
-    extraResources: [
-      {
-        from: '../../../teleport/build/tsh',
-        to: './bin/tsh',
+    // On macOS, helper apps (such as tsh.app) should be under Contents/MacOS, hence using
+    // `extraFiles` instead of `extraResources`.
+    // https://developer.apple.com/documentation/bundleresources/placing_content_in_a_bundle
+    // https://developer.apple.com/forums/thread/128166
+    extraFiles: [
+      // CONNECT_TSH_APP_PATH is for environments where we want to copy over the whole signed
+      // version of tsh.app for Touch ID support.
+      env.CONNECT_TSH_APP_PATH && {
+        from: env.CONNECT_TSH_APP_PATH,
+        to: './MacOS/tsh.app',
       },
-    ],
+      // CONNECT_TSH_BIN_PATH is for environments where we just need a regular tsh binary. We still
+      // copy it to the same location that it would be at in a real tsh.app to avoid conditional
+      // logic elsewhere.
+      env.CONNECT_TSH_BIN_PATH && {
+        from: env.CONNECT_TSH_BIN_PATH,
+        to: './MacOS/tsh.app/Contents/MacOS/tsh',
+      },
+    ].filter(Boolean),
   },
   dmg: {
     contents: [
@@ -40,22 +75,22 @@ module.exports = {
     artifactName: '${productName} Setup-${version}.${ext}',
     icon: 'assets/icon-win.ico',
     extraResources: [
-      {
-        from: '../../../teleport/build/tsh.exe',
+      env.CONNECT_TSH_BIN_PATH && {
+        from: env.CONNECT_TSH_BIN_PATH,
         to: './bin/tsh.exe',
       },
-    ],
+    ].filter(Boolean),
   },
   linux: {
     target: ['deb'],
     category: 'Development',
     icon: 'assets/icon-linux',
     extraResources: [
-      {
-        from: '../../../teleport/build/tsh',
+      env.CONNECT_TSH_BIN_PATH && {
+        from: env.CONNECT_TSH_BIN_PATH,
         to: './bin/tsh',
       },
-    ],
+    ].filter(Boolean),
   },
   directories: {
     buildResources: 'assets',

--- a/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -14,7 +14,7 @@ const RESOURCES_PATH = app.isPackaged
   ? process.resourcesPath
   : path.join(__dirname, '../../../../');
 
-const TSH_BIN_ENV_VAR = 'TELETERM_TSH_PATH';
+const TSH_BIN_ENV_VAR = 'CONNECT_TSH_BIN_PATH';
 
 const dev = env.NODE_ENV === 'development' || env.DEBUG_PROD === 'true';
 
@@ -86,11 +86,19 @@ function getTshHomeDir() {
 // tshBinPath is used by Connect to call tsh directly.
 function getBinaryPaths(): { binDir?: string; tshBinPath: string } {
   if (app.isPackaged) {
-    const binDir = path.join(RESOURCES_PATH, 'bin');
-    const tshBinPath = path.join(
-      binDir,
-      process.platform === 'win32' ? 'tsh.exe' : 'tsh'
-    );
+    const isWin = process.platform === 'win32';
+    const isMac = process.platform === 'darwin';
+    // On macOS, tsh lives within tsh.app:
+    //
+    //     Teleport Connect.app/Contents/MacOS/tsh.app/Contents/MacOS
+    //
+    // exe path is an absolute path to
+    //
+    //     Teleport Connect.app/Contents/MacOS/Teleport Connect
+    const binDir = isMac
+      ? path.join(app.getPath('exe'), '../tsh.app/Contents/MacOS')
+      : path.join(RESOURCES_PATH, 'bin');
+    const tshBinPath = path.join(binDir, isWin ? 'tsh.exe' : 'tsh');
 
     return { binDir, tshBinPath };
   }


### PR DESCRIPTION
This PR adds the capability to support Touch ID in Connect builds.

I still need to update some scripts in this repo and in teleport so that we actually pass correct env vars everywhere. But this is the extent of the changes that need to be made in Connect itself.

Please also take a look at the [Teleport Connect build process](https://gravitational.slab.com/posts/teleport-connect-build-process-fu6da5ld) Slab page that the readme is linking too.