### PR TITLE
Ignore `*.story.tsx` when type checking during Webpack builds

### DIFF
--- a/packages/build/webpack/webpack.base.js
+++ b/packages/build/webpack/webpack.base.js
@@ -35,6 +35,9 @@ const configFactory = {
         typescript: {
           configFile: tsconfigPath,
         },
+        issue: {
+          exclude: [{ file: '**/*.story.tsx' }],
+        },
       });
     },
     indexHtml(options) {


### PR DESCRIPTION
Exclude `**/*.story.tsx` from the issues that `fork-ts-checker-webpack-plugin` reports, so any type errors in a story won't block the app from loading.