### PR TITLE
[Discover] User menu checkmark, alert bubble, tweaks

### DIFF
--- a/packages/teleport/src/Discover/DownloadScript/__snapshots__/DownloadScript.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/DownloadScript/__snapshots__/DownloadScript.story.test.tsx.snap
@@ -1,29 +1,151 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`failed 1`] = `
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 2px;
-  box-sizing: border-box;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.24);
-  margin: 0 0 24px 0;
-  min-height: 40px;
-  padding: 8px 16px;
-  overflow: auto;
-  word-break: break-word;
-  line-height: 1.5;
-  background: #f50057;
-  color: #FFFFFF;
-}
-
-.c3 a {
-  color: #FFFFFF;
-}
-
 .c0 {
   box-sizing: border-box;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: none;
+  text-transform: none;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-left: 8px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: none;
+  text-decoration: underline;
+}
+
+.c7:disabled {
+  background: none;
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c10:active {
+  opacity: 0.56;
+}
+
+.c10:hover,
+.c10:focus {
+  background: #651FFF;
+}
+
+.c10:active {
+  background: #354AA4;
+}
+
+.c10:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c11 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c11:active {
+  opacity: 0.56;
+}
+
+.c11:hover,
+.c11:focus {
+  background: #2C3A73;
+}
+
+.c11:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c6 {
+  display: inline-block;
+  transition: color 0.3s;
+  margin-left: 4px;
+  color: #f50057;
 }
 
 .c1 {
@@ -41,6 +163,45 @@ exports[`failed 1`] = `
   text-overflow: ellipsis;
   margin: 0px;
   margin-bottom: 32px;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+}
+
+.c5 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 16px;
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.c5 .icon {
+  margin-right: 8px;
+}
+
+.c8 {
+  color: #03a9f4;
+  font-weight: normal;
+  padding-left: 0;
+  font-size: inherit;
+  min-height: auto;
+}
+
+.c3 {
+  box-sizing: border-box;
+  padding: 16px;
+  height: auto;
+  border-radius: 8px;
+  max-width: 800px;
+  background-color: rgba(255,255,255,0.05);
+  border: 2px solid #f50057;
 }
 
 <div
@@ -61,9 +222,52 @@ exports[`failed 1`] = `
   </div>
   <div
     class="c3"
-    kind="danger"
+    height="auto"
   >
-    some error message
+    <div
+      class="c4"
+    >
+      Command
+    </div>
+    <div
+      class="c5"
+    >
+      <span
+        class="c6 icon icon-warning "
+        color="danger"
+      />
+      Encountered Error: 
+      some error message
+    </div>
+    <button
+      class="c7 c8"
+      kind="text"
+    >
+      Refetch a command
+    </button>
+  </div>
+  <div
+    class="c9"
+  >
+    
+    <button
+      class="c10"
+      disabled=""
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c11"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
   </div>
 </div>
 `;
@@ -152,7 +356,7 @@ exports[`polling error state 1`] = `
   min-height: 32px;
   font-size: 12px;
   padding: 0px 24px;
-  margin-left: 8px;
+  margin-left: 4px;
 }
 
 .c11:active {
@@ -327,21 +531,22 @@ exports[`polling error state 1`] = `
   margin-right: 8px;
 }
 
+.c12 {
+  color: #03a9f4;
+  font-weight: normal;
+  padding-left: 0;
+  font-size: inherit;
+  min-height: auto;
+}
+
 .c3 {
   box-sizing: border-box;
   padding: 16px;
+  height: auto;
   border-radius: 8px;
   max-width: 800px;
   background-color: rgba(255,255,255,0.05);
   border: 2px solid #f50057;
-}
-
-.c12 {
-  color: #03a9f4;
-  font-weight: normal;
-  padding-left: 2px;
-  font-size: inherit;
-  min-height: auto;
 }
 
 .c14 {
@@ -367,6 +572,7 @@ exports[`polling error state 1`] = `
   </div>
   <div
     class="c3"
+    height="auto"
   >
     <div
       class="c4"
@@ -660,6 +866,7 @@ exports[`polling state 1`] = `
 .c3 {
   box-sizing: border-box;
   padding: 16px;
+  height: auto;
   border-radius: 8px;
   max-width: 800px;
   background-color: rgba(255,255,255,0.05);
@@ -697,6 +904,7 @@ exports[`polling state 1`] = `
   </div>
   <div
     class="c3"
+    height="auto"
   >
     <div
       class="c4"
@@ -975,6 +1183,7 @@ exports[`polling success state 1`] = `
 .c3 {
   box-sizing: border-box;
   padding: 16px;
+  height: auto;
   border-radius: 8px;
   max-width: 800px;
   background-color: rgba(255,255,255,0.05);
@@ -999,6 +1208,7 @@ exports[`polling success state 1`] = `
   </div>
   <div
     class="c3"
+    height="auto"
   >
     <div
       class="c4"

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
@@ -77,4 +77,5 @@ const props: State = {
   staticLogins: ['ubunutu', 'debian'],
   nextStep: () => null,
   addLogin: () => null,
+  fetchLoginTraits: () => null,
 };

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.tsx
@@ -108,29 +108,31 @@ export function LoginTrait({
             )}
             {/* static logins cannot be modified */}
             {staticLogins.map((login, index) => {
+              const id = `${login}${index}`;
               return (
                 <CheckboxWrapper key={index} className="disabled">
                   <CheckboxInput
                     type="checkbox"
-                    name={login}
-                    id={login}
+                    name={id}
+                    id={id}
                     defaultChecked
                   />
-                  <Label htmlFor={login}>{login}</Label>
+                  <Label htmlFor={id}>{login}</Label>
                 </CheckboxWrapper>
               );
             })}
             {dynamicLogins.map((login, index) => {
+              const id = `${login}${index}`;
               return (
                 <CheckboxWrapper key={index}>
                   <CheckboxInput
                     type="checkbox"
-                    name={login}
-                    id={login}
+                    name={id}
+                    id={id}
                     ref={el => (inputRefs.current[index] = el)}
                     defaultChecked
                   />
-                  <Label htmlFor={login}>{login}</Label>
+                  <Label htmlFor={id}>{login}</Label>
                 </CheckboxWrapper>
               );
             })}

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.tsx
@@ -19,18 +19,22 @@ import styled from 'styled-components';
 import {
   Flex,
   ButtonPrimary,
-  ButtonText,
   Text,
   Box,
   Indicator,
   Input,
+  ButtonText,
 } from 'design';
-import { Danger } from 'design/Alert';
 import * as Icons from 'design/Icon';
 
 import useTeleport from 'teleport/useTeleport';
 
-import { Header, HeaderSubtitle, ActionButtons } from '../Shared';
+import {
+  Header,
+  HeaderSubtitle,
+  ActionButtons,
+  ButtonBlueText,
+} from '../Shared';
 
 import { useLoginTrait, State } from './useLoginTrait';
 
@@ -49,6 +53,7 @@ export function LoginTrait({
   dynamicLogins,
   staticLogins,
   addLogin,
+  fetchLoginTraits,
 }: State) {
   const inputRefs = useRef<HTMLInputElement[]>([]);
   const [newLogin, setNewLogin] = useState('');
@@ -76,12 +81,22 @@ export function LoginTrait({
   let $content;
   switch (attempt.status) {
     case 'failed':
-      $content = <Danger>{attempt.statusText}</Danger>;
+      $content = (
+        <>
+          <Text my={3}>
+            <Icons.Warning ml={1} mr={2} color="danger" />
+            Encountered Error: {attempt.statusText}
+          </Text>
+          <ButtonBlueText ml={1} onClick={fetchLoginTraits}>
+            Refetch OS Users
+          </ButtonBlueText>
+        </>
+      );
       break;
 
     case 'processing':
       $content = (
-        <Box textAlign="center" m={10}>
+        <Box mt={4} textAlign="center" height="70px" width="300px">
           <Indicator />
         </Box>
       );
@@ -90,75 +105,82 @@ export function LoginTrait({
     case 'success':
       $content = (
         <>
-          <Text bold mb={2}>
-            Select OS Users
-          </Text>
-          <Box mb={6}>
-            {!hasLogins && (
-              <CheckboxWrapper>
-                <Text
-                  css={`
-                    font-style: italic;
-                    overflow: visible;
-                  `}
-                >
-                  No OS users added
-                </Text>
+          {!hasLogins && (
+            <CheckboxWrapper>
+              <Text
+                css={`
+                  font-style: italic;
+                  overflow: visible;
+                `}
+              >
+                No OS users added
+              </Text>
+            </CheckboxWrapper>
+          )}
+          {/* static logins cannot be modified */}
+          {staticLogins.map((login, index) => {
+            const id = `${login}${index}`;
+            return (
+              <CheckboxWrapper key={index} className="disabled">
+                <CheckboxInput
+                  type="checkbox"
+                  name={id}
+                  id={id}
+                  defaultChecked
+                />
+                <Label htmlFor={id}>{login}</Label>
               </CheckboxWrapper>
-            )}
-            {/* static logins cannot be modified */}
-            {staticLogins.map((login, index) => {
-              const id = `${login}${index}`;
-              return (
-                <CheckboxWrapper key={index} className="disabled">
-                  <CheckboxInput
-                    type="checkbox"
-                    name={id}
-                    id={id}
-                    defaultChecked
-                  />
-                  <Label htmlFor={id}>{login}</Label>
-                </CheckboxWrapper>
-              );
-            })}
-            {dynamicLogins.map((login, index) => {
-              const id = `${login}${index}`;
-              return (
-                <CheckboxWrapper key={index}>
-                  <CheckboxInput
-                    type="checkbox"
-                    name={id}
-                    id={id}
-                    ref={el => (inputRefs.current[index] = el)}
-                    defaultChecked
-                  />
-                  <Label htmlFor={id}>{login}</Label>
-                </CheckboxWrapper>
-              );
-            })}
-            {showInputBox ? (
-              <AddLoginInput
-                newLogin={newLogin}
-                addLogin={onAddLogin}
-                setNewLogin={setNewLogin}
-              />
-            ) : (
-              <AddLoginButton setShowInputBox={setShowInputBox} />
-            )}
-          </Box>
-          <ActionButtons onProceed={onProceed} disableProceed={!hasLogins} />
+            );
+          })}
+          {dynamicLogins.map((login, index) => {
+            const id = `${login}${index}`;
+            return (
+              <CheckboxWrapper key={index}>
+                <CheckboxInput
+                  type="checkbox"
+                  name={id}
+                  id={id}
+                  ref={el => (inputRefs.current[index] = el)}
+                  defaultChecked
+                />
+                <Label htmlFor={id}>{login}</Label>
+              </CheckboxWrapper>
+            );
+          })}
+          {showInputBox ? (
+            <AddLoginInput
+              newLogin={newLogin}
+              addLogin={onAddLogin}
+              setNewLogin={setNewLogin}
+            />
+          ) : (
+            <AddLoginButton setShowInputBox={setShowInputBox} />
+          )}
         </>
       );
       break;
   }
 
   return (
-    <Box>
+    <Box maxWidth="700px">
       <Header>Set Up Access</Header>
       <HeaderSubtitle>
         Select the OS users you will use to connect to server.
       </HeaderSubtitle>
-      {$content}
+      <>
+        <Text bold mb={2}>
+          Select OS Users
+        </Text>
+        <Box mb={3}>{$content}</Box>
+        <ActionButtons
+          onProceed={onProceed}
+          disableProceed={
+            attempt.status === 'failed' ||
+            attempt.status === 'processing' ||
+            !hasLogins
+          }
+        />
+      </>
     </Box>
   );
 }

--- a/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
@@ -3,11 +3,12 @@
 exports[`empty state 1`] = `
 .c0 {
   box-sizing: border-box;
+  max-width: 700px;
 }
 
 .c4 {
   box-sizing: border-box;
-  margin-bottom: 40px;
+  margin-bottom: 16px;
 }
 
 .c11 {
@@ -286,11 +287,12 @@ exports[`empty state 1`] = `
 exports[`empty state with static logins 1`] = `
 .c0 {
   box-sizing: border-box;
+  max-width: 700px;
 }
 
 .c4 {
   box-sizing: border-box;
-  margin-bottom: 40px;
+  margin-bottom: 16px;
 }
 
 .c12 {
@@ -533,13 +535,13 @@ exports[`empty state with static logins 1`] = `
       <input
         checked=""
         class="c6"
-        id="ubunutu"
-        name="ubunutu"
+        id="ubunutu0"
+        name="ubunutu0"
         type="checkbox"
       />
       <label
         class="c7"
-        for="ubunutu"
+        for="ubunutu0"
       >
         ubunutu
       </label>
@@ -550,13 +552,13 @@ exports[`empty state with static logins 1`] = `
       <input
         checked=""
         class="c6"
-        id="debian"
-        name="debian"
+        id="debian1"
+        name="debian1"
         type="checkbox"
       />
       <label
         class="c7"
-        for="debian"
+        for="debian1"
       >
         debian
       </label>
@@ -598,29 +600,158 @@ exports[`empty state with static logins 1`] = `
 `;
 
 exports[`failed 1`] = `
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 2px;
-  box-sizing: border-box;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.24);
-  margin: 0 0 24px 0;
-  min-height: 40px;
-  padding: 8px 16px;
-  overflow: auto;
-  word-break: break-word;
-  line-height: 1.5;
-  background: #f50057;
-  color: #FFFFFF;
-}
-
-.c3 a {
-  color: #FFFFFF;
-}
-
 .c0 {
   box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: none;
+  text-transform: none;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-left: 4px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: none;
+  text-decoration: underline;
+}
+
+.c7:disabled {
+  background: none;
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c10:active {
+  opacity: 0.56;
+}
+
+.c10:hover,
+.c10:focus {
+  background: #651FFF;
+}
+
+.c10:active {
+  background: #354AA4;
+}
+
+.c10:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c11 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c11:active {
+  opacity: 0.56;
+}
+
+.c11:hover,
+.c11:focus {
+  background: #2C3A73;
+}
+
+.c11:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c6 {
+  display: inline-block;
+  transition: color 0.3s;
+  margin-left: 4px;
+  margin-right: 8px;
+  color: #f50057;
 }
 
 .c1 {
@@ -640,6 +771,30 @@ exports[`failed 1`] = `
   margin-bottom: 32px;
 }
 
+.c3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  margin: 0px;
+  margin-bottom: 8px;
+}
+
+.c5 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c8 {
+  color: #03a9f4;
+  font-weight: normal;
+  padding-left: 0;
+  font-size: inherit;
+  min-height: auto;
+}
+
 <div
   class="c0"
 >
@@ -656,9 +811,51 @@ exports[`failed 1`] = `
   </div>
   <div
     class="c3"
-    kind="danger"
   >
-    some error message
+    Select OS Users
+  </div>
+  <div
+    class="c4"
+  >
+    <div
+      class="c5"
+    >
+      <span
+        class="c6 icon icon-warning "
+        color="danger"
+      />
+      Encountered Error: 
+      some error message
+    </div>
+    <button
+      class="c7 c8"
+      kind="text"
+    >
+      Refetch OS Users
+    </button>
+  </div>
+  <div
+    class="c9"
+  >
+    
+    <button
+      class="c10"
+      disabled=""
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c11"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
   </div>
 </div>
 `;
@@ -666,11 +863,12 @@ exports[`failed 1`] = `
 exports[`loaded with static state 1`] = `
 .c0 {
   box-sizing: border-box;
+  max-width: 700px;
 }
 
 .c4 {
   box-sizing: border-box;
-  margin-bottom: 40px;
+  margin-bottom: 16px;
 }
 
 .c12 {
@@ -913,13 +1111,13 @@ exports[`loaded with static state 1`] = `
       <input
         checked=""
         class="c6"
-        id="ubunutu"
-        name="ubunutu"
+        id="ubunutu0"
+        name="ubunutu0"
         type="checkbox"
       />
       <label
         class="c7"
-        for="ubunutu"
+        for="ubunutu0"
       >
         ubunutu
       </label>
@@ -930,13 +1128,13 @@ exports[`loaded with static state 1`] = `
       <input
         checked=""
         class="c6"
-        id="debian"
-        name="debian"
+        id="debian1"
+        name="debian1"
         type="checkbox"
       />
       <label
         class="c7"
-        for="debian"
+        for="debian1"
       >
         debian
       </label>
@@ -947,13 +1145,13 @@ exports[`loaded with static state 1`] = `
       <input
         checked=""
         class="c6"
-        id="root"
-        name="root"
+        id="root0"
+        name="root0"
         type="checkbox"
       />
       <label
         class="c7"
-        for="root"
+        for="root0"
       >
         root
       </label>
@@ -964,13 +1162,13 @@ exports[`loaded with static state 1`] = `
       <input
         checked=""
         class="c6"
-        id="llama"
-        name="llama"
+        id="llama1"
+        name="llama1"
         type="checkbox"
       />
       <label
         class="c7"
-        for="llama"
+        for="llama1"
       >
         llama
       </label>
@@ -981,13 +1179,13 @@ exports[`loaded with static state 1`] = `
       <input
         checked=""
         class="c6"
-        id="george_washington_really_long_name_testing"
-        name="george_washington_really_long_name_testing"
+        id="george_washington_really_long_name_testing2"
+        name="george_washington_really_long_name_testing2"
         type="checkbox"
       />
       <label
         class="c7"
-        for="george_washington_really_long_name_testing"
+        for="george_washington_really_long_name_testing2"
       >
         george_washington_really_long_name_testing
       </label>

--- a/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
+++ b/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
@@ -30,6 +30,10 @@ export function useLoginTrait({ ctx, props }: Props) {
   const [dynamicLogins, setDynamicLogins] = useState<string[]>([]);
 
   useEffect(() => {
+    fetchLoginTraits();
+  }, []);
+
+  function fetchLoginTraits() {
     run(() =>
       ctx.userService.fetchUser(ctx.storeUser.getUsername()).then(user => {
         setUser(user);
@@ -46,7 +50,7 @@ export function useLoginTrait({ ctx, props }: Props) {
         setDynamicLogins(userDefinedLogins);
       })
     );
-  }, []);
+  }
 
   async function nextStep(logins: string[]) {
     // Currently, fetching user for user traits does not
@@ -86,6 +90,7 @@ export function useLoginTrait({ ctx, props }: Props) {
     dynamicLogins,
     staticLogins,
     addLogin,
+    fetchLoginTraits,
   };
 }
 

--- a/packages/teleport/src/Discover/Shared.tsx
+++ b/packages/teleport/src/Discover/Shared.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { NavLink } from 'react-router-dom';
 
-import { Text, ButtonPrimary, Box } from 'design';
+import { Text, ButtonPrimary, Box, ButtonText } from 'design';
 import { ButtonSecondary } from 'design/Button';
 
 import cfg from 'teleport/config';
@@ -91,4 +91,12 @@ export const TextBox = styled(Box)`
   border-radius: 8px;
   background-color: ${p => p.theme.colors.primary.light};
   padding: 24px;
+`;
+
+export const ButtonBlueText = styled(ButtonText)`
+  color: ${({ theme }) => theme.colors.link};
+  font-weight: normal;
+  padding-left: 0;
+  font-size: inherit;
+  min-height: auto;
 `;

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.story.tsx
@@ -54,7 +54,8 @@ export const LoadedWithDiagnosisFailure = () => {
         id: '',
         traceType: 'some trace type',
         status: 'failed',
-        details: 'Some failed detail.',
+        details:
+          'Invalid user. Please ensure the principal "debian" is a valid Linux login in the target node. Output from Node: Failed to launch: user: unknown user debian.',
         error: 'ssh: handshake failed: EOF',
       } as ConnectionDiagnosticTrace,
     ],

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.story.tsx
@@ -82,37 +82,31 @@ const mockDiagnosis = {
   message: 'some diagnosis message',
   traces: [
     {
-      id: '',
       traceType: 'rbac node',
       status: 'success',
       details: 'Resource exists.',
     },
     {
-      id: '',
       traceType: 'network connectivity',
       status: 'success',
       details: 'Host is alive and reachable.',
     },
     {
-      id: '',
       traceType: 'rbac principal',
       status: 'success',
       details: 'Successfully authenticated.',
     },
     {
-      id: '',
       traceType: 'node ssh server',
       status: 'success',
       details: 'Established an SSH connection.',
     },
     {
-      id: '',
       traceType: 'node ssh session',
       status: 'success',
       details: 'Created an SSH session.',
     },
     {
-      id: '',
       traceType: 'node principal',
       status: 'success',
       details: 'User exists message.',

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
@@ -132,9 +132,20 @@ export function TestConnection({
                       </>
                     );
                   }
+                  if (t.status === 'success') {
+                    return (
+                      <TextIcon>
+                        <Icons.CircleCheck mr={1} color="success" />
+                        {t.details}
+                      </TextIcon>
+                    );
+                  }
+
+                  // For whatever reason the status is not the value
+                  // of failed or success.
                   return (
                     <TextIcon>
-                      <Icons.CircleCheck mr={1} color="success" />
+                      <Icons.Question mr={1} />
                       {t.details}
                     </TextIcon>
                   );

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
@@ -120,23 +120,23 @@ export function TestConnection({
               `Failed to Start Testing: ${attempt.statusText}`}
             {attempt.status === 'success' && (
               <Box>
-                {diagnosis.traces.map(t => {
-                  if (t.status === 'failed') {
+                {diagnosis.traces.map((trace, index) => {
+                  if (trace.status === 'failed') {
                     return (
-                      <>
+                      <React.Fragment key={index}>
                         <TextIcon>
                           <Icons.Warning mr={1} color="danger" />
-                          {t.details}
+                          {trace.details}
                         </TextIcon>
-                        <Box mt={2}>{t.error}</Box>
-                      </>
+                        <Box mt={2}>{trace.error}</Box>
+                      </React.Fragment>
                     );
                   }
-                  if (t.status === 'success') {
+                  if (trace.status === 'success') {
                     return (
-                      <TextIcon>
+                      <TextIcon key={index}>
                         <Icons.CircleCheck mr={1} color="success" />
-                        {t.details}
+                        {trace.details}
                       </TextIcon>
                     );
                   }
@@ -144,9 +144,9 @@ export function TestConnection({
                   // For whatever reason the status is not the value
                   // of failed or success.
                   return (
-                    <TextIcon>
+                    <TextIcon key={index}>
                       <Icons.Question mr={1} />
-                      {t.details}
+                      {trace.details}
                     </TextIcon>
                   );
                 })}

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
@@ -117,7 +117,7 @@ export function TestConnection({
             borderColor={diagnosisStateBorderColor}
           >
             {attempt.status === 'failed' &&
-              `Failed to Start Testing: ${attempt.statusText}`}
+              `Encountered Error: ${attempt.statusText}`}
             {attempt.status === 'success' && (
               <Box>
                 {diagnosis.traces.map((trace, index) => {

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
@@ -122,10 +122,13 @@ export function TestConnection({
                 {diagnosis.traces.map((trace, index) => {
                   if (trace.status === 'failed') {
                     return (
-                      <TextIcon key={index}>
-                        <Icons.Warning mr={1} color="danger" />
-                        {trace.details}
-                      </TextIcon>
+                      <>
+                        <TextIcon>
+                          <Icons.CircleCross mr={1} color="danger" />
+                          {trace.details}
+                        </TextIcon>
+                        <Box mt={2}>{trace.error}</Box>
+                      </>
                     );
                   }
                   if (trace.status === 'success') {

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
@@ -59,11 +59,7 @@ export function TestConnection({
         Testing in-progress
       </TextIcon>
     );
-  }
-
-  let diagnosisStateBorderColor = 'transparent';
-  if (attempt.status === 'failed' || (diagnosis && !diagnosis.success)) {
-    diagnosisStateBorderColor = 'danger';
+  } else if (attempt.status === 'failed' || (diagnosis && !diagnosis.success)) {
     $diagnosisStateComponent = (
       <TextIcon>
         <Icons.Warning ml={1} color="danger" />
@@ -71,7 +67,6 @@ export function TestConnection({
       </TextIcon>
     );
   } else if (attempt.status === 'success' && diagnosis?.success) {
-    diagnosisStateBorderColor = 'success';
     $diagnosisStateComponent = (
       <TextIcon>
         <Icons.CircleCheck ml={1} color="success" />
@@ -108,14 +103,18 @@ export function TestConnection({
         <Text typography="subtitle1" mb={3}>
           Verify that the server is accessible
         </Text>
-        {showDiagnosisOutput && (
-          <Box
-            bg="rgba(255, 255, 255, 0.05)"
-            p={3}
-            borderRadius={3}
-            border={2}
-            borderColor={diagnosisStateBorderColor}
+        <Flex alignItems="center" mt={3}>
+          <ButtonSecondary
+            width="200px"
+            onClick={() => runConnectionDiagnostic(selectedOpt.value)}
+            disabled={attempt.status === 'processing'}
           >
+            {diagnosis ? 'Restart Test' : 'Test Connection'}
+          </ButtonSecondary>
+          <Box ml={4}>{$diagnosisStateComponent}</Box>
+        </Flex>
+        {showDiagnosisOutput && (
+          <Box mt={3}>
             {attempt.status === 'failed' &&
               `Encountered Error: ${attempt.statusText}`}
             {attempt.status === 'success' && (
@@ -123,13 +122,10 @@ export function TestConnection({
                 {diagnosis.traces.map((trace, index) => {
                   if (trace.status === 'failed') {
                     return (
-                      <React.Fragment key={index}>
-                        <TextIcon>
-                          <Icons.Warning mr={1} color="danger" />
-                          {trace.details}
-                        </TextIcon>
-                        <Box mt={2}>{trace.error}</Box>
-                      </React.Fragment>
+                      <TextIcon key={index}>
+                        <Icons.Warning mr={1} color="danger" />
+                        {trace.details}
+                      </TextIcon>
                     );
                   }
                   if (trace.status === 'success') {
@@ -154,16 +150,6 @@ export function TestConnection({
             )}
           </Box>
         )}
-        <Flex alignItems="center" mt={3}>
-          <ButtonSecondary
-            width="200px"
-            onClick={() => runConnectionDiagnostic(selectedOpt.value)}
-            disabled={attempt.status === 'processing'}
-          >
-            {diagnosis ? 'Restart Test' : 'Test Connection'}
-          </ButtonSecondary>
-          <Box ml={4}>{$diagnosisStateComponent}</Box>
-        </Flex>
       </StyledBox>
       <StyledBox>
         <Text bold>Step 3</Text>

--- a/packages/teleport/src/Discover/TestConnection/useTestConnection.ts
+++ b/packages/teleport/src/Discover/TestConnection/useTestConnection.ts
@@ -43,6 +43,7 @@ export function useTestConnection({ ctx, props }: Props) {
 
   function runConnectionDiagnostic(login: string) {
     const meta = props.agentMeta as NodeMeta;
+    setDiagnosis(null);
     run(() =>
       ctx.agentService
         .createConnectionDiagnostic({

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -66,8 +66,8 @@ export function Main(props: State) {
   }
 
   function updateOnboardDiscover() {
-    const { hasResource } = localStorage.getOnboardDiscover();
-    localStorage.setOnboardDiscover({ hasResource, notified: true });
+    const discover = localStorage.getOnboardDiscover();
+    localStorage.setOnboardDiscover({ ...discover, notified: true });
   }
 
   // render feature routes

--- a/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
+++ b/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import * as Icons from 'design/Icon';
+import {
+  render as testingRender,
+  screen,
+  fireEvent,
+} from 'design/utils/testing';
+
+import cfg from 'teleport/config';
+import localStorage from 'teleport/services/localStorage';
+import history from 'teleport/services/history';
+
+import { UserMenuNav } from './UserMenuNav';
+
+afterAll(() => {
+  localStorage.clear();
+});
+
+describe('checkmark render', () => {
+  test.each`
+    viewing                                 | menuName
+    ${cfg.routes.discover}                  | ${'Manage Access'}
+    ${cfg.routes.users}                     | ${'Browse Resources'}
+    ${cfg.getNodesRoute('some-cluster-id')} | ${'Browse Resources'}
+    ${cfg.routes.account}                   | ${'Account'}
+    ${cfg.routes.accountPassword}           | ${'Account'}
+    ${cfg.routes.support}                   | ${'support'}
+  `(
+    'path `$viewing` renders checkmark next to menu item `$menuName`',
+    ({ viewing, menuName }) => {
+      render(viewing);
+
+      // Click on dropdown menu.
+      fireEvent.click(screen.getByText(/llama/i));
+
+      // Only one checkmark should be rendered at a time.
+      const targetEl = screen.getAllByTestId('checkmark');
+      expect(targetEl).toHaveLength(1);
+
+      expect(targetEl[0].previousSibling).toHaveTextContent(menuName);
+    }
+  );
+});
+
+test('alert bubble rendered when there is no resources', () => {
+  localStorage.setOnboardDiscover({ hasResource: false });
+  render(cfg.routes.users);
+
+  fireEvent.click(screen.getByText(/llama/i));
+
+  const targetEl = screen.getAllByTestId('alert-bubble');
+  expect(targetEl).toHaveLength(1);
+
+  expect(targetEl[0].parentNode.nextSibling).toHaveTextContent(
+    /manage access/i
+  );
+});
+
+test('alert bubble not rendered when viewing discovery', () => {
+  localStorage.setOnboardDiscover({ hasResource: false });
+  render(cfg.routes.discover);
+
+  fireEvent.click(screen.getByText(/llama/i));
+
+  const targetEl = screen.queryAllByTestId('alert-bubble');
+  expect(targetEl).toHaveLength(0);
+});
+
+test('alert bubble not rendered when there is resources', () => {
+  localStorage.setOnboardDiscover({ hasResource: true });
+  render(cfg.routes.discover);
+
+  fireEvent.click(screen.getByText(/llama/i));
+
+  const targetEl = screen.queryAllByTestId('alert-bubble');
+  expect(targetEl).toHaveLength(0);
+});
+
+test('clicking on discovery (going to) removes the alert bubble', () => {
+  jest.spyOn(history, 'push').mockImplementation();
+  localStorage.setOnboardDiscover({ hasResource: false });
+
+  render(cfg.routes.users);
+
+  fireEvent.click(screen.getByText(/llama/i));
+
+  // Test initially we have the alert bubble when not viewing discovery.
+  let targetEl = screen.getAllByTestId('alert-bubble');
+  expect(targetEl).toHaveLength(1);
+
+  // Test clicking on discovery updates the local storage.
+  fireEvent.click(screen.getByText(/manage access/i));
+  expect(history.push).toHaveBeenCalledWith(cfg.routes.discover);
+  expect(localStorage.getOnboardDiscover()).toEqual({
+    hasResource: false,
+    hasVisited: true,
+  });
+
+  // Test alert bubble is no longer rendered.
+  fireEvent.click(screen.getByText(/llama/i));
+  targetEl = screen.queryAllByTestId('alert-bubble');
+  expect(targetEl).toHaveLength(0);
+});
+
+function render(path: string) {
+  testingRender(
+    <MemoryRouter initialEntries={[path]}>
+      <UserMenuNav
+        navItems={[
+          {
+            title: 'support',
+            Icon: Icons.Question,
+            getLink() {
+              return cfg.routes.support;
+            },
+          },
+          {
+            title: 'Account',
+            Icon: Icons.Question,
+            getLink() {
+              return cfg.routes.account;
+            },
+          },
+        ]}
+        username="llama"
+        logout={() => null}
+      />
+    </MemoryRouter>
+  );
+}

--- a/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
+++ b/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
@@ -52,10 +52,10 @@ describe('checkmark render', () => {
       fireEvent.click(screen.getByText(/llama/i));
 
       // Only one checkmark should be rendered at a time.
-      const targetEl = screen.getAllByTestId('checkmark');
-      expect(targetEl).toHaveLength(1);
+      const targetEl = screen.getByTestId('checkmark');
+      expect(targetEl).toBeInTheDocument();
 
-      expect(targetEl[0].previousSibling).toHaveTextContent(menuName);
+      expect(targetEl.previousSibling).toHaveTextContent(menuName);
     }
   );
 });
@@ -66,12 +66,10 @@ test('alert bubble rendered when there is no resources', () => {
 
   fireEvent.click(screen.getByText(/llama/i));
 
-  const targetEl = screen.getAllByTestId('alert-bubble');
-  expect(targetEl).toHaveLength(1);
+  const targetEl = screen.getByTestId('alert-bubble');
+  expect(targetEl).toBeInTheDocument();
 
-  expect(targetEl[0].parentNode.nextSibling).toHaveTextContent(
-    /manage access/i
-  );
+  expect(targetEl.parentNode.nextSibling).toHaveTextContent(/manage access/i);
 });
 
 test('alert bubble not rendered when viewing discovery', () => {
@@ -80,8 +78,8 @@ test('alert bubble not rendered when viewing discovery', () => {
 
   fireEvent.click(screen.getByText(/llama/i));
 
-  const targetEl = screen.queryAllByTestId('alert-bubble');
-  expect(targetEl).toHaveLength(0);
+  const targetEl = screen.queryByTestId('alert-bubble');
+  expect(targetEl).not.toBeInTheDocument();
 });
 
 test('alert bubble not rendered when there is resources', () => {
@@ -90,8 +88,8 @@ test('alert bubble not rendered when there is resources', () => {
 
   fireEvent.click(screen.getByText(/llama/i));
 
-  const targetEl = screen.queryAllByTestId('alert-bubble');
-  expect(targetEl).toHaveLength(0);
+  const targetEl = screen.queryByTestId('alert-bubble');
+  expect(targetEl).not.toBeInTheDocument();
 });
 
 test('clicking on discovery (going to) removes the alert bubble', () => {
@@ -103,8 +101,8 @@ test('clicking on discovery (going to) removes the alert bubble', () => {
   fireEvent.click(screen.getByText(/llama/i));
 
   // Test initially we have the alert bubble when not viewing discovery.
-  let targetEl = screen.getAllByTestId('alert-bubble');
-  expect(targetEl).toHaveLength(1);
+  let targetEl = screen.getByTestId('alert-bubble');
+  expect(targetEl).toBeInTheDocument();
 
   // Test clicking on discovery updates the local storage.
   fireEvent.click(screen.getByText(/manage access/i));
@@ -116,8 +114,8 @@ test('clicking on discovery (going to) removes the alert bubble', () => {
 
   // Test alert bubble is no longer rendered.
   fireEvent.click(screen.getByText(/llama/i));
-  targetEl = screen.queryAllByTestId('alert-bubble');
-  expect(targetEl).toHaveLength(0);
+  targetEl = screen.queryByTestId('alert-bubble');
+  expect(targetEl).not.toBeInTheDocument();
 });
 
 function render(path: string) {

--- a/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useLocation } from 'react-router';
 import { NavLink } from 'react-router-dom';
@@ -40,20 +40,23 @@ export function UserMenuNav({ navItems, username, logout }: Props) {
   // on the dropdown items should be rendered.
   const viewingDiscover = pathname === cfg.routes.discover;
   const viewingUserMenu =
-    !viewingDiscover &&
-    navItems.filter(n => pathname.startsWith(n.getLink())).length > 0;
+    !viewingDiscover && navItems.some(n => pathname.startsWith(n.getLink()));
   const viewingResources = !viewingUserMenu && !viewingDiscover;
 
   const firstTimeDiscoverVisit =
     discover && !discover.hasResource && !discover.hasVisited;
   const showDiscoverAlertBubble = !viewingDiscover && firstTimeDiscoverVisit;
+  const isFirstTimeDiscoverVisited = viewingDiscover && firstTimeDiscoverVisit;
 
-  if (viewingDiscover && firstTimeDiscoverVisit) {
-    localStorage.setOnboardDiscover({
-      ...discover,
-      hasVisited: true,
-    });
-  }
+  useEffect(() => {
+    if (isFirstTimeDiscoverVisited) {
+      const discover = localStorage.getOnboardDiscover();
+      localStorage.setOnboardDiscover({
+        ...discover,
+        hasVisited: true,
+      });
+    }
+  }, [isFirstTimeDiscoverVisited]);
 
   const menuItemProps = {
     onClick: closeMenu,

--- a/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -14,19 +14,47 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useLocation } from 'react-router';
 import { NavLink } from 'react-router-dom';
 
-import { ButtonPrimary, Box } from 'design';
+import { ButtonPrimary, Box, Text, Flex } from 'design';
 import { OpenBox, Person } from 'design/Icon';
 import TopNavUserMenu from 'design/TopNav/TopNavUserMenu';
 import { MenuItemIcon, MenuItem } from 'design/Menu';
 
+import history from 'teleport/services/history';
 import cfg from 'teleport/config';
 import { NavItem } from 'teleport/stores/storeNav';
+import localStorage from 'teleport/services/localStorage';
 
 export function UserMenuNav({ navItems, username, logout }: Props) {
-  const [open, setOpen] = React.useState(false);
+  const { pathname } = useLocation();
+  const [open, setOpen] = useState(false);
+
+  const discover = localStorage.getOnboardDiscover();
+
+  // viewingXXX flags to determine what view the user is
+  // currently on to determine where the checkmark icon
+  // on the dropdown items should be rendered.
+  const viewingDiscover = pathname === cfg.routes.discover;
+  const viewingUserMenu =
+    !viewingDiscover &&
+    navItems.filter(n => pathname.startsWith(n.getLink())).length > 0;
+  const viewingResources = !viewingUserMenu && !viewingDiscover;
+
+  const firstTimeDiscoverVisit =
+    discover && !discover.hasResource && !discover.hasVisited;
+  const showDiscoverAlertBubble = !viewingDiscover && firstTimeDiscoverVisit;
+
+  if (viewingDiscover && firstTimeDiscoverVisit) {
+    localStorage.setOnboardDiscover({
+      ...discover,
+      hasVisited: true,
+    });
+  }
+
   const menuItemProps = {
     onClick: closeMenu,
     py: 2,
@@ -34,12 +62,22 @@ export function UserMenuNav({ navItems, username, logout }: Props) {
     exact: true,
   };
 
-  const $userMenuItems = navItems.map((item, index) => (
-    <MenuItem {...menuItemProps} key={index} to={item.getLink()}>
-      <MenuItemIcon as={item.Icon} mr="2" />
-      {item.title}
-    </MenuItem>
-  ));
+  const $userMenuItems = navItems.map((item, index) => {
+    const menuPath = item.getLink();
+    return (
+      <MenuItem {...menuItemProps} key={index} to={menuPath}>
+        <FlexedMenuItemIcon as={item.Icon} />
+        <FlexSpaceBetween>
+          <Text>{item.title}</Text>
+          {/* Using 'startsWith' to account for routes that have sub paths eg:
+              - main path: /web/account
+              - sub paths: /web/account/password, /web/account/twofactor
+          */}
+          {pathname.startsWith(menuPath) && <Checkmark />}
+        </FlexSpaceBetween>
+      </MenuItem>
+    );
+  });
 
   function showMenu() {
     setOpen(true);
@@ -54,6 +92,15 @@ export function UserMenuNav({ navItems, username, logout }: Props) {
     logout();
   }
 
+  function handleClickDiscover() {
+    if (firstTimeDiscoverVisit) {
+      localStorage.setOnboardDiscover({ ...discover, hasVisited: true });
+    }
+
+    history.push(cfg.routes.discover);
+    closeMenu();
+  }
+
   return (
     <TopNavUserMenu
       menuListCss={menuListCss}
@@ -63,12 +110,27 @@ export function UserMenuNav({ navItems, username, logout }: Props) {
       user={username}
     >
       <MenuItem {...menuItemProps} to={cfg.routes.root}>
-        <MenuItemIcon as={Person} mr="2" />
-        Browse Resources
+        <BorderedFlexedMenuItemIcon as={Person} />
+        <FlexSpaceBetween>
+          <Text>Browse Resources</Text>
+          {viewingResources && <Checkmark />}
+        </FlexSpaceBetween>
       </MenuItem>
-      <MenuItem {...menuItemProps} to={cfg.routes.discover}>
-        <MenuItemIcon as={OpenBox} mr="2" />
-        Manage Access
+      <MenuItem py={2} onClick={handleClickDiscover}>
+        <div
+          css={`
+            position: relative;
+          `}
+        >
+          <BorderedFlexedMenuItemIcon as={OpenBox} />
+          {showDiscoverAlertBubble && (
+            <AlertBubble data-testid="alert-bubble" />
+          )}
+        </div>
+        <FlexSpaceBetween>
+          <Text>Manage Access</Text>
+          {viewingDiscover && <Checkmark />}
+        </FlexSpaceBetween>
       </MenuItem>
       <Box
         my={2}
@@ -86,8 +148,49 @@ export function UserMenuNav({ navItems, username, logout }: Props) {
   );
 }
 
+const Checkmark = () => <StyledCheckmark data-testid="checkmark" />;
+const StyledCheckmark = styled(Text)(
+  props => `
+  color: ${props.theme.colors.success};
+  font-size: ${props.theme.fontSizes[6]}${'px'};
+
+  :before {
+    content: '✓';
+  }
+`
+);
+
 const menuListCss = () => `
-  width: 250px;
+  width: 220px;
+`;
+
+const FlexedMenuItemIcon = styled(MenuItemIcon)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const BorderedFlexedMenuItemIcon = styled(FlexedMenuItemIcon)`
+  background: #f1eeee;
+  border-radius: 4px;
+  padding: 3px;
+  width: 18px;
+  height: 18px;
+`;
+
+const AlertBubble = styled.div`
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  background: ${({ theme }) => theme.colors.danger};
+  border-radius: 100%;
+  top: -2px;
+  right: 6px;
+`;
+
+const FlexSpaceBetween = styled(Flex)`
+  width: 100%;
+  justify-content: space-between;
 `;
 
 type Props = {

--- a/packages/teleport/src/services/agents/make.ts
+++ b/packages/teleport/src/services/agents/make.ts
@@ -18,11 +18,10 @@ import type { ConnectionDiagnostic, ConnectionDiagnosticTrace } from './types';
 
 export function makeConnectionDiagnostic(json: any): ConnectionDiagnostic {
   json = json || {};
-  const { id, labels, success, message, traces } = json;
+  const { id, success, message, traces } = json;
 
   return {
     id,
-    labels: labels ? labels : [],
     success,
     message,
     traces: makeTraces(traces),
@@ -35,9 +34,8 @@ function makeTraces(traces: any): ConnectionDiagnosticTrace[] {
   }
 
   return traces.map(t => ({
-    id: t.id,
     traceType: t.trace_type,
-    status: t.status,
+    status: t.status?.toLowerCase(),
     details: t.details,
     error: t.error,
   }));

--- a/packages/teleport/src/services/agents/types.ts
+++ b/packages/teleport/src/services/agents/types.ts
@@ -67,8 +67,6 @@ export type AgentIdKind =
 export type ConnectionDiagnostic = {
   // id is the identifier of the connection diagnostic.
   id: string;
-  // labels is a map of static and dynamic labels associated with the connection diagnostic.
-  labels: AgentLabel[];
   // success is whether the connection was successful
   success: boolean;
   // message is the diagnostic summary
@@ -79,7 +77,6 @@ export type ConnectionDiagnostic = {
 
 // ConnectionDiagnosticTrace describes a trace of a connection diagnostic
 export type ConnectionDiagnosticTrace = {
-  id: string;
   traceType: string;
   status: 'success' | 'failed';
   details: string;

--- a/packages/teleport/src/services/user/types.ts
+++ b/packages/teleport/src/services/user/types.ts
@@ -121,4 +121,7 @@ export type OnboardDiscover = {
   // hasResource is a flag to indicate if user has access to
   // any registered resource.
   hasResource: boolean;
+  // hasVisited is a flag to indicate if user has visited the
+  // discover page.
+  hasVisited?: boolean;
 };

--- a/packages/teleport/src/services/user/user.ts
+++ b/packages/teleport/src/services/user/user.ts
@@ -69,7 +69,7 @@ const service = {
   },
 
   applyUserTraits() {
-    return session.renewSession({ updateUserTraits: true });
+    return session.renewSession({ reloadUser: true });
   },
 
   checkUserHasAccessToRegisteredResource(): Promise<boolean> {

--- a/packages/teleport/src/services/websession/types.ts
+++ b/packages/teleport/src/services/websession/types.ts
@@ -17,7 +17,7 @@
 export type RenewSessionRequest = {
   requestId?: string;
   switchback?: boolean;
-  updateUserTraits?: boolean;
+  reloadUser?: boolean;
 };
 
 export type BearerToken = {


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/13997

#### Description
- Adds checkmark to where the user is currently on
- Adds alert bubble to the discover nav item if user:
  - doesn't have a resource
  - has not visited the discover page
- Added allowing user to re-fetch failure points (eg network errors) so they don't need to restart the flow, just refetch the data that was required for that step
  
#### Screenshot
on resources (anything but discover or user menu nav items)

![image](https://user-images.githubusercontent.com/43280172/187742935-687bb08a-e1aa-472a-aabf-6df427bb1b6a.png)

no resources alert bubble that goes away when a user visits the discover page (like github)

![image](https://user-images.githubusercontent.com/43280172/187743293-56337e53-c1d2-4a23-b26b-f18cd8d7dea5.png)


on discover

![image](https://user-images.githubusercontent.com/43280172/187742987-9b409e99-15e3-4365-8368-58b068e1bc90.png)


on a user menu nav item

![image](https://user-images.githubusercontent.com/43280172/187743101-2005ccbe-47bf-48a3-8732-45b37fbf52fa.png)

Refetching from errors (eg network)

![image](https://user-images.githubusercontent.com/43280172/188244494-53f41452-162b-4320-908f-83f9aba0b568.png)
![image](https://user-images.githubusercontent.com/43280172/188244518-53678308-2559-46b9-b4f6-352b30b79a56.png)

