### PR TITLE
Turn on directory sharing by default 

### DIFF
--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -31,8 +31,6 @@ import { RecordingType } from 'teleport/services/recordings';
 import generateResourcePath from './generateResourcePath';
 
 const cfg = {
-  // TODO(isaiah): remove after feature is finished.
-  enableDirectorySharing: false, // note to reviewers: should be false in any PRs.
   isEnterprise: false,
   isCloud: false,
   tunnelPublicAddress: '',

--- a/packages/teleport/src/services/user/makeAcl.ts
+++ b/packages/teleport/src/services/user/makeAcl.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import cfg from 'teleport/config';
-
 import { Acl } from './types';
 
 export default function makeAcl(json): Acl {
@@ -49,8 +47,7 @@ export default function makeAcl(json): Acl {
   // Behaves like clipboardSharingEnabled, see
   // https://github.com/gravitational/teleport/pull/12684#issue-1237830087
   const directorySharingEnabled =
-    (json.directorySharing !== undefined ? json.directorySharing : true) &&
-    cfg.enableDirectorySharing;
+    json.directorySharing !== undefined ? json.directorySharing : true;
 
   const nodes = json.nodes || defaultAccess;
 

--- a/packages/teleport/src/services/user/user.test.ts
+++ b/packages/teleport/src/services/user/user.test.ts
@@ -165,7 +165,7 @@ test('undefined values in context response gives proper default values', async (
         remove: false,
       },
       desktopSessionRecordingEnabled: true,
-      directorySharingEnabled: false,
+      directorySharingEnabled: true,
     },
     cluster: {
       clusterId: 'aws',


### PR DESCRIPTION
Removes `enableDirectorySharing` flag to turn on directory sharing by default

corresponds with https://github.com/gravitational/teleport/pull/15789

requires backport to v10