### PR TITLE
Change DEB artifact name

### DIFF
--- a/packages/teleterm/electron-builder-config.js
+++ b/packages/teleterm/electron-builder-config.js
@@ -95,7 +95,7 @@ module.exports = {
     artifactName: '${name}-${version}.${arch}.${ext}',
   },
   deb: {
-    artifactName: '${name}-${version}_${arch}.${ext}',
+    artifactName: '${name}_${version}_${arch}.${ext}',
   },
   linux: {
     target: ['tar.gz', 'rpm', 'deb'],


### PR DESCRIPTION
By mistake I changed `teleport-connect_1.0.2_amd64.deb` to `teleport-connect-1.0.2_amd64.deb` in this [PR](https://github.com/gravitational/webapps/pull/1142).
Houston can't see the file because of that.