### PR TITLE
Change `tar.gz` artifact name

### DIFF
--- a/packages/teleterm/electron-builder-config.js
+++ b/packages/teleterm/electron-builder-config.js
@@ -46,8 +46,15 @@ module.exports = {
       },
     ],
   },
+  rpm: {
+    artifactName: '${name}-${version}.${arch}.${ext}',
+  },
+  deb: {
+    artifactName: '${name}-${version}_${arch}.${ext}',
+  },
   linux: {
     target: ['tar.gz', 'rpm', 'deb'],
+    artifactName: '${name}-${version}-${arch}.${ext}', //tar.gz
     category: 'Development',
     icon: 'assets/icon-linux',
     extraResources: [


### PR DESCRIPTION
It adds the architecture  to the `tar.gz` artifact name: 
`teleport-connect-11.0.0.tar.gz` -> `teleport-connect-1.0.2-x64.tar.gz`.

I had to specify `artifactName` also for `rpm` and `deb`, otherwise they will be overridden by the name from `linux`.