### PR TITLE
[v10] Add unsafe-eval to CSP in dev mode to make source maps work

### DIFF
--- a/packages/teleterm/webpack.renderer.dev.config.js
+++ b/packages/teleterm/webpack.renderer.dev.config.js
@@ -28,6 +28,6 @@ devCfg.devServer = {
 };
 
 devCfg.output.publicPath = '';
-devCfg.plugins.push(createHtmlPlugin());
+devCfg.plugins.push(createHtmlPlugin({ isDev: true }));
 
 module.exports = devCfg;

--- a/packages/teleterm/webpack.renderer.dev.config.js
+++ b/packages/teleterm/webpack.renderer.dev.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 const defaultCfg = require('@gravitational/build/webpack/webpack.dev.config');
 const configFactory = require('@gravitational/build/webpack/webpack.base');
 
-const { extend, createHtmlPlugin } = require('./webpack.renderer.extend');
+const { extend } = require('./webpack.renderer.extend');
 const devCfg = extend(defaultCfg);
 
 devCfg.devServer = {

--- a/packages/teleterm/webpack.renderer.dev.config.js
+++ b/packages/teleterm/webpack.renderer.dev.config.js
@@ -28,6 +28,9 @@ devCfg.devServer = {
 };
 
 devCfg.output.publicPath = '';
-devCfg.plugins.push(createHtmlPlugin({ isDev: true }));
+devCfg.plugins.push(
+  configFactory.plugins.tsChecker(),
+  configFactory.plugins.reactRefresh()
+);
 
 module.exports = devCfg;

--- a/packages/teleterm/webpack.renderer.extend.js
+++ b/packages/teleterm/webpack.renderer.extend.js
@@ -5,18 +5,22 @@ const HtmlWebPackPlugin = require('html-webpack-plugin');
 const resolvepath = require('@gravitational/build/webpack/resolvepath');
 
 function extend(cfg) {
+  const isDev = cfg.mode === 'development';
+
   cfg.entry = { app: ['./src/ui/boot'] };
   cfg.output.publicPath = 'auto';
   cfg.output.path = resolvepath('build/app/dist/renderer');
   cfg.output.libraryTarget = 'umd';
   cfg.output.globalObject = 'this';
   cfg.resolve.alias['teleterm'] = path.join(__dirname, './src');
-  cfg.plugins = [new CleanWebpackPlugin(), createHtmlPlugin()];
+  cfg.plugins = [new CleanWebpackPlugin(), createHtmlPlugin({ isDev })];
 
   return cfg;
 }
 
-function createHtmlPlugin() {
+function createHtmlPlugin({ isDev }) {
+  const csp = getCsp({ isDev });
+
   return new HtmlWebPackPlugin({
     filename: 'index.html',
     title: '',
@@ -29,13 +33,33 @@ function createHtmlPlugin() {
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="referrer" content="no-referrer" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod https://usage.teleport.dev; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; object-src 'none'; font-src 'self' data:">
+        <meta http-equiv="Content-Security-Policy" content="${csp}">
       </head>
       <body>
         <div id="app"></div>
       </body>
     </html>`,
   });
+}
+
+function getCsp({ isDev }) {
+  let csp = `
+default-src 'self';
+connect-src 'self' https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod https://usage.teleport.dev;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+object-src 'none';
+font-src 'self' data:;
+`
+    .replaceAll('\n', ' ')
+    .trim();
+
+  if (isDev) {
+    // Required to make source maps work in dev mode.
+    csp += " script-src 'self' 'unsafe-eval';";
+  }
+
+  return csp;
 }
 
 module.exports = {

--- a/packages/teleterm/webpack.renderer.extend.js
+++ b/packages/teleterm/webpack.renderer.extend.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const resolvepath = require('@gravitational/build/webpack/resolvepath');
 
@@ -13,7 +12,7 @@ function extend(cfg) {
   cfg.output.libraryTarget = 'umd';
   cfg.output.globalObject = 'this';
   cfg.resolve.alias['teleterm'] = path.join(__dirname, './src');
-  cfg.plugins = [new CleanWebpackPlugin(), createHtmlPlugin({ isDev })];
+  cfg.plugins = [createHtmlPlugin({ isDev })];
 
   return cfg;
 }

--- a/packages/teleterm/webpack.renderer.prod.config.js
+++ b/packages/teleterm/webpack.renderer.prod.config.js
@@ -1,5 +1,11 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
 const defaultCfg = require('@gravitational/build/webpack/webpack.prod.config');
 
 const { extend } = require('./webpack.renderer.extend');
 
-module.exports = extend(defaultCfg);
+const prodCfg = extend(defaultCfg);
+
+prodCfg.plugins.unshift(new CleanWebpackPlugin());
+
+module.exports = prodCfg;


### PR DESCRIPTION
Backport #1031 & #1032.

I forgot to backport this so dev mode in v10 wasn't really working but it looks like no one ran into that problem yet.