### PR TITLE
[Discover] Prompt the user on pressing the back button during Discover

### DIFF
--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -20,6 +20,8 @@ import { Flex, Text, Box, Indicator } from 'design';
 import { Danger } from 'design/Alert';
 import * as Icons from 'design/Icon';
 
+import { Prompt } from 'react-router-dom';
+
 import useTeleport from 'teleport/useTeleport';
 import getFeatures from 'teleport/features';
 import { UserMenuNav } from 'teleport/components/UserMenuNav';
@@ -72,6 +74,10 @@ export function Discover({
 
   return (
     <MainContainer>
+      <Prompt
+        message="Are you sure you want to exit the “Add New Resource” workflow? You’ll have to start from the beginning next time."
+        when={currentStep > 0}
+      />
       {initAttempt.status === 'processing' && (
         <main.StyledIndicator>
           <Indicator />

--- a/packages/teleport/src/Discover/DownloadScript/DownloadScript.story.tsx
+++ b/packages/teleport/src/Discover/DownloadScript/DownloadScript.story.tsx
@@ -16,6 +16,8 @@
 
 import React from 'react';
 
+import { MemoryRouter } from 'react-router';
+
 import { DownloadScript } from './DownloadScript';
 import { State } from './useDownloadScript';
 
@@ -23,25 +25,37 @@ export default {
   title: 'Teleport/Discover/DownloadScript',
 };
 
-export const Polling = () => <DownloadScript {...props} />;
+export const Polling = () => (
+  <MemoryRouter>
+    <DownloadScript {...props} />
+  </MemoryRouter>
+);
 
 export const PollingSuccess = () => (
-  <DownloadScript {...props} pollState="success" />
+  <MemoryRouter>
+    <DownloadScript {...props} pollState="success" />
+  </MemoryRouter>
 );
 
 export const PollingError = () => (
-  <DownloadScript {...props} pollState="error" />
+  <MemoryRouter>
+    <DownloadScript {...props} pollState="error" />
+  </MemoryRouter>
 );
 
 export const Processing = () => (
-  <DownloadScript {...props} attempt={{ status: 'processing' }} />
+  <MemoryRouter>
+    <DownloadScript {...props} attempt={{ status: 'processing' }} />
+  </MemoryRouter>
 );
 
 export const Failed = () => (
-  <DownloadScript
-    {...props}
-    attempt={{ status: 'failed', statusText: 'some error message' }}
-  />
+  <MemoryRouter>
+    <DownloadScript
+      {...props}
+      attempt={{ status: 'failed', statusText: 'some error message' }}
+    />
+  </MemoryRouter>
 );
 
 const props: State = {

--- a/packages/teleport/src/Discover/DownloadScript/__snapshots__/DownloadScript.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/DownloadScript/__snapshots__/DownloadScript.story.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`polling error state 1`] = `
   text-transform: uppercase;
   transition: all 0.3s;
   -webkit-font-smoothing: antialiased;
-  background: #222C59;
+  background: #512FC9;
   color: rgba(255,255,255,0.87);
   min-height: 32px;
   font-size: 12px;
@@ -235,7 +235,11 @@ exports[`polling error state 1`] = `
 
 .c15:hover,
 .c15:focus {
-  background: #2C3A73;
+  background: #651FFF;
+}
+
+.c15:active {
+  background: #354AA4;
 }
 
 .c15:disabled {
@@ -395,13 +399,16 @@ exports[`polling error state 1`] = `
     >
       Next
     </button>
-    <button
+    <a
       class="c15"
-      kind="secondary"
+      href="/web"
+      kind="primary"
+      mt="3"
+      theme="[object Object]"
       width="165px"
     >
       Exit
-    </button>
+    </a>
   </div>
 </div>
 `;
@@ -530,7 +537,7 @@ exports[`polling state 1`] = `
   text-transform: uppercase;
   transition: all 0.3s;
   -webkit-font-smoothing: antialiased;
-  background: #222C59;
+  background: #512FC9;
   color: rgba(255,255,255,0.87);
   min-height: 32px;
   font-size: 12px;
@@ -545,7 +552,11 @@ exports[`polling state 1`] = `
 
 .c13:hover,
 .c13:focus {
-  background: #2C3A73;
+  background: #651FFF;
+}
+
+.c13:active {
+  background: #354AA4;
 }
 
 .c13:disabled {
@@ -692,13 +703,16 @@ exports[`polling state 1`] = `
     >
       Next
     </button>
-    <button
+    <a
       class="c13"
-      kind="secondary"
+      href="/web"
+      kind="primary"
+      mt="3"
+      theme="[object Object]"
       width="165px"
     >
       Exit
-    </button>
+    </a>
   </div>
 </div>
 `;
@@ -827,7 +841,7 @@ exports[`polling success state 1`] = `
   text-transform: uppercase;
   transition: all 0.3s;
   -webkit-font-smoothing: antialiased;
-  background: #222C59;
+  background: #512FC9;
   color: rgba(255,255,255,0.87);
   min-height: 32px;
   font-size: 12px;
@@ -842,7 +856,11 @@ exports[`polling success state 1`] = `
 
 .c13:hover,
 .c13:focus {
-  background: #2C3A73;
+  background: #651FFF;
+}
+
+.c13:active {
+  background: #354AA4;
 }
 
 .c13:disabled {
@@ -986,13 +1004,16 @@ exports[`polling success state 1`] = `
     >
       Next
     </button>
-    <button
+    <a
       class="c13"
-      kind="secondary"
+      href="/web"
+      kind="primary"
+      mt="3"
+      theme="[object Object]"
       width="165px"
     >
       Exit
-    </button>
+    </a>
   </div>
 </div>
 `;

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
@@ -18,34 +18,49 @@ import React from 'react';
 
 import { LoginTrait } from './LoginTrait';
 import { State } from './useLoginTrait';
+import { MemoryRouter } from 'react-router';
 
 export default {
   title: 'Teleport/Discover/LoginTrait',
 };
 
-export const LoadedWithStatic = () => <LoginTrait {...props} />;
+export const LoadedWithStatic = () => (
+  <MemoryRouter>
+    <LoginTrait {...props} />
+  </MemoryRouter>
+);
 
 export const LoadedWithoutStatic = () => (
-  <LoginTrait {...props} staticLogins={[]} />
+  <MemoryRouter>
+    <LoginTrait {...props} staticLogins={[]} />
+  </MemoryRouter>
 );
 
 export const EmptyWithStatic = () => (
-  <LoginTrait {...props} dynamicLogins={[]} />
+  <MemoryRouter>
+    <LoginTrait {...props} dynamicLogins={[]} />
+  </MemoryRouter>
 );
 
 export const EmptyWithoutStatic = () => (
-  <LoginTrait {...props} dynamicLogins={[]} staticLogins={[]} />
+  <MemoryRouter>
+    <LoginTrait {...props} dynamicLogins={[]} staticLogins={[]} />
+  </MemoryRouter>
 );
 
 export const Processing = () => (
-  <LoginTrait {...props} attempt={{ status: 'processing' }} />
+  <MemoryRouter>
+    <LoginTrait {...props} attempt={{ status: 'processing' }} />
+  </MemoryRouter>
 );
 
 export const Failed = () => (
-  <LoginTrait
-    {...props}
-    attempt={{ status: 'failed', statusText: 'some error message' }}
-  />
+  <MemoryRouter>
+    <LoginTrait
+      {...props}
+      attempt={{ status: 'failed', statusText: 'some error message' }}
+    />
+  </MemoryRouter>
 );
 
 const props: State = {

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
@@ -16,9 +16,10 @@
 
 import React from 'react';
 
+import { MemoryRouter } from 'react-router';
+
 import { LoginTrait } from './LoginTrait';
 import { State } from './useLoginTrait';
-import { MemoryRouter } from 'react-router';
 
 export default {
   title: 'Teleport/Discover/LoginTrait',

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
@@ -26,6 +26,7 @@ import LoginTrait from './LoginTrait';
 import type { User } from 'teleport/services/user';
 import type { RenderResult } from '@testing-library/react';
 import type { NodeMeta } from '../useDiscover';
+import { MemoryRouter } from 'react-router';
 
 describe('login trait comp behavior', () => {
   const ctx = new TeleportContext();
@@ -35,18 +36,20 @@ describe('login trait comp behavior', () => {
 
   beforeEach(() => {
     Component = (
-      <ContextProvider ctx={ctx}>
-        <LoginTrait
-          // TODO we don't need all of this
-          attempt={null}
-          joinToken={null}
-          createJoinToken={null}
-          agentMeta={mockedNodeMeta}
-          updateAgentMeta={null}
-          nextStep={null}
-          prevStep={null}
-        />
-      </ContextProvider>
+      <MemoryRouter>
+        <ContextProvider ctx={ctx}>
+          <LoginTrait
+            // TODO we don't need all of this
+            attempt={null}
+            joinToken={null}
+            createJoinToken={null}
+            agentMeta={mockedNodeMeta}
+            updateAgentMeta={null}
+            nextStep={null}
+            prevStep={null}
+          />
+        </ContextProvider>
+      </MemoryRouter>
     );
   });
 

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
@@ -18,6 +18,8 @@ import React from 'react';
 
 import { render, screen, act, fireEvent } from 'design/utils/testing';
 
+import { MemoryRouter } from 'react-router';
+
 import TeleportContext from 'teleport/teleportContext';
 import ContextProvider from 'teleport/TeleportContextProvider';
 
@@ -26,7 +28,6 @@ import LoginTrait from './LoginTrait';
 import type { User } from 'teleport/services/user';
 import type { RenderResult } from '@testing-library/react';
 import type { NodeMeta } from '../useDiscover';
-import { MemoryRouter } from 'react-router';
 
 describe('login trait comp behavior', () => {
   const ctx = new TeleportContext();

--- a/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`empty state 1`] = `
   text-transform: uppercase;
   transition: all 0.3s;
   -webkit-font-smoothing: antialiased;
-  background: #222C59;
+  background: #512FC9;
   color: rgba(255,255,255,0.87);
   min-height: 32px;
   font-size: 12px;
@@ -138,7 +138,11 @@ exports[`empty state 1`] = `
 
 .c12:hover,
 .c12:focus {
-  background: #2C3A73;
+  background: #651FFF;
+}
+
+.c12:active {
+  background: #354AA4;
 }
 
 .c12:disabled {
@@ -255,13 +259,16 @@ exports[`empty state 1`] = `
     >
       Next
     </button>
-    <button
+    <a
       class="c12"
-      kind="secondary"
+      href="/web"
+      kind="primary"
+      mt="3"
+      theme="[object Object]"
       width="165px"
     >
       Exit
-    </button>
+    </a>
   </div>
 </div>
 `;
@@ -389,7 +396,7 @@ exports[`empty state with static logins 1`] = `
   text-transform: uppercase;
   transition: all 0.3s;
   -webkit-font-smoothing: antialiased;
-  background: #222C59;
+  background: #512FC9;
   color: rgba(255,255,255,0.87);
   min-height: 32px;
   font-size: 12px;
@@ -404,7 +411,11 @@ exports[`empty state with static logins 1`] = `
 
 .c13:hover,
 .c13:focus {
-  background: #2C3A73;
+  background: #651FFF;
+}
+
+.c13:active {
+  background: #354AA4;
 }
 
 .c13:disabled {
@@ -551,13 +562,16 @@ exports[`empty state with static logins 1`] = `
     >
       Next
     </button>
-    <button
+    <a
       class="c13"
-      kind="secondary"
+      href="/web"
+      kind="primary"
+      mt="3"
+      theme="[object Object]"
       width="165px"
     >
       Exit
-    </button>
+    </a>
   </div>
 </div>
 `;
@@ -738,7 +752,7 @@ exports[`loaded with static state 1`] = `
   text-transform: uppercase;
   transition: all 0.3s;
   -webkit-font-smoothing: antialiased;
-  background: #222C59;
+  background: #512FC9;
   color: rgba(255,255,255,0.87);
   min-height: 32px;
   font-size: 12px;
@@ -753,7 +767,11 @@ exports[`loaded with static state 1`] = `
 
 .c13:hover,
 .c13:focus {
-  background: #2C3A73;
+  background: #651FFF;
+}
+
+.c13:active {
+  background: #354AA4;
 }
 
 .c13:disabled {
@@ -948,13 +966,16 @@ exports[`loaded with static state 1`] = `
     >
       Next
     </button>
-    <button
+    <a
       class="c13"
-      kind="secondary"
+      href="/web"
+      kind="primary"
+      mt="3"
+      theme="[object Object]"
       width="165px"
     >
       Exit
-    </button>
+    </a>
   </div>
 </div>
 `;

--- a/packages/teleport/src/Discover/Shared.tsx
+++ b/packages/teleport/src/Discover/Shared.tsx
@@ -45,7 +45,6 @@ export const ActionButtons = ({
   disableProceed?: boolean;
   lastStep?: boolean;
 }) => {
-  const [confirmExit, setConfirmExit] = React.useState(false);
   return (
     <Box mt={4}>
       {proceedHref && (
@@ -71,46 +70,12 @@ export const ActionButtons = ({
           {lastStep ? 'Finish' : 'Next'}
         </ButtonPrimary>
       )}
-      <ButtonSecondary
-        mt={3}
-        width="165px"
-        onClick={() => setConfirmExit(true)}
-      >
+      <ButtonPrimary as={NavLink} to={cfg.routes.root} mt={3} width="165px">
         Exit
-      </ButtonSecondary>
-      {confirmExit && (
-        <ConfirmExitDialog onClose={() => setConfirmExit(false)} />
-      )}
+      </ButtonPrimary>
     </Box>
   );
 };
-
-function ConfirmExitDialog({ onClose }: { onClose(): void }) {
-  return (
-    <Dialog
-      dialogCss={() => ({ maxWidth: '600px' })}
-      disableEscapeKeyDown={false}
-      onClose={onClose}
-      open={true}
-    >
-      <DialogHeader>
-        <DialogTitle>Exit Resource Connection</DialogTitle>
-      </DialogHeader>
-      <DialogContent minWidth="500px" flex="0 0 auto">
-        <Text mb={2}>
-          Are you sure you want to exit the “Add New Resource” workflow? You’ll
-          have to start from the beginning next time.
-        </Text>
-      </DialogContent>
-      <DialogFooter>
-        <ButtonPrimary mr="3" as={NavLink} to={cfg.routes.root} size="medium">
-          Exit
-        </ButtonPrimary>
-        <ButtonSecondary onClick={onClose}>Stay</ButtonSecondary>
-      </DialogFooter>
-    </Dialog>
-  );
-}
 
 export const TextIcon = styled(Text)`
   display: flex;


### PR DESCRIPTION
If the user clicks exit, or presses the back button, this will ask the user to confirm that they want to navigate away -

![image](https://user-images.githubusercontent.com/7922109/185244864-6bb35d4e-61b2-4bcd-bb1e-e1d0ce422c58.png)

Note - this doesn't include refresh, as we're not sure if it is needed and it's a different looking confirm dialog (you can't change this one) -

<img width="278" alt="image" src="https://user-images.githubusercontent.com/7922109/185245376-040fba40-dc05-4e9b-9ccc-cc3bbe294c67.png">

We had to remove the exit confirm dialog UI, otherwise we'd end up in a double confirmation situation when the user clicks exit -

![image](https://user-images.githubusercontent.com/7922109/185245038-04547e95-4358-4762-a5f3-1bd149a63393.png)

It is possible to get around this in the future - with a bit of rework to where the exit dialog open state is, we can disable the prompt when the exit dialog is open.

For now, we just have the one UI when a user tries to navigate away. If we put the exit confirmation dialog UI back in, that'll be two UIs, and if we add the reload, that's three different UIs. Not sure if we care that much about these confirmation dialogs looking different.

This will implement #1120.