### PR TITLE
[v10] Update GitHub connector template

### DIFF
--- a/packages/teleport/src/AuthConnectors/templates/github.yaml
+++ b/packages/teleport/src/AuthConnectors/templates/github.yaml
@@ -13,9 +13,9 @@ spec:
   # connector display name that will be appended to the title of "Login with"
   # button on the cluster login screen so it will say "Login with Github"
   display: Github
-  # mapping of Github team memberships to Teleport cluster roles
-  teams_to_logins:
+  # mapping of Github team memberships to Teleport roles
+  teams_to_roles:
     - organization: <github-org>
       team: <github-team>
-      logins:
+      roles:
         - "access"


### PR DESCRIPTION
We deprecated teams_to_logins in favor of teams_to_roles in v10.
Starting with v11, teams_to_logins will no longer be accepted.

Backports #1157