### PR TITLE
Fix double scroll bars, make everything have min width 1250px

### DIFF
--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -26,7 +26,6 @@ import useTeleport from 'teleport/useTeleport';
 import getFeatures from 'teleport/features';
 import { UserMenuNav } from 'teleport/components/UserMenuNav';
 import * as main from 'teleport/Main';
-import { MainContainer } from 'teleport/Main/MainContainer';
 import * as sideNav from 'teleport/SideNav';
 import { TopBarContainer } from 'teleport/TopBar';
 import { FeatureBox } from 'teleport/components/Layout';
@@ -141,8 +140,8 @@ export function Discover({
                 agentViews[selectedAgentKind].length > 1 ? agentStepTitles : []
               }
             />
-            <HorizontalSplit>
-              <ContentMinWidth>
+            <main.HorizontalSplit>
+              <main.ContentMinWidth>
                 <TopBarContainer>
                   <Text typography="h5" bold>
                     Manage Access
@@ -156,8 +155,8 @@ export function Discover({
                 <FeatureBox pt={4} maxWidth="1450px">
                   {AgentComponent && <AgentComponent {...agentProps} />}
                 </FeatureBox>
-              </ContentMinWidth>
-            </HorizontalSplit>
+              </main.ContentMinWidth>
+            </main.HorizontalSplit>
           </>
         )}
       </MainContainer>
@@ -227,15 +226,8 @@ function SideNavAgentConnect({
   );
 }
 
-const HorizontalSplit = styled(main.HorizontalSplit)`
-  // sidebar is 280px + 1px right border
-  width: calc(100% - 281px);
-  flex: 1 0 calc(100% - 281px);
-`;
-
-const ContentMinWidth = styled.div`
-  // sidebar is 280px + 1px right border
-  min-width: calc(1250px - 281px);
+const MainContainer = styled(main.MainContainer)`
+  --sidebar-width: 280px;
 `;
 
 const Bullet = styled.span`
@@ -283,8 +275,8 @@ const StepsContainer = styled(Text)`
 `;
 
 const StyledNav = styled(sideNav.Nav)`
-  min-width: 280px;
-  width: 280px;
+  min-width: var(--sidebar-width);
+  width: var(--sidebar-width);
 `;
 
 const StyledNavContent = styled(sideNav.Content)`

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -142,21 +142,23 @@ export function Discover({
               }
             />
             <main.HorizontalSplit>
-              <main.ContentMinWidth>
-                <TopBarContainer>
-                  <Text typography="h5" bold>
-                    Manage Access
-                  </Text>
-                  <UserMenuNav
-                    navItems={userMenuItems}
-                    logout={logout}
-                    username={username}
-                  />
-                </TopBarContainer>
-                <FeatureBox pt={4}>
-                  {AgentComponent && <AgentComponent {...agentProps} />}
-                </FeatureBox>
-              </main.ContentMinWidth>
+              <main.HorizontalSplit>
+                <ContentMinWidth>
+                  <TopBarContainer>
+                    <Text typography="h5" bold>
+                      Manage Access
+                    </Text>
+                    <UserMenuNav
+                      navItems={userMenuItems}
+                      logout={logout}
+                      username={username}
+                    />
+                  </TopBarContainer>
+                  <FeatureBox pt={4}>
+                    {AgentComponent && <AgentComponent {...agentProps} />}
+                  </FeatureBox>
+                </ContentMinWidth>
+              </main.HorizontalSplit>
             </main.HorizontalSplit>
           </>
         )}
@@ -226,6 +228,11 @@ function SideNavAgentConnect({
     </StyledNav>
   );
 }
+
+const ContentMinWidth = styled.div`
+  // sidebar is 280px + 1px right border
+  min-width: calc(1250px - 281px);
+`;
 
 const Bullet = styled.span`
   height: 14px;

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -141,25 +141,23 @@ export function Discover({
                 agentViews[selectedAgentKind].length > 1 ? agentStepTitles : []
               }
             />
-            <main.HorizontalSplit>
-              <main.HorizontalSplit>
-                <ContentMinWidth>
-                  <TopBarContainer>
-                    <Text typography="h5" bold>
-                      Manage Access
-                    </Text>
-                    <UserMenuNav
-                      navItems={userMenuItems}
-                      logout={logout}
-                      username={username}
-                    />
-                  </TopBarContainer>
-                  <FeatureBox pt={4}>
-                    {AgentComponent && <AgentComponent {...agentProps} />}
-                  </FeatureBox>
-                </ContentMinWidth>
-              </main.HorizontalSplit>
-            </main.HorizontalSplit>
+            <HorizontalSplit>
+              <ContentMinWidth>
+                <TopBarContainer>
+                  <Text typography="h5" bold>
+                    Manage Access
+                  </Text>
+                  <UserMenuNav
+                    navItems={userMenuItems}
+                    logout={logout}
+                    username={username}
+                  />
+                </TopBarContainer>
+                <FeatureBox pt={4}>
+                  {AgentComponent && <AgentComponent {...agentProps} />}
+                </FeatureBox>
+              </ContentMinWidth>
+            </HorizontalSplit>
           </>
         )}
       </MainContainer>
@@ -228,6 +226,12 @@ function SideNavAgentConnect({
     </StyledNav>
   );
 }
+
+const HorizontalSplit = styled(main.HorizontalSplit)`
+  // sidebar is 240px + 1px right border
+  width: calc(100% - 281px);
+  flex: 1 0 calc(100% - 281px);
+`;
 
 const ContentMinWidth = styled.div`
   // sidebar is 280px + 1px right border

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -142,19 +142,21 @@ export function Discover({
               }
             />
             <main.HorizontalSplit>
-              <TopBarContainer>
-                <Text typography="h5" bold>
-                  Manage Access
-                </Text>
-                <UserMenuNav
-                  navItems={userMenuItems}
-                  logout={logout}
-                  username={username}
-                />
-              </TopBarContainer>
-              <FeatureBox pt={4}>
-                {AgentComponent && <AgentComponent {...agentProps} />}
-              </FeatureBox>
+              <main.ContentMinWidth>
+                <TopBarContainer>
+                  <Text typography="h5" bold>
+                    Manage Access
+                  </Text>
+                  <UserMenuNav
+                    navItems={userMenuItems}
+                    logout={logout}
+                    username={username}
+                  />
+                </TopBarContainer>
+                <FeatureBox pt={4}>
+                  {AgentComponent && <AgentComponent {...agentProps} />}
+                </FeatureBox>
+              </main.ContentMinWidth>
             </main.HorizontalSplit>
           </>
         )}
@@ -270,10 +272,10 @@ const StepsContainer = styled(Text)`
 `;
 
 const StyledNav = styled(sideNav.Nav)`
-  min-width: 350px;
-  width: 350px;
+  min-width: 280px;
+  width: 280px;
 `;
 
 const StyledNavContent = styled(sideNav.Content)`
-  padding: 20px 32px 32px 32px;
+  padding: 0 20px;
 `;

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -228,7 +228,7 @@ function SideNavAgentConnect({
 }
 
 const HorizontalSplit = styled(main.HorizontalSplit)`
-  // sidebar is 240px + 1px right border
+  // sidebar is 280px + 1px right border
   width: calc(100% - 281px);
   flex: 1 0 calc(100% - 281px);
 `;

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -153,7 +153,7 @@ export function Discover({
                     username={username}
                   />
                 </TopBarContainer>
-                <FeatureBox pt={4}>
+                <FeatureBox pt={4} maxWidth="1450px">
                   {AgentComponent && <AgentComponent {...agentProps} />}
                 </FeatureBox>
               </ContentMinWidth>

--- a/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -134,7 +134,7 @@ export function SelectResource({
   const disabled = checkPermissions(acl, tabs[selectedTabIndex]);
 
   return (
-    <Box maxWidth="1450px">
+    <Box>
       <Header>Select Resource Type</Header>
       <HeaderSubtitle>
         Users are able to add and access many different types of resources

--- a/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -134,7 +134,7 @@ export function SelectResource({
   const disabled = checkPermissions(acl, tabs[selectedTabIndex]);
 
   return (
-    <Box width="1020px">
+    <Box maxWidth="1450px">
       <Header>Select Resource Type</Header>
       <HeaderSubtitle>
         Users are able to add and access many different types of resources

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -156,7 +156,6 @@ export const ContentMinWidth = styled.div`
 export const HorizontalSplit = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
   flex: 1;
   overflow-x: auto;
 `;

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -150,8 +150,7 @@ export function Main(props: State) {
 }
 
 export const ContentMinWidth = styled.div`
-  // minus 1px for the sidebar right border
-  min-width: calc(1250px - var(--sidebar-width) - 1px);
+  min-width: calc(1250px - var(--sidebar-width));
 `;
 
 export const HorizontalSplit = styled.div`

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -150,8 +150,8 @@ export function Main(props: State) {
 }
 
 export const ContentMinWidth = styled.div`
-  // sidebar is 280px + 1px right border
-  min-width: calc(1250px - 281px);
+  // sidebar is 240px + 1px right border
+  min-width: calc(1250px - 241px);
 `;
 
 export const HorizontalSplit = styled.div`
@@ -159,9 +159,9 @@ export const HorizontalSplit = styled.div`
   flex-direction: column;
   height: 100%;
 
-  // sidebar is 280px + 1px right border
-  width: calc(100% - 281px);
-  flex: 1 0 calc(100% - 281px);
+  // sidebar is 240px + 1px right border
+  width: calc(100% - 241px);
+  flex: 1 0 calc(100% - 241px);
   overflow-x: auto;
 `;
 

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -135,8 +135,10 @@ export function Main(props: State) {
         <MainContainer>
           <SideNav />
           <HorizontalSplit>
-            <TopBar />
-            <Switch>{$features}</Switch>
+            <ContentMinWidth>
+              <TopBar />
+              <Switch>{$features}</Switch>
+            </ContentMinWidth>
           </HorizontalSplit>
         </MainContainer>
       </BannerList>
@@ -147,14 +149,20 @@ export function Main(props: State) {
   );
 }
 
+export const ContentMinWidth = styled.div`
+  // sidebar is 280px + 1px right border
+  min-width: calc(1250px - 281px);
+`;
+
 export const HorizontalSplit = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
   height: 100%;
 
-  // Allows shrinking beyond content size on flexed childrens.
-  min-width: 0;
+  // sidebar is 280px + 1px right border
+  width: calc(100% - 281px);
+  flex: 1 0 calc(100% - 281px);
+  overflow-x: auto;
 `;
 
 export const StyledIndicator = styled(HorizontalSplit)`

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -150,18 +150,15 @@ export function Main(props: State) {
 }
 
 export const ContentMinWidth = styled.div`
-  // sidebar is 240px + 1px right border
-  min-width: calc(1250px - 241px);
+  // minus 1px for the sidebar right border
+  min-width: calc(1250px - var(--sidebar-width) - 1px);
 `;
 
 export const HorizontalSplit = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-
-  // sidebar is 240px + 1px right border
-  width: calc(100% - 241px);
-  flex: 1 0 calc(100% - 241px);
+  flex: 1;
   overflow-x: auto;
 `;
 

--- a/packages/teleport/src/Main/MainContainer.tsx
+++ b/packages/teleport/src/Main/MainContainer.tsx
@@ -27,4 +27,5 @@ export const MainContainer = styled.div`
   display: flex;
   flex: 1;
   position: absolute;
+  --sidebar-width: 240px;
 `;

--- a/packages/teleport/src/Main/MainContainer.tsx
+++ b/packages/teleport/src/Main/MainContainer.tsx
@@ -23,9 +23,8 @@ import styled from 'styled-components';
 // times.
 export const MainContainer = styled.div`
   width: 100%;
-  height: 100%;
   display: flex;
   flex: 1;
-  position: absolute;
+  min-height: 0;
   --sidebar-width: 240px;
 `;

--- a/packages/teleport/src/Main/MainContainer.tsx
+++ b/packages/teleport/src/Main/MainContainer.tsx
@@ -27,5 +27,4 @@ export const MainContainer = styled.div`
   display: flex;
   flex: 1;
   position: absolute;
-  min-width: 1000px;
 `;

--- a/packages/teleport/src/Main/index.ts
+++ b/packages/teleport/src/Main/index.ts
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 export {
-  default as Main,
+  default,
+  Main,
   ContentMinWidth,
   HorizontalSplit,
   StyledIndicator,

--- a/packages/teleport/src/Main/index.ts
+++ b/packages/teleport/src/Main/index.ts
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Main, { HorizontalSplit, StyledIndicator } from './Main';
-
-export { HorizontalSplit, StyledIndicator };
-export default Main;
+export {
+  default as Main,
+  ContentMinWidth,
+  HorizontalSplit,
+  StyledIndicator,
+} from './Main';
+export { MainContainer } from './MainContainer';

--- a/packages/teleport/src/SideNav/SideNav.tsx
+++ b/packages/teleport/src/SideNav/SideNav.tsx
@@ -86,6 +86,7 @@ export const Nav = styled.nav`
   flex-direction: column;
   min-width: var(--sidebar-width);
   width: var(--sidebar-width);
+  box-sizing: border-box;
 `;
 
 export const Content = styled.div`

--- a/packages/teleport/src/SideNav/SideNav.tsx
+++ b/packages/teleport/src/SideNav/SideNav.tsx
@@ -80,12 +80,12 @@ const LogoItem = styled(Flex)(
 export const Nav = styled.nav`
   background: ${props => props.theme.colors.primary.light};
   border-right: 1px solid ${props => props.theme.colors.primary.dark};
-  min-width: 240px;
-  width: 240px;
   overflow: auto;
   height: 100%;
   display: flex;
   flex-direction: column;
+  min-width: var(--sidebar-width);
+  width: var(--sidebar-width);
 `;
 
 export const Content = styled.div`

--- a/packages/teleport/src/SideNav/__snapshots__/SideNav.story.test.tsx.snap
+++ b/packages/teleport/src/SideNav/__snapshots__/SideNav.story.test.tsx.snap
@@ -227,12 +227,12 @@ exports[`rendering of SideNav 1`] = `
 .c1 {
   background: #222C59;
   border-right: 1px solid #111B48;
-  min-width: 240px;
-  width: 240px;
   overflow: auto;
   height: 100%;
   display: flex;
   flex-direction: column;
+  min-width: var(--sidebar-width);
+  width: var(--sidebar-width);
 }
 
 .c4 {

--- a/packages/teleport/src/SideNav/__snapshots__/SideNav.story.test.tsx.snap
+++ b/packages/teleport/src/SideNav/__snapshots__/SideNav.story.test.tsx.snap
@@ -233,6 +233,7 @@ exports[`rendering of SideNav 1`] = `
   flex-direction: column;
   min-width: var(--sidebar-width);
   width: var(--sidebar-width);
+  box-sizing: border-box;
 }
 
 .c4 {

--- a/packages/teleport/src/Teleport.tsx
+++ b/packages/teleport/src/Teleport.tsx
@@ -21,7 +21,7 @@ import { Router, Route, Switch } from 'teleport/components/Router';
 import CatchError from 'teleport/components/CatchError';
 import Authenticated from 'teleport/components/Authenticated';
 
-import Main from './Main';
+import { Main } from './Main';
 import Welcome from './Welcome';
 import Login, { LoginSuccess, LoginFailed } from './Login';
 import AppLauncher from './AppLauncher';

--- a/packages/teleport/src/Teleport.tsx
+++ b/packages/teleport/src/Teleport.tsx
@@ -21,7 +21,7 @@ import { Router, Route, Switch } from 'teleport/components/Router';
 import CatchError from 'teleport/components/CatchError';
 import Authenticated from 'teleport/components/Authenticated';
 
-import { Main } from './Main';
+import Main from './Main';
 import Welcome from './Welcome';
 import Login, { LoginSuccess, LoginFailed } from './Login';
 import AppLauncher from './AppLauncher';

--- a/packages/teleport/src/components/BannerList/BannerList.tsx
+++ b/packages/teleport/src/components/BannerList/BannerList.tsx
@@ -73,10 +73,14 @@ export const BannerList = ({
 };
 
 const Wrapper = styled(Box)`
+  display: flex;
+  height: 100vh;
+  flex-direction: column;
+
   ${MainContainer} {
+    flex: 1;
     height: calc(100% - ${props => props.bannerCount * 38}px);
   }
-  min-width: 1000px;
 `;
 
 type Props = {


### PR DESCRIPTION
This makes it so `MainContainer` no longer scrolls and `HorizontalSplit` is instead the element that scrolls when the screen width is too small.

To do this, I've made it so the contents inside `HorizontalSplit` are wrapped with a min width, to force `HorizontalSplit` to scroll when its children's size (which is 100% minus the sidebar width) exceed its width. This then makes the `MainContainer` never have to scroll, so double scroll bars won't happen.

This shows the correct scrollbar appearing when the browser width is ~1000px
![image](https://user-images.githubusercontent.com/7922109/188275401-675e356c-e47f-4246-9db9-87d600b48635.png)

Everything's fine at wide resolutions
![image](https://user-images.githubusercontent.com/7922109/188275430-18bdf607-582b-4661-b8b6-cbbdc7cdf792.png)

This also changes discover to have a max content width of 1450px (so 1450px + 281px for the sidebar = it'll stop expanding past a browser being 1731px wide).
![image](https://user-images.githubusercontent.com/7922109/188275650-b9a5effa-b223-4501-b5ea-7512b361c350.png)

At 1300px wide
![image](https://user-images.githubusercontent.com/7922109/188275658-20fc83e1-4e13-4c6a-a0fd-9f74580ce246.png)

At 1000px wide
![image](https://user-images.githubusercontent.com/7922109/188275677-24e84a7f-345d-415c-bc51-89985cc5a0a1.png)
