### PR TITLE
Add default value for CONNECT_TSH_BIN_PATH in dev mode

### DIFF
--- a/packages/teleterm/README.md
+++ b/packages/teleterm/README.md
@@ -48,7 +48,7 @@ Prepare Webapps repo
 $ git clone https://github.com/gravitational/webapps.git
 $ cd webapps
 $ yarn install
-$ yarn build-and-package-term
+$ CONNECT_TSH_BIN_PATH=$PWD/../teleport/build/tsh yarn build-and-package-term
 ```
 
 The installable file can be found in `/webapps/packages/teleterm/build/release/`

--- a/packages/teleterm/README.md
+++ b/packages/teleterm/README.md
@@ -74,7 +74,10 @@ To launch `teleterm` in development mode:
 ```sh
 $ cd webapps
 
-## CONNECT_TSH_BIN_PATH has to point to a tsh binary, typically from the teleport repo.
+$ yarn start-term
+
+## By default, the dev version assumes that the tsh binary is at ../teleport/build/tsh.
+## You can provide a different absolute path to a tsh binary though the CONNECT_TSH_BIN_PATH env var.
 $ CONNECT_TSH_BIN_PATH=$PWD/../teleport/build/tsh yarn start-term
 ```
 


### PR DESCRIPTION
#1116 changes `TELETERM_TSH_PATH` to `CONNECT_TSH_BIN_PATH` and this PR adds a default value for `CONNECT_TSH_BIN_PATH` in dev mode.