### PR TITLE
[Discover] Check permission during the flow step instead of at beginning

### DIFF
--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -32,7 +32,6 @@ import { FeatureBox } from 'teleport/components/Layout';
 import cfg from 'teleport/config';
 
 import { useDiscover, State } from './useDiscover';
-
 import { SelectResource } from './SelectResource';
 import { DownloadScript } from './DownloadScript';
 import { LoginTrait } from './LoginTrait';

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -43,12 +43,26 @@ import type { AgentKind } from './useDiscover';
 import type { AgentStepComponent } from './types';
 
 export const agentViews: Record<AgentKind, AgentStepComponent[]> = {
-  app: [],
-  db: [],
-  desktop: [],
-  kube: [],
-  node: [SelectResource, DownloadScript, LoginTrait, TestConnection, Finished],
+  application: [SelectResource],
+  database: [SelectResource],
+  desktop: [SelectResource],
+  kubernetes: [SelectResource],
+  server: [
+    SelectResource,
+    DownloadScript,
+    LoginTrait,
+    TestConnection,
+    Finished,
+  ],
 };
+
+const agentStepTitles: string[] = [
+  'Select Resource Type',
+  'Configure Resource',
+  'Set Up Access',
+  'Test Connection',
+  '',
+];
 
 export default function Container() {
   const [features] = useState(() => getFeatures());
@@ -63,11 +77,11 @@ export function Discover({
   userMenuItems,
   username,
   currentStep,
-  selectedAgentKind = 'node',
   logout,
   // onSelectResource,
   ...agentProps
 }: State) {
+  const selectedAgentKind = agentProps.selectedAgentKind;
   let AgentComponent;
   if (selectedAgentKind) {
     AgentComponent = agentViews[selectedAgentKind][currentStep];
@@ -92,7 +106,13 @@ export function Discover({
       )}
       {initAttempt.status === 'success' && (
         <>
-          <SideNavAgentConnect currentStep={currentStep} />
+          <SideNavAgentConnect
+            currentStep={currentStep}
+            // TODO: hack to not show titles for unfinished flows.
+            stepTitles={
+              agentViews[selectedAgentKind].length > 1 ? agentStepTitles : []
+            }
+          />
           <main.HorizontalSplit>
             <TopBarContainer>
               <Text typography="h5" bold>
@@ -114,15 +134,13 @@ export function Discover({
   );
 }
 
-const agentStepTitles: string[] = [
-  'Select Resource Type',
-  'Configure Resource',
-  'Set Up Access',
-  'Test Connection',
-  '',
-];
-
-function SideNavAgentConnect({ currentStep }: { currentStep: number }) {
+function SideNavAgentConnect({
+  currentStep,
+  stepTitles,
+}: {
+  currentStep: number;
+  stepTitles: string[];
+}) {
   return (
     <StyledNav>
       <sideNav.Logo />
@@ -147,29 +165,31 @@ function SideNavAgentConnect({ currentStep }: { currentStep: number }) {
             </Flex>
             <Text bold>Add New Resource</Text>
           </Flex>
-          <Box ml={4} mt={4}>
-            {agentStepTitles.map((stepTitle, index) => {
-              let className = '';
-              if (currentStep > index) {
-                className = 'checked';
-              } else if (currentStep === index) {
-                className = 'active';
-              }
+          {stepTitles.length > 0 && (
+            <Box ml={4} mt={4}>
+              {stepTitles.map((stepTitle, index) => {
+                let className = '';
+                if (currentStep > index) {
+                  className = 'checked';
+                } else if (currentStep === index) {
+                  className = 'active';
+                }
 
-              // All flows will have a finished step that
-              // does not have a title.
-              if (!stepTitle) {
-                return null;
-              }
+                // All flows will have a finished step that
+                // does not have a title.
+                if (!stepTitle) {
+                  return null;
+                }
 
-              return (
-                <StepsContainer className={className} key={stepTitle}>
-                  <Bullet />
-                  {stepTitle}
-                </StepsContainer>
-              );
-            })}
-          </Box>
+                return (
+                  <StepsContainer className={className} key={stepTitle}>
+                    <Bullet />
+                    {stepTitle}
+                  </StepsContainer>
+                );
+              })}
+            </Box>
+          )}
         </Box>
       </StyledNavContent>
     </StyledNav>

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -29,6 +29,7 @@ import * as main from 'teleport/Main';
 import * as sideNav from 'teleport/SideNav';
 import { TopBarContainer } from 'teleport/TopBar';
 import { FeatureBox } from 'teleport/components/Layout';
+import cfg from 'teleport/config';
 
 import { useDiscover, State } from './useDiscover';
 
@@ -75,7 +76,10 @@ export function Discover({
   return (
     <MainContainer>
       <Prompt
-        message="Are you sure you want to exit the “Add New Resource” workflow? You’ll have to start from the beginning next time."
+        message={nextLocation => {
+          if (nextLocation.pathname === cfg.routes.discover) return true;
+          return 'Are you sure you want to exit the “Add New Resource” workflow? You’ll have to start from the beginning next time.';
+        }}
         when={currentStep > 0}
       />
       {initAttempt.status === 'processing' && (

--- a/packages/teleport/src/Discover/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/DownloadScript/DownloadScript.tsx
@@ -57,8 +57,8 @@ export function DownloadScript({
     <Box>
       <Header>Configure Resource</Header>
       <HeaderSubtitle>
-        Install and configure the Teleport SSH Service on the server you want to
-        add. <br />
+        Install and configure the Teleport SSH Service.
+        <br />
         Run the following command on the server you want to add.
       </HeaderSubtitle>
       <ScriptBox

--- a/packages/teleport/src/Discover/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/DownloadScript/DownloadScript.tsx
@@ -31,6 +31,7 @@ import {
   ActionButtons,
   TextIcon,
   ButtonBlueText,
+  Mark,
 } from '../Shared';
 
 import { useDownloadScript } from './useDownloadScript';
@@ -192,7 +193,7 @@ const TimeoutError = ({
         <li>
           The Teleport SSH Service could not join this Teleport cluster. Check
           the logs for errors by running <br />
-          `journalctl status teleport`
+          <Mark>journalctl status teleport</Mark>
         </li>
       </ul>
     </Box>

--- a/packages/teleport/src/Discover/DownloadScript/__snapshots__/DownloadScript.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/DownloadScript/__snapshots__/DownloadScript.story.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`failed 1`] = `
   <div
     class="c2"
   >
-    Install and configure the Teleport SSH Service on the server you want to add. 
+    Install and configure the Teleport SSH Service.
     <br />
     Run the following command on the server you want to add.
   </div>
@@ -573,7 +573,7 @@ exports[`polling error state 1`] = `
   <div
     class="c2"
   >
-    Install and configure the Teleport SSH Service on the server you want to add. 
+    Install and configure the Teleport SSH Service.
     <br />
     Run the following command on the server you want to add.
   </div>
@@ -909,7 +909,7 @@ exports[`polling state 1`] = `
   <div
     class="c2"
   >
-    Install and configure the Teleport SSH Service on the server you want to add. 
+    Install and configure the Teleport SSH Service.
     <br />
     Run the following command on the server you want to add.
   </div>
@@ -1213,7 +1213,7 @@ exports[`polling success state 1`] = `
   <div
     class="c2"
   >
-    Install and configure the Teleport SSH Service on the server you want to add. 
+    Install and configure the Teleport SSH Service.
     <br />
     Run the following command on the server you want to add.
   </div>

--- a/packages/teleport/src/Discover/DownloadScript/__snapshots__/DownloadScript.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/DownloadScript/__snapshots__/DownloadScript.story.test.tsx.snap
@@ -282,7 +282,7 @@ exports[`polling error state 1`] = `
   margin-right: 4px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   margin-top: 24px;
 }
@@ -374,7 +374,7 @@ exports[`polling error state 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c16 {
+.c17 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -402,25 +402,25 @@ exports[`polling error state 1`] = `
   width: 165px;
 }
 
-.c16:active {
+.c17:active {
   opacity: 0.56;
 }
 
-.c16:hover,
-.c16:focus {
+.c17:hover,
+.c17:focus {
   background: #651FFF;
 }
 
-.c16:active {
+.c17:active {
   background: #354AA4;
 }
 
-.c16:disabled {
+.c17:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c17 {
+.c18 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -448,16 +448,16 @@ exports[`polling error state 1`] = `
   width: 165px;
 }
 
-.c17:active {
+.c18:active {
   opacity: 0.56;
 }
 
-.c17:hover,
-.c17:focus {
+.c18:hover,
+.c18:focus {
   background: #2C3A73;
 }
 
-.c17:disabled {
+.c18:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -537,6 +537,13 @@ exports[`polling error state 1`] = `
   padding-left: 0;
   font-size: inherit;
   min-height: auto;
+}
+
+.c15 {
+  padding: 2px 5px;
+  border-radius: 6px;
+  background-color: rgb(255 255 255 / 17%);
+  color: inherit;
 }
 
 .c3 {
@@ -636,17 +643,21 @@ exports[`polling error state 1`] = `
         <li>
           The Teleport SSH Service could not join this Teleport cluster. Check the logs for errors by running 
           <br />
-          \`journalctl status teleport\`
+          <mark
+            class="c15"
+          >
+            journalctl status teleport
+          </mark>
         </li>
       </ul>
     </div>
   </div>
   <div
-    class="c15"
+    class="c16"
   >
     
     <button
-      class="c16"
+      class="c17"
       disabled=""
       kind="primary"
       width="165px"
@@ -654,7 +665,7 @@ exports[`polling error state 1`] = `
       Next
     </button>
     <a
-      class="c17"
+      class="c18"
       href="/web"
       kind="secondary"
       mt="3"

--- a/packages/teleport/src/Discover/Finished/Finished.story.tsx
+++ b/packages/teleport/src/Discover/Finished/Finished.story.tsx
@@ -30,4 +30,6 @@ const props: AgentStepProps = {
   agentMeta: { resourceName: 'some-resource-name' } as any,
   updateAgentMeta: () => null,
   nextStep: () => null,
+  selectedAgentKind: 'server',
+  onSelectResource: () => null,
 };

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.test.tsx
@@ -17,29 +17,49 @@
 import React from 'react';
 import { render } from 'design/utils/testing';
 
-import {
-  LoadedWithStatic,
-  EmptyWithoutStatic,
-  EmptyWithStatic,
-  Failed,
-} from './LoginTrait.story';
+import * as stories from './LoginTrait.story';
 
-test('loaded with static state', () => {
-  const { container } = render(<LoadedWithStatic />);
+test('no logins and perms', () => {
+  const { container } = render(<stories.NoLoginsAndPerm />);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('empty state', () => {
-  const { container } = render(<EmptyWithoutStatic />);
+test('no logins, perms, and is a SSO user', () => {
+  const { container } = render(<stories.NoLoginsAndPermAndSsoUser />);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('empty state with static logins', () => {
-  const { container } = render(<EmptyWithStatic />);
+test('logins with no perms', () => {
+  const { container } = render(<stories.NoPerm />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('logins and is  SSO user', () => {
+  const { container } = render(<stories.SsoUser />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('static and dynamic logins with perms`', () => {
+  const { container } = render(<stories.StaticAndDynamic />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('dynamic only logins with perms', () => {
+  const { container } = render(<stories.DynamicOnly />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('static only logins with perms', () => {
+  const { container } = render(<stories.StaticOnly />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('no logins with perms', () => {
+  const { container } = render(<stories.NoLogins />);
   expect(container.firstChild).toMatchSnapshot();
 });
 
 test('failed', () => {
-  const { container } = render(<Failed />);
+  const { container } = render(<stories.Failed />);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.story.tsx
@@ -25,25 +25,60 @@ export default {
   title: 'Teleport/Discover/LoginTrait',
 };
 
-export const LoadedWithStatic = () => (
+export const NoLoginsAndPerm = () => (
+  <MemoryRouter>
+    <LoginTrait
+      {...props}
+      canEditUser={false}
+      staticLogins={[]}
+      dynamicLogins={[]}
+    />
+  </MemoryRouter>
+);
+
+export const NoLoginsAndPermAndSsoUser = () => (
+  <MemoryRouter>
+    <LoginTrait
+      {...props}
+      canEditUser={false}
+      isSsoUser={true}
+      staticLogins={[]}
+      dynamicLogins={[]}
+    />
+  </MemoryRouter>
+);
+
+export const NoPerm = () => (
+  <MemoryRouter>
+    <LoginTrait {...props} canEditUser={false} />
+  </MemoryRouter>
+);
+
+export const SsoUser = () => (
+  <MemoryRouter>
+    <LoginTrait {...props} isSsoUser={true} />
+  </MemoryRouter>
+);
+
+export const StaticAndDynamic = () => (
   <MemoryRouter>
     <LoginTrait {...props} />
   </MemoryRouter>
 );
 
-export const LoadedWithoutStatic = () => (
+export const DynamicOnly = () => (
   <MemoryRouter>
     <LoginTrait {...props} staticLogins={[]} />
   </MemoryRouter>
 );
 
-export const EmptyWithStatic = () => (
+export const StaticOnly = () => (
   <MemoryRouter>
     <LoginTrait {...props} dynamicLogins={[]} />
   </MemoryRouter>
 );
 
-export const EmptyWithoutStatic = () => (
+export const NoLogins = () => (
   <MemoryRouter>
     <LoginTrait {...props} dynamicLogins={[]} staticLogins={[]} />
   </MemoryRouter>
@@ -78,4 +113,6 @@ const props: State = {
   nextStep: () => null,
   addLogin: () => null,
   fetchLoginTraits: () => null,
+  canEditUser: true,
+  isSsoUser: false,
 };

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
@@ -40,6 +40,8 @@ describe('login trait comp behavior', () => {
           agentMeta={mockedNodeMeta}
           updateAgentMeta={() => null}
           nextStep={() => null}
+          selectedAgentKind="server"
+          onSelectResource={() => null}
         />
       </ContextProvider>
     </MemoryRouter>

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
@@ -26,32 +26,42 @@ import makeAcl from 'teleport/services/user/makeAcl';
 
 import LoginTrait from './LoginTrait';
 
-import type { User } from 'teleport/services/user';
+import type { User, UserContext } from 'teleport/services/user';
 import type { NodeMeta } from '../useDiscover';
 
 describe('login trait comp behavior', () => {
-  const ctx = new TeleportContext();
-  const userSvc = ctx.userService;
+  const setup = (mockUserContext: Partial<UserContext>, mockUser: User) => {
+    const ctx = new TeleportContext();
+    ctx.storeUser.setState(mockUserContext);
+    const userSvc = ctx.userService;
 
-  const Component = () => (
-    <MemoryRouter>
-      <ContextProvider ctx={ctx}>
-        <LoginTrait
-          agentMeta={mockedNodeMeta}
-          updateAgentMeta={() => null}
-          nextStep={() => null}
-          selectedAgentKind="server"
-          onSelectResource={() => null}
-        />
-      </ContextProvider>
-    </MemoryRouter>
-  );
+    jest.spyOn(userSvc, 'fetchUser').mockResolvedValue(mockUser);
+    jest.spyOn(userSvc, 'updateUser').mockResolvedValue(null);
+    jest.spyOn(userSvc, 'applyUserTraits').mockResolvedValue(null);
+
+    render(
+      <MemoryRouter>
+        <ContextProvider ctx={ctx}>
+          <LoginTrait
+            agentMeta={mockedNodeMeta}
+            updateAgentMeta={() => null}
+            nextStep={() => null}
+            selectedAgentKind="server"
+            onSelectResource={() => null}
+          />
+        </ContextProvider>
+      </MemoryRouter>
+    );
+
+    return { userSvc };
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   test('add a new login with no existing logins', async () => {
-    ctx.storeUser.setState(userContext);
-    jest.spyOn(userSvc, 'fetchUser').mockResolvedValue(mockUser);
-
-    render(<Component />);
+    setup(userContext, mockUser);
 
     // Expect no checkboxes to be rendered.
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
@@ -65,18 +75,7 @@ describe('login trait comp behavior', () => {
   });
 
   test('add a new login with existing logins', async () => {
-    const user = {
-      ...mockUser,
-      traits: {
-        ...mockUser.traits,
-        logins: ['apple', 'banana'],
-      },
-    };
-
-    jest.spyOn(userSvc, 'fetchUser').mockResolvedValue(user);
-    jest.spyOn(userSvc, 'updateUser').mockResolvedValue(null);
-
-    render(<Component />);
+    const { userSvc } = setup(userContext, mockUserWithLoginTrait);
 
     // Test existing logins to be rendered.
     await waitFor(() => {
@@ -98,9 +97,36 @@ describe('login trait comp behavior', () => {
 
     fireEvent.click(screen.getByText(/next/i));
     expect(userSvc.updateUser).toHaveBeenCalledWith({
-      ...user,
-      traits: { ...user.traits, logins: [...user.traits.logins, 'carrot'] },
+      ...mockUserWithLoginTrait,
+      traits: {
+        ...mockUserWithLoginTrait.traits,
+        logins: [...mockUserWithLoginTrait.traits.logins, 'carrot'],
+      },
     });
+  });
+
+  test('skipping api calls without perms', async () => {
+    const { userSvc } = setup(
+      { ...userContext, acl: makeAcl({ users: { edit: false } }) },
+      mockUserWithLoginTrait
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+    });
+    fireEvent.click(screen.getByText(/next/i));
+    expect(userSvc.updateUser).not.toHaveBeenCalled();
+  });
+
+  test('skipping api calls when user used sso', async () => {
+    const { userSvc } = setup(
+      { ...userContext, authType: 'sso' },
+      mockUserWithLoginTrait
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+    });
+    fireEvent.click(screen.getByText(/next/i));
+    expect(userSvc.updateUser).not.toHaveBeenCalled();
   });
 });
 
@@ -115,6 +141,14 @@ const mockUser: User = {
     kubeGroups: [],
     windowsLogins: [],
     awsRoleArns: [],
+  },
+};
+
+const mockUserWithLoginTrait: User = {
+  ...mockUser,
+  traits: {
+    ...mockUser.traits,
+    logins: ['apple', 'banana'],
   },
 };
 

--- a/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
+++ b/packages/teleport/src/Discover/LoginTrait/LoginTrait.test.tsx
@@ -22,6 +22,7 @@ import { MemoryRouter } from 'react-router';
 
 import TeleportContext from 'teleport/teleportContext';
 import ContextProvider from 'teleport/TeleportContextProvider';
+import makeAcl from 'teleport/services/user/makeAcl';
 
 import LoginTrait from './LoginTrait';
 
@@ -45,6 +46,7 @@ describe('login trait comp behavior', () => {
   );
 
   test('add a new login with no existing logins', async () => {
+    ctx.storeUser.setState(userContext);
     jest.spyOn(userSvc, 'fetchUser').mockResolvedValue(mockUser);
 
     render(<Component />);
@@ -125,4 +127,9 @@ const mockedNodeMeta: NodeMeta = {
     addr: '',
     tunnel: false,
   },
+};
+
+const userContext = {
+  acl: makeAcl({ users: { edit: true } }),
+  authType: 'local' as const,
 };

--- a/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
@@ -578,6 +578,875 @@ exports[`logins and is  SSO user 1`] = `
   margin-bottom: 16px;
 }
 
+.c10 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c11 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c11:active {
+  opacity: 0.56;
+}
+
+.c11:hover,
+.c11:focus {
+  background: #651FFF;
+}
+
+.c11:active {
+  background: #354AA4;
+}
+
+.c11:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c12 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c12:active {
+  opacity: 0.56;
+}
+
+.c12:hover,
+.c12:focus {
+  background: #2C3A73;
+}
+
+.c12:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-top: 24px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  min-height: 115px;
+  display: flex;
+}
+
+.c9 {
+  overflow: hidden;
+  border-radius: 4px;
+  flex: 1;
+  display: flex;
+  position: relative;
+  border: none;
+  background: #010B1C;
+}
+
+.c9 .ace-monokai {
+  background: #010B1C;
+}
+
+.c9 .ace-monokai .ace_gutter,
+.c9 .ace-monokai .ace_gutter-cell {
+  color: rgba(255,255,255,0.56);
+  background: #010B1C;
+}
+
+.c9 > .ace_editor {
+  position: absolute;
+  top: 8px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+  padding: 8px;
+  margin-bottom: 4px;
+  width: 300px;
+  align-items: center;
+  border: 1px solid #222C59;
+  border-radius: 8px;
+}
+
+.c4.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.c5 {
+  margin-right: 10px;
+  accent-color: #512FC9;
+}
+
+.c5:hover {
+  cursor: pointer;
+}
+
+.c6 {
+  width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    font-size="18px"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select the OS users you will use to connect to server.
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="ubunutu0"
+        name="ubunutu"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="ubunutu0"
+      >
+        ubunutu
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="debian1"
+        name="debian"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="debian1"
+      >
+        debian
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="root0"
+        name="root"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="root0"
+      >
+        root
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="llama1"
+        name="llama"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="llama1"
+      >
+        llama
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="george_washington_really_long_name_testing2"
+        name="george_washington_really_long_name_testing"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="george_washington_really_long_name_testing2"
+      >
+        george_washington_really_long_name_testing
+      </label>
+    </div>
+    <div
+      class="c7"
+    >
+      SSO users are not able to add new OS users.
+      <br />
+      If you don't see the OS user that you require, please ask your Teleport administrator to update your role to add the required OS users (logins):
+    </div>
+    <div
+      class="c8"
+    >
+      <div
+        class="c9"
+      >
+        <div
+          class=" ace_editor ace_hidpi ace-monokai ace_dark ace_focus"
+        >
+          <textarea
+            autocapitalize="off"
+            autocorrect="off"
+            class="ace_text-input"
+            readonly=""
+            spellcheck="false"
+            style="opacity: 0; font-size: 1px; position: fixed; top: 0px;"
+            wrap="off"
+          />
+          <div
+            aria-hidden="true"
+            class="ace_gutter ace_fade-fold-widgets"
+            style="display: block;"
+          >
+            <div
+              class="ace_layer ace_gutter-layer ace_folding-enabled"
+              style="height: 1000000px;"
+            />
+          </div>
+          <div
+            class="ace_scroller"
+            style="line-height: 0px;"
+          >
+            <div
+              class="ace_content"
+            >
+              <div
+                class="ace_layer ace_print-margin-layer"
+              >
+                <div
+                  class="ace_print-margin"
+                  style="left: 4px; visibility: hidden;"
+                />
+              </div>
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_text-layer"
+                style="height: 1000000px; margin: 0px 4px;"
+              />
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_cursor-layer"
+              >
+                <div
+                  class="ace_cursor"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-v"
+            style="display: none; width: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="width: 20px;"
+            >
+               
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-h"
+            style="display: none; height: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="height: 20px;"
+            >
+               
+            </div>
+          </div>
+          <div
+            style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: hidden;"
+          >
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            />
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            >
+              XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c10"
+  >
+    
+    <button
+      class="c11"
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c12"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`logins with no perms 1`] = `
+.c0 {
+  box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
+.c11 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c12 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c12:active {
+  opacity: 0.56;
+}
+
+.c12:hover,
+.c12:focus {
+  background: #651FFF;
+}
+
+.c12:active {
+  background: #354AA4;
+}
+
+.c12:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c13 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c13:active {
+  opacity: 0.56;
+}
+
+.c13:hover,
+.c13:focus {
+  background: #2C3A73;
+}
+
+.c13:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-top: 24px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  min-height: 185px;
+  display: flex;
+}
+
+.c10 {
+  overflow: hidden;
+  border-radius: 4px;
+  flex: 1;
+  display: flex;
+  position: relative;
+  border: none;
+  background: #010B1C;
+}
+
+.c10 .ace-monokai {
+  background: #010B1C;
+}
+
+.c10 .ace-monokai .ace_gutter,
+.c10 .ace-monokai .ace_gutter-cell {
+  color: rgba(255,255,255,0.56);
+  background: #010B1C;
+}
+
+.c10 > .ace_editor {
+  position: absolute;
+  top: 8px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.c8 {
+  padding: 2px 5px;
+  border-radius: 6px;
+  background-color: rgb(255 255 255 / 17%);
+  color: inherit;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+  padding: 8px;
+  margin-bottom: 4px;
+  width: 300px;
+  align-items: center;
+  border: 1px solid #222C59;
+  border-radius: 8px;
+}
+
+.c4.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.c5 {
+  margin-right: 10px;
+  accent-color: #512FC9;
+}
+
+.c5:hover {
+  cursor: pointer;
+}
+
+.c6 {
+  width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    font-size="18px"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select the OS users you will use to connect to server.
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="ubunutu0"
+        name="ubunutu"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="ubunutu0"
+      >
+        ubunutu
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="debian1"
+        name="debian"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="debian1"
+      >
+        debian
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="root0"
+        name="root"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="root0"
+      >
+        root
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="llama1"
+        name="llama"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="llama1"
+      >
+        llama
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="george_washington_really_long_name_testing2"
+        name="george_washington_really_long_name_testing"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="george_washington_really_long_name_testing2"
+      >
+        george_washington_really_long_name_testing
+      </label>
+    </div>
+    <div
+      class="c7"
+    >
+      You don't have permission to add new OS users.
+      <br />
+      If you don't see the OS user that you require, please ask your Teleport administrator to update your role to either add the required OS users (logins) or add the 
+      <mark
+        class="c8"
+      >
+        users
+      </mark>
+       rule:
+    </div>
+    <div
+      class="c9"
+    >
+      <div
+        class="c10"
+      >
+        <div
+          class=" ace_editor ace_hidpi ace-monokai ace_dark ace_focus"
+        >
+          <textarea
+            autocapitalize="off"
+            autocorrect="off"
+            class="ace_text-input"
+            readonly=""
+            spellcheck="false"
+            style="opacity: 0; font-size: 1px; position: fixed; top: 0px;"
+            wrap="off"
+          />
+          <div
+            aria-hidden="true"
+            class="ace_gutter ace_fade-fold-widgets"
+            style="display: block;"
+          >
+            <div
+              class="ace_layer ace_gutter-layer ace_folding-enabled"
+              style="height: 1000000px;"
+            />
+          </div>
+          <div
+            class="ace_scroller"
+            style="line-height: 0px;"
+          >
+            <div
+              class="ace_content"
+            >
+              <div
+                class="ace_layer ace_print-margin-layer"
+              >
+                <div
+                  class="ace_print-margin"
+                  style="left: 4px; visibility: hidden;"
+                />
+              </div>
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_text-layer"
+                style="height: 1000000px; margin: 0px 4px;"
+              />
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_cursor-layer"
+              >
+                <div
+                  class="ace_cursor"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-v"
+            style="display: none; width: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="width: 20px;"
+            >
+               
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-h"
+            style="display: none; height: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="height: 20px;"
+            >
+               
+            </div>
+          </div>
+          <div
+            style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: hidden;"
+          >
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            />
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            >
+              XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c11"
+  >
+    
+    <button
+      class="c12"
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c13"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`no logins and perms 1`] = `
+.c0 {
+  box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
 .c8 {
   box-sizing: border-box;
   margin-top: 24px;
@@ -688,612 +1557,46 @@ exports[`logins and is  SSO user 1`] = `
   margin-bottom: 32px;
 }
 
-.c7 {
+.c4 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
   margin-top: 24px;
 }
 
-.c4 {
-  box-sizing: border-box;
-  display: flex;
-  padding: 8px;
-  margin-bottom: 4px;
-  width: 300px;
-  align-items: center;
-  border: 1px solid #222C59;
-  border-radius: 8px;
-}
-
-.c4.disabled {
-  pointer-events: none;
-  opacity: 0.5;
-}
-
-.c5 {
-  margin-right: 10px;
-  accent-color: #512FC9;
-}
-
-.c5:hover {
-  cursor: pointer;
-}
-
 .c6 {
-  width: 250px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    font-size="18px"
-  >
-    Set Up Access
-  </div>
-  <div
-    class="c2"
-  >
-    Select the OS users you will use to connect to server.
-  </div>
-  <div
-    class="c3"
-  >
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="ubunutu0"
-        name="ubunutu"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="ubunutu0"
-      >
-        ubunutu
-      </label>
-    </div>
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="debian1"
-        name="debian"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="debian1"
-      >
-        debian
-      </label>
-    </div>
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="root0"
-        name="root"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="root0"
-      >
-        root
-      </label>
-    </div>
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="llama1"
-        name="llama"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="llama1"
-      >
-        llama
-      </label>
-    </div>
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="george_washington_really_long_name_testing2"
-        name="george_washington_really_long_name_testing"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="george_washington_really_long_name_testing2"
-      >
-        george_washington_really_long_name_testing
-      </label>
-    </div>
-    <div
-      class="c7"
-    >
-      SSO users are not able to add new logins.
-      <br />
-      If you don't see the login that you require, please ask your Teleport administrator to update your role to add the required logins.
-    </div>
-  </div>
-  <div
-    class="c8"
-  >
-    
-    <button
-      class="c9"
-      kind="primary"
-      width="165px"
-    >
-      Next
-    </button>
-    <a
-      class="c10"
-      href="/web"
-      kind="secondary"
-      mt="3"
-      theme="[object Object]"
-      width="165px"
-    >
-      Exit
-    </a>
-  </div>
-</div>
-`;
-
-exports[`logins with no perms 1`] = `
-.c0 {
   box-sizing: border-box;
-  max-width: 700px;
-}
-
-.c3 {
-  box-sizing: border-box;
-  margin-bottom: 16px;
-}
-
-.c9 {
-  box-sizing: border-box;
-  margin-top: 24px;
-}
-
-.c10 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  margin-right: 16px;
-  width: 165px;
-}
-
-.c10:active {
-  opacity: 0.56;
-}
-
-.c10:hover,
-.c10:focus {
-  background: #651FFF;
-}
-
-.c10:active {
-  background: #354AA4;
-}
-
-.c10:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c11 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #222C59;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
   margin-top: 16px;
-  width: 165px;
-}
-
-.c11:active {
-  opacity: 0.56;
-}
-
-.c11:hover,
-.c11:focus {
-  background: #2C3A73;
-}
-
-.c11:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c1 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  font-size: 18px;
-  margin: 0px;
-  margin-top: 4px;
-  margin-bottom: 4px;
-}
-
-.c2 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-  margin-bottom: 32px;
-}
-
-.c7 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-  margin-top: 24px;
-}
-
-.c8 {
-  padding: 2px 5px;
-  border-radius: 6px;
-  background-color: rgb(255 255 255 / 17%);
-  color: inherit;
-}
-
-.c4 {
-  box-sizing: border-box;
+  min-height: 185px;
   display: flex;
-  padding: 8px;
-  margin-bottom: 4px;
-  width: 300px;
-  align-items: center;
-  border: 1px solid #222C59;
-  border-radius: 8px;
-}
-
-.c4.disabled {
-  pointer-events: none;
-  opacity: 0.5;
-}
-
-.c5 {
-  margin-right: 10px;
-  accent-color: #512FC9;
-}
-
-.c5:hover {
-  cursor: pointer;
-}
-
-.c6 {
-  width: 250px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    font-size="18px"
-  >
-    Set Up Access
-  </div>
-  <div
-    class="c2"
-  >
-    Select the OS users you will use to connect to server.
-  </div>
-  <div
-    class="c3"
-  >
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="ubunutu0"
-        name="ubunutu"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="ubunutu0"
-      >
-        ubunutu
-      </label>
-    </div>
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="debian1"
-        name="debian"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="debian1"
-      >
-        debian
-      </label>
-    </div>
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="root0"
-        name="root"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="root0"
-      >
-        root
-      </label>
-    </div>
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="llama1"
-        name="llama"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="llama1"
-      >
-        llama
-      </label>
-    </div>
-    <div
-      class="c4 disabled"
-    >
-      <input
-        checked=""
-        class="c5"
-        id="george_washington_really_long_name_testing2"
-        name="george_washington_really_long_name_testing"
-        type="checkbox"
-      />
-      <label
-        class="c6"
-        for="george_washington_really_long_name_testing2"
-      >
-        george_washington_really_long_name_testing
-      </label>
-    </div>
-    <div
-      class="c7"
-    >
-      You don't have permission to add new logins.
-      <br />
-      If you don't see the login that you require, please ask your Teleport administrator to update your role to either add the required logins or add the rule 
-      <mark
-        class="c8"
-      >
-        users.update
-      </mark>
-      .
-    </div>
-  </div>
-  <div
-    class="c9"
-  >
-    
-    <button
-      class="c10"
-      kind="primary"
-      width="165px"
-    >
-      Next
-    </button>
-    <a
-      class="c11"
-      href="/web"
-      kind="secondary"
-      mt="3"
-      theme="[object Object]"
-      width="165px"
-    >
-      Exit
-    </a>
-  </div>
-</div>
-`;
-
-exports[`no logins and perms 1`] = `
-.c0 {
-  box-sizing: border-box;
-  max-width: 700px;
-}
-
-.c3 {
-  box-sizing: border-box;
-  margin-bottom: 16px;
-}
-
-.c6 {
-  box-sizing: border-box;
-  margin-top: 24px;
 }
 
 .c7 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
+  overflow: hidden;
   border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
+  flex: 1;
+  display: flex;
   position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  margin-right: 16px;
-  width: 165px;
-}
-
-.c7:active {
-  opacity: 0.56;
-}
-
-.c7:hover,
-.c7:focus {
-  background: #651FFF;
-}
-
-.c7:active {
-  background: #354AA4;
-}
-
-.c7:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c8 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
   border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #222C59;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  margin-top: 16px;
-  width: 165px;
+  background: #010B1C;
 }
 
-.c8:active {
-  opacity: 0.56;
+.c7 .ace-monokai {
+  background: #010B1C;
 }
 
-.c8:hover,
-.c8:focus {
-  background: #2C3A73;
+.c7 .ace-monokai .ace_gutter,
+.c7 .ace-monokai .ace_gutter-cell {
+  color: rgba(255,255,255,0.56);
+  background: #010B1C;
 }
 
-.c8:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c1 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  font-size: 18px;
-  margin: 0px;
-  margin-top: 4px;
-  margin-bottom: 4px;
-}
-
-.c2 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-  margin-bottom: 32px;
-}
-
-.c4 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-  margin-top: 24px;
+.c7 > .ace_editor {
+  position: absolute;
+  top: 8px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
 }
 
 .c5 {
@@ -1324,23 +1627,123 @@ exports[`no logins and perms 1`] = `
       class="c4"
       width="100px"
     >
-      You don’t have any allowed logins and permission to add new logins.
+      You don’t have any allowed OS users or permission to add new OS users.
       <br />
-      Please ask your Teleport administrator to update your role to either add the required logins or add the rule 
+      Please ask your Teleport administrator to update your role to either add the required OS users (logins) or add the
+       
       <mark
         class="c5"
       >
-        users.update
+        users
       </mark>
-      .
+      rule:
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <div
+          class=" ace_editor ace_hidpi ace-monokai ace_dark ace_focus"
+        >
+          <textarea
+            autocapitalize="off"
+            autocorrect="off"
+            class="ace_text-input"
+            readonly=""
+            spellcheck="false"
+            style="opacity: 0; font-size: 1px; position: fixed; top: 0px;"
+            wrap="off"
+          />
+          <div
+            aria-hidden="true"
+            class="ace_gutter ace_fade-fold-widgets"
+            style="display: block;"
+          >
+            <div
+              class="ace_layer ace_gutter-layer ace_folding-enabled"
+              style="height: 1000000px;"
+            />
+          </div>
+          <div
+            class="ace_scroller"
+            style="line-height: 0px;"
+          >
+            <div
+              class="ace_content"
+            >
+              <div
+                class="ace_layer ace_print-margin-layer"
+              >
+                <div
+                  class="ace_print-margin"
+                  style="left: 4px; visibility: hidden;"
+                />
+              </div>
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_text-layer"
+                style="height: 1000000px; margin: 0px 4px;"
+              />
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_cursor-layer"
+              >
+                <div
+                  class="ace_cursor"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-v"
+            style="display: none; width: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="width: 20px;"
+            >
+               
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-h"
+            style="display: none; height: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="height: 20px;"
+            >
+               
+            </div>
+          </div>
+          <div
+            style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: hidden;"
+          >
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            />
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            >
+              XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
-    class="c6"
+    class="c8"
   >
     
     <button
-      class="c7"
+      class="c9"
       disabled=""
       kind="primary"
       width="165px"
@@ -1348,7 +1751,7 @@ exports[`no logins and perms 1`] = `
       Next
     </button>
     <a
-      class="c8"
+      class="c10"
       href="/web"
       kind="secondary"
       mt="3"
@@ -1643,12 +2046,12 @@ exports[`no logins, perms, and is a SSO user 1`] = `
   margin-bottom: 16px;
 }
 
-.c5 {
+.c7 {
   box-sizing: border-box;
   margin-top: 24px;
 }
 
-.c6 {
+.c8 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -1676,25 +2079,25 @@ exports[`no logins, perms, and is a SSO user 1`] = `
   width: 165px;
 }
 
-.c6:active {
+.c8:active {
   opacity: 0.56;
 }
 
-.c6:hover,
-.c6:focus {
+.c8:hover,
+.c8:focus {
   background: #651FFF;
 }
 
-.c6:active {
+.c8:active {
   background: #354AA4;
 }
 
-.c6:disabled {
+.c8:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c7 {
+.c9 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -1722,16 +2125,16 @@ exports[`no logins, perms, and is a SSO user 1`] = `
   width: 165px;
 }
 
-.c7:active {
+.c9:active {
   opacity: 0.56;
 }
 
-.c7:hover,
-.c7:focus {
+.c9:hover,
+.c9:focus {
   background: #2C3A73;
 }
 
-.c7:disabled {
+.c9:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
@@ -1760,6 +2163,41 @@ exports[`no logins, perms, and is a SSO user 1`] = `
   margin-top: 24px;
 }
 
+.c5 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  min-height: 115px;
+  display: flex;
+}
+
+.c6 {
+  overflow: hidden;
+  border-radius: 4px;
+  flex: 1;
+  display: flex;
+  position: relative;
+  border: none;
+  background: #010B1C;
+}
+
+.c6 .ace-monokai {
+  background: #010B1C;
+}
+
+.c6 .ace-monokai .ace_gutter,
+.c6 .ace-monokai .ace_gutter-cell {
+  color: rgba(255,255,255,0.56);
+  background: #010B1C;
+}
+
+.c6 > .ace_editor {
+  position: absolute;
+  top: 8px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
 <div
   class="c0"
 >
@@ -1781,17 +2219,116 @@ exports[`no logins, perms, and is a SSO user 1`] = `
       class="c4"
       width="100px"
     >
-      You don’t have any allowed logins.
+      You don’t have any allowed OS users defined.
       <br />
-      Please ask your Teleport administrator to update your role and add the required logins.
+      Please ask your Teleport administrator to update your role and add the required OS users (logins).
+    </div>
+    <div
+      class="c5"
+    >
+      <div
+        class="c6"
+      >
+        <div
+          class=" ace_editor ace_hidpi ace-monokai ace_dark ace_focus"
+        >
+          <textarea
+            autocapitalize="off"
+            autocorrect="off"
+            class="ace_text-input"
+            readonly=""
+            spellcheck="false"
+            style="opacity: 0; font-size: 1px; position: fixed; top: 0px;"
+            wrap="off"
+          />
+          <div
+            aria-hidden="true"
+            class="ace_gutter ace_fade-fold-widgets"
+            style="display: block;"
+          >
+            <div
+              class="ace_layer ace_gutter-layer ace_folding-enabled"
+              style="height: 1000000px;"
+            />
+          </div>
+          <div
+            class="ace_scroller"
+            style="line-height: 0px;"
+          >
+            <div
+              class="ace_content"
+            >
+              <div
+                class="ace_layer ace_print-margin-layer"
+              >
+                <div
+                  class="ace_print-margin"
+                  style="left: 4px; visibility: hidden;"
+                />
+              </div>
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_text-layer"
+                style="height: 1000000px; margin: 0px 4px;"
+              />
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_cursor-layer"
+              >
+                <div
+                  class="ace_cursor"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-v"
+            style="display: none; width: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="width: 20px;"
+            >
+               
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-h"
+            style="display: none; height: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="height: 20px;"
+            >
+               
+            </div>
+          </div>
+          <div
+            style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: hidden;"
+          >
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            />
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            >
+              XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
-    class="c5"
+    class="c7"
   >
     
     <button
-      class="c6"
+      class="c8"
       disabled=""
       kind="primary"
       width="165px"
@@ -1799,7 +2336,7 @@ exports[`no logins, perms, and is a SSO user 1`] = `
       Next
     </button>
     <a
-      class="c7"
+      class="c9"
       href="/web"
       kind="secondary"
       mt="3"

--- a/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
+++ b/packages/teleport/src/Discover/LoginTrait/__snapshots__/LoginTrait.story.test.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`empty state 1`] = `
+exports[`dynamic only logins with perms 1`] = `
 .c0 {
   box-sizing: border-box;
   max-width: 700px;
 }
 
-.c4 {
+.c3 {
   box-sizing: border-box;
   margin-bottom: 16px;
 }
@@ -170,15 +170,7 @@ exports[`empty state 1`] = `
   margin-bottom: 32px;
 }
 
-.c3 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  margin: 0px;
-  margin-bottom: 8px;
-}
-
-.c5 {
+.c4 {
   box-sizing: border-box;
   display: flex;
   padding: 8px;
@@ -189,17 +181,24 @@ exports[`empty state 1`] = `
   border-radius: 8px;
 }
 
-.c5.disabled {
+.c4.disabled {
   pointer-events: none;
   opacity: 0.5;
 }
 
+.c5 {
+  margin-right: 10px;
+  accent-color: #512FC9;
+}
+
+.c5:hover {
+  cursor: pointer;
+}
+
 .c6 {
+  width: 250px;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin: 0px;
-  font-style: italic;
-  overflow: visible;
 }
 
 .c8 {
@@ -233,19 +232,56 @@ exports[`empty state 1`] = `
   <div
     class="c3"
   >
-    Select OS Users
-  </div>
-  <div
-    class="c4"
-  >
     <div
-      class="c5"
+      class="c4"
     >
-      <div
+      <input
+        checked=""
+        class="c5"
+        id="root0"
+        name="root"
+        type="checkbox"
+      />
+      <label
         class="c6"
+        for="root0"
       >
-        No OS users added
-      </div>
+        root
+      </label>
+    </div>
+    <div
+      class="c4"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="llama1"
+        name="llama"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="llama1"
+      >
+        llama
+      </label>
+    </div>
+    <div
+      class="c4"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="george_washington_really_long_name_testing2"
+        name="george_washington_really_long_name_testing"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="george_washington_really_long_name_testing2"
+      >
+        george_washington_really_long_name_testing
+      </label>
     </div>
     <button
       class="c7 c8"
@@ -264,7 +300,6 @@ exports[`empty state 1`] = `
     
     <button
       class="c12"
-      disabled=""
       kind="primary"
       width="165px"
     >
@@ -272,321 +307,6 @@ exports[`empty state 1`] = `
     </button>
     <a
       class="c13"
-      href="/web"
-      kind="secondary"
-      mt="3"
-      theme="[object Object]"
-      width="165px"
-    >
-      Exit
-    </a>
-  </div>
-</div>
-`;
-
-exports[`empty state with static logins 1`] = `
-.c0 {
-  box-sizing: border-box;
-  max-width: 700px;
-}
-
-.c4 {
-  box-sizing: border-box;
-  margin-bottom: 16px;
-}
-
-.c12 {
-  box-sizing: border-box;
-  margin-top: 24px;
-}
-
-.c8 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: none;
-  text-transform: none;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  margin-top: 8px;
-}
-
-.c8:active {
-  opacity: 0.56;
-}
-
-.c8:hover,
-.c8:focus {
-  background: none;
-  text-decoration: underline;
-}
-
-.c8:disabled {
-  background: none;
-  color: rgba(255,255,255,0.3);
-}
-
-.c13 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #512FC9;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  margin-right: 16px;
-  width: 165px;
-}
-
-.c13:active {
-  opacity: 0.56;
-}
-
-.c13:hover,
-.c13:focus {
-  background: #651FFF;
-}
-
-.c13:active {
-  background: #354AA4;
-}
-
-.c13:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c14 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #222C59;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  margin-top: 16px;
-  width: 165px;
-}
-
-.c14:active {
-  opacity: 0.56;
-}
-
-.c14:hover,
-.c14:focus {
-  background: #2C3A73;
-}
-
-.c14:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c10 {
-  display: inline-block;
-  transition: color 0.3s;
-  color: #FFFFFF;
-}
-
-.c1 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  font-size: 18px;
-  margin: 0px;
-  margin-top: 4px;
-  margin-bottom: 4px;
-}
-
-.c2 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-  margin-bottom: 32px;
-}
-
-.c3 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  margin: 0px;
-  margin-bottom: 8px;
-}
-
-.c5 {
-  box-sizing: border-box;
-  display: flex;
-  padding: 8px;
-  margin-bottom: 4px;
-  width: 300px;
-  align-items: center;
-  border: 1px solid #222C59;
-  border-radius: 8px;
-}
-
-.c5.disabled {
-  pointer-events: none;
-  opacity: 0.5;
-}
-
-.c6 {
-  margin-right: 10px;
-  accent-color: #512FC9;
-}
-
-.c6:hover {
-  cursor: pointer;
-}
-
-.c7 {
-  width: 250px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c9 {
-  line-height: normal;
-  padding-left: 4px;
-}
-
-.c11 {
-  font-weight: bold;
-  letter-spacing: 4px;
-}
-
-.c11:after {
-  content: ' ';
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    font-size="18px"
-  >
-    Set Up Access
-  </div>
-  <div
-    class="c2"
-  >
-    Select the OS users you will use to connect to server.
-  </div>
-  <div
-    class="c3"
-  >
-    Select OS Users
-  </div>
-  <div
-    class="c4"
-  >
-    <div
-      class="c5 disabled"
-    >
-      <input
-        checked=""
-        class="c6"
-        id="ubunutu0"
-        name="ubunutu"
-        type="checkbox"
-      />
-      <label
-        class="c7"
-        for="ubunutu0"
-      >
-        ubunutu
-      </label>
-    </div>
-    <div
-      class="c5 disabled"
-    >
-      <input
-        checked=""
-        class="c6"
-        id="debian1"
-        name="debian"
-        type="checkbox"
-      />
-      <label
-        class="c7"
-        for="debian1"
-      >
-        debian
-      </label>
-    </div>
-    <button
-      class="c8 c9"
-      kind="text"
-    >
-      <span
-        class="c10 icon icon-add c11"
-        color="light"
-      />
-      Add new OS User
-    </button>
-  </div>
-  <div
-    class="c12"
-  >
-    
-    <button
-      class="c13"
-      kind="primary"
-      width="165px"
-    >
-      Next
-    </button>
-    <a
-      class="c14"
       href="/web"
       kind="secondary"
       mt="3"
@@ -605,17 +325,17 @@ exports[`failed 1`] = `
   max-width: 700px;
 }
 
-.c4 {
+.c3 {
   box-sizing: border-box;
   margin-bottom: 16px;
 }
 
-.c9 {
+.c8 {
   box-sizing: border-box;
   margin-top: 24px;
 }
 
-.c7 {
+.c6 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -643,19 +363,518 @@ exports[`failed 1`] = `
   margin-left: 4px;
 }
 
-.c7:active {
+.c6:active {
   opacity: 0.56;
 }
 
-.c7:hover,
-.c7:focus {
+.c6:hover,
+.c6:focus {
   background: none;
   text-decoration: underline;
 }
 
-.c7:disabled {
+.c6:disabled {
   background: none;
   color: rgba(255,255,255,0.3);
+}
+
+.c9 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c9:active {
+  opacity: 0.56;
+}
+
+.c9:hover,
+.c9:focus {
+  background: #651FFF;
+}
+
+.c9:active {
+  background: #354AA4;
+}
+
+.c9:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c10:active {
+  opacity: 0.56;
+}
+
+.c10:hover,
+.c10:focus {
+  background: #2C3A73;
+}
+
+.c10:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c5 {
+  display: inline-block;
+  transition: color 0.3s;
+  margin-left: 4px;
+  margin-right: 8px;
+  color: #f50057;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c7 {
+  color: #03a9f4;
+  font-weight: normal;
+  padding-left: 0;
+  font-size: inherit;
+  min-height: auto;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    font-size="18px"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select the OS users you will use to connect to server.
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4"
+    >
+      <span
+        class="c5 icon icon-warning "
+        color="danger"
+      />
+      Encountered Error: 
+      some error message
+    </div>
+    <button
+      class="c6 c7"
+      kind="text"
+    >
+      Refetch OS Users
+    </button>
+  </div>
+  <div
+    class="c8"
+  >
+    
+    <button
+      class="c9"
+      disabled=""
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c10"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`logins and is  SSO user 1`] = `
+.c0 {
+  box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c9 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c9:active {
+  opacity: 0.56;
+}
+
+.c9:hover,
+.c9:focus {
+  background: #651FFF;
+}
+
+.c9:active {
+  background: #354AA4;
+}
+
+.c9:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c10:active {
+  opacity: 0.56;
+}
+
+.c10:hover,
+.c10:focus {
+  background: #2C3A73;
+}
+
+.c10:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-top: 24px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+  padding: 8px;
+  margin-bottom: 4px;
+  width: 300px;
+  align-items: center;
+  border: 1px solid #222C59;
+  border-radius: 8px;
+}
+
+.c4.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.c5 {
+  margin-right: 10px;
+  accent-color: #512FC9;
+}
+
+.c5:hover {
+  cursor: pointer;
+}
+
+.c6 {
+  width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    font-size="18px"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select the OS users you will use to connect to server.
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="ubunutu0"
+        name="ubunutu"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="ubunutu0"
+      >
+        ubunutu
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="debian1"
+        name="debian"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="debian1"
+      >
+        debian
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="root0"
+        name="root"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="root0"
+      >
+        root
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="llama1"
+        name="llama"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="llama1"
+      >
+        llama
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="george_washington_really_long_name_testing2"
+        name="george_washington_really_long_name_testing"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="george_washington_really_long_name_testing2"
+      >
+        george_washington_really_long_name_testing
+      </label>
+    </div>
+    <div
+      class="c7"
+    >
+      SSO users are not able to add new logins.
+      <br />
+      If you don't see the login that you require, please ask your Teleport administrator to update your role to add the required logins.
+    </div>
+  </div>
+  <div
+    class="c8"
+  >
+    
+    <button
+      class="c9"
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c10"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`logins with no perms 1`] = `
+.c0 {
+  box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-top: 24px;
 }
 
 .c10 {
@@ -746,14 +965,6 @@ exports[`failed 1`] = `
   color: rgba(255,255,255,0.3);
 }
 
-.c6 {
-  display: inline-block;
-  transition: color 0.3s;
-  margin-left: 4px;
-  margin-right: 8px;
-  color: #f50057;
-}
-
 .c1 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -771,28 +982,49 @@ exports[`failed 1`] = `
   margin-bottom: 32px;
 }
 
-.c3 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  margin: 0px;
-  margin-bottom: 8px;
-}
-
-.c5 {
+.c7 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  margin-top: 24px;
 }
 
 .c8 {
-  color: #03a9f4;
-  font-weight: normal;
-  padding-left: 0;
-  font-size: inherit;
-  min-height: auto;
+  padding: 2px 5px;
+  border-radius: 6px;
+  background-color: rgb(255 255 255 / 17%);
+  color: inherit;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+  padding: 8px;
+  margin-bottom: 4px;
+  width: 300px;
+  align-items: center;
+  border: 1px solid #222C59;
+  border-radius: 8px;
+}
+
+.c4.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.c5 {
+  margin-right: 10px;
+  accent-color: #512FC9;
+}
+
+.c5:hover {
+  cursor: pointer;
+}
+
+.c6 {
+  width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 <div
@@ -812,27 +1044,104 @@ exports[`failed 1`] = `
   <div
     class="c3"
   >
-    Select OS Users
-  </div>
-  <div
-    class="c4"
-  >
     <div
-      class="c5"
+      class="c4 disabled"
     >
-      <span
-        class="c6 icon icon-warning "
-        color="danger"
+      <input
+        checked=""
+        class="c5"
+        id="ubunutu0"
+        name="ubunutu"
+        type="checkbox"
       />
-      Encountered Error: 
-      some error message
+      <label
+        class="c6"
+        for="ubunutu0"
+      >
+        ubunutu
+      </label>
     </div>
-    <button
-      class="c7 c8"
-      kind="text"
+    <div
+      class="c4 disabled"
     >
-      Refetch OS Users
-    </button>
+      <input
+        checked=""
+        class="c5"
+        id="debian1"
+        name="debian"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="debian1"
+      >
+        debian
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="root0"
+        name="root"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="root0"
+      >
+        root
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="llama1"
+        name="llama"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="llama1"
+      >
+        llama
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="george_washington_really_long_name_testing2"
+        name="george_washington_really_long_name_testing"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="george_washington_really_long_name_testing2"
+      >
+        george_washington_really_long_name_testing
+      </label>
+    </div>
+    <div
+      class="c7"
+    >
+      You don't have permission to add new logins.
+      <br />
+      If you don't see the login that you require, please ask your Teleport administrator to update your role to either add the required logins or add the rule 
+      <mark
+        class="c8"
+      >
+        users.update
+      </mark>
+      .
+    </div>
   </div>
   <div
     class="c9"
@@ -840,7 +1149,6 @@ exports[`failed 1`] = `
     
     <button
       class="c10"
-      disabled=""
       kind="primary"
       width="165px"
     >
@@ -860,66 +1168,23 @@ exports[`failed 1`] = `
 </div>
 `;
 
-exports[`loaded with static state 1`] = `
+exports[`no logins and perms 1`] = `
 .c0 {
   box-sizing: border-box;
   max-width: 700px;
 }
 
-.c4 {
+.c3 {
   box-sizing: border-box;
   margin-bottom: 16px;
 }
 
-.c12 {
+.c6 {
   box-sizing: border-box;
   margin-top: 24px;
 }
 
-.c8 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: none;
-  text-transform: none;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-  margin-top: 8px;
-}
-
-.c8:active {
-  opacity: 0.56;
-}
-
-.c8:hover,
-.c8:focus {
-  background: none;
-  text-decoration: underline;
-}
-
-.c8:disabled {
-  background: none;
-  color: rgba(255,255,255,0.3);
-}
-
-.c13 {
+.c7 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -947,25 +1212,25 @@ exports[`loaded with static state 1`] = `
   width: 165px;
 }
 
-.c13:active {
+.c7:active {
   opacity: 0.56;
 }
 
-.c13:hover,
-.c13:focus {
+.c7:hover,
+.c7:focus {
   background: #651FFF;
 }
 
-.c13:active {
+.c7:active {
   background: #354AA4;
 }
 
-.c13:disabled {
+.c7:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c14 {
+.c8 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -993,21 +1258,257 @@ exports[`loaded with static state 1`] = `
   width: 165px;
 }
 
-.c14:active {
+.c8:active {
   opacity: 0.56;
 }
 
-.c14:hover,
-.c14:focus {
+.c8:hover,
+.c8:focus {
   background: #2C3A73;
 }
 
-.c14:disabled {
+.c8:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-top: 24px;
+}
+
+.c5 {
+  padding: 2px 5px;
+  border-radius: 6px;
+  background-color: rgb(255 255 255 / 17%);
+  color: inherit;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    font-size="18px"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select the OS users you will use to connect to server.
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4"
+      width="100px"
+    >
+      You don’t have any allowed logins and permission to add new logins.
+      <br />
+      Please ask your Teleport administrator to update your role to either add the required logins or add the rule 
+      <mark
+        class="c5"
+      >
+        users.update
+      </mark>
+      .
+    </div>
+  </div>
+  <div
+    class="c6"
+  >
+    
+    <button
+      class="c7"
+      disabled=""
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c8"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`no logins with perms 1`] = `
+.c0 {
+  box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
 .c10 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c6 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: none;
+  text-transform: none;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 8px;
+}
+
+.c6:active {
+  opacity: 0.56;
+}
+
+.c6:hover,
+.c6:focus {
+  background: none;
+  text-decoration: underline;
+}
+
+.c6:disabled {
+  background: none;
+  color: rgba(255,255,255,0.3);
+}
+
+.c11 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c11:active {
+  opacity: 0.56;
+}
+
+.c11:hover,
+.c11:focus {
+  background: #651FFF;
+}
+
+.c11:active {
+  background: #354AA4;
+}
+
+.c11:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c12 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c12:active {
+  opacity: 0.56;
+}
+
+.c12:hover,
+.c12:focus {
+  background: #2C3A73;
+}
+
+.c12:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c8 {
   display: inline-block;
   transition: color 0.3s;
   color: #FFFFFF;
@@ -1030,15 +1531,7 @@ exports[`loaded with static state 1`] = `
   margin-bottom: 32px;
 }
 
-.c3 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  margin: 0px;
-  margin-bottom: 8px;
-}
-
-.c5 {
+.c4 {
   box-sizing: border-box;
   display: flex;
   padding: 8px;
@@ -1049,37 +1542,30 @@ exports[`loaded with static state 1`] = `
   border-radius: 8px;
 }
 
-.c5.disabled {
+.c4.disabled {
   pointer-events: none;
   opacity: 0.5;
 }
 
-.c6 {
-  margin-right: 10px;
-  accent-color: #512FC9;
-}
-
-.c6:hover {
-  cursor: pointer;
+.c5 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  font-style: italic;
+  overflow: visible;
 }
 
 .c7 {
-  width: 250px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c9 {
   line-height: normal;
   padding-left: 4px;
 }
 
-.c11 {
+.c9 {
   font-weight: bold;
   letter-spacing: 4px;
 }
 
-.c11:after {
+.c9:after {
   content: ' ';
 }
 
@@ -1100,120 +1586,875 @@ exports[`loaded with static state 1`] = `
   <div
     class="c3"
   >
-    Select OS Users
-  </div>
-  <div
-    class="c4"
-  >
     <div
-      class="c5 disabled"
+      class="c4"
     >
-      <input
-        checked=""
-        class="c6"
-        id="ubunutu0"
-        name="ubunutu"
-        type="checkbox"
-      />
-      <label
-        class="c7"
-        for="ubunutu0"
+      <div
+        class="c5"
       >
-        ubunutu
-      </label>
-    </div>
-    <div
-      class="c5 disabled"
-    >
-      <input
-        checked=""
-        class="c6"
-        id="debian1"
-        name="debian"
-        type="checkbox"
-      />
-      <label
-        class="c7"
-        for="debian1"
-      >
-        debian
-      </label>
-    </div>
-    <div
-      class="c5"
-    >
-      <input
-        checked=""
-        class="c6"
-        id="root0"
-        name="root"
-        type="checkbox"
-      />
-      <label
-        class="c7"
-        for="root0"
-      >
-        root
-      </label>
-    </div>
-    <div
-      class="c5"
-    >
-      <input
-        checked=""
-        class="c6"
-        id="llama1"
-        name="llama"
-        type="checkbox"
-      />
-      <label
-        class="c7"
-        for="llama1"
-      >
-        llama
-      </label>
-    </div>
-    <div
-      class="c5"
-    >
-      <input
-        checked=""
-        class="c6"
-        id="george_washington_really_long_name_testing2"
-        name="george_washington_really_long_name_testing"
-        type="checkbox"
-      />
-      <label
-        class="c7"
-        for="george_washington_really_long_name_testing2"
-      >
-        george_washington_really_long_name_testing
-      </label>
+        No OS users added
+      </div>
     </div>
     <button
-      class="c8 c9"
+      class="c6 c7"
       kind="text"
     >
       <span
-        class="c10 icon icon-add c11"
+        class="c8 icon icon-add c9"
         color="light"
       />
       Add new OS User
     </button>
   </div>
   <div
-    class="c12"
+    class="c10"
   >
     
     <button
-      class="c13"
+      class="c11"
+      disabled=""
       kind="primary"
       width="165px"
     >
       Next
     </button>
     <a
-      class="c14"
+      class="c12"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`no logins, perms, and is a SSO user 1`] = `
+.c0 {
+  box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
+.c5 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c6 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c6:active {
+  opacity: 0.56;
+}
+
+.c6:hover,
+.c6:focus {
+  background: #651FFF;
+}
+
+.c6:active {
+  background: #354AA4;
+}
+
+.c6:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: #2C3A73;
+}
+
+.c7:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-top: 24px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    font-size="18px"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select the OS users you will use to connect to server.
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4"
+      width="100px"
+    >
+      You don’t have any allowed logins.
+      <br />
+      Please ask your Teleport administrator to update your role and add the required logins.
+    </div>
+  </div>
+  <div
+    class="c5"
+  >
+    
+    <button
+      class="c6"
+      disabled=""
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c7"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`static and dynamic logins with perms\` 1`] = `
+.c0 {
+  box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
+.c11 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: none;
+  text-transform: none;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 8px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: none;
+  text-decoration: underline;
+}
+
+.c7:disabled {
+  background: none;
+  color: rgba(255,255,255,0.3);
+}
+
+.c12 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c12:active {
+  opacity: 0.56;
+}
+
+.c12:hover,
+.c12:focus {
+  background: #651FFF;
+}
+
+.c12:active {
+  background: #354AA4;
+}
+
+.c12:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c13 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c13:active {
+  opacity: 0.56;
+}
+
+.c13:hover,
+.c13:focus {
+  background: #2C3A73;
+}
+
+.c13:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c9 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+  padding: 8px;
+  margin-bottom: 4px;
+  width: 300px;
+  align-items: center;
+  border: 1px solid #222C59;
+  border-radius: 8px;
+}
+
+.c4.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.c5 {
+  margin-right: 10px;
+  accent-color: #512FC9;
+}
+
+.c5:hover {
+  cursor: pointer;
+}
+
+.c6 {
+  width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c8 {
+  line-height: normal;
+  padding-left: 4px;
+}
+
+.c10 {
+  font-weight: bold;
+  letter-spacing: 4px;
+}
+
+.c10:after {
+  content: ' ';
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    font-size="18px"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select the OS users you will use to connect to server.
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="ubunutu0"
+        name="ubunutu"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="ubunutu0"
+      >
+        ubunutu
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="debian1"
+        name="debian"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="debian1"
+      >
+        debian
+      </label>
+    </div>
+    <div
+      class="c4"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="root0"
+        name="root"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="root0"
+      >
+        root
+      </label>
+    </div>
+    <div
+      class="c4"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="llama1"
+        name="llama"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="llama1"
+      >
+        llama
+      </label>
+    </div>
+    <div
+      class="c4"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="george_washington_really_long_name_testing2"
+        name="george_washington_really_long_name_testing"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="george_washington_really_long_name_testing2"
+      >
+        george_washington_really_long_name_testing
+      </label>
+    </div>
+    <button
+      class="c7 c8"
+      kind="text"
+    >
+      <span
+        class="c9 icon icon-add c10"
+        color="light"
+      />
+      Add new OS User
+    </button>
+  </div>
+  <div
+    class="c11"
+  >
+    
+    <button
+      class="c12"
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c13"
+      href="/web"
+      kind="secondary"
+      mt="3"
+      theme="[object Object]"
+      width="165px"
+    >
+      Exit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`static only logins with perms 1`] = `
+.c0 {
+  box-sizing: border-box;
+  max-width: 700px;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+}
+
+.c11 {
+  box-sizing: border-box;
+  margin-top: 24px;
+}
+
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: none;
+  text-transform: none;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 8px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: none;
+  text-decoration: underline;
+}
+
+.c7:disabled {
+  background: none;
+  color: rgba(255,255,255,0.3);
+}
+
+.c12 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-right: 16px;
+  width: 165px;
+}
+
+.c12:active {
+  opacity: 0.56;
+}
+
+.c12:hover,
+.c12:focus {
+  background: #651FFF;
+}
+
+.c12:active {
+  background: #354AA4;
+}
+
+.c12:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c13 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  margin-top: 16px;
+  width: 165px;
+}
+
+.c13:active {
+  opacity: 0.56;
+}
+
+.c13:hover,
+.c13:focus {
+  background: #2C3A73;
+}
+
+.c13:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c9 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+  padding: 8px;
+  margin-bottom: 4px;
+  width: 300px;
+  align-items: center;
+  border: 1px solid #222C59;
+  border-radius: 8px;
+}
+
+.c4.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.c5 {
+  margin-right: 10px;
+  accent-color: #512FC9;
+}
+
+.c5:hover {
+  cursor: pointer;
+}
+
+.c6 {
+  width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c8 {
+  line-height: normal;
+  padding-left: 4px;
+}
+
+.c10 {
+  font-weight: bold;
+  letter-spacing: 4px;
+}
+
+.c10:after {
+  content: ' ';
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    font-size="18px"
+  >
+    Set Up Access
+  </div>
+  <div
+    class="c2"
+  >
+    Select the OS users you will use to connect to server.
+  </div>
+  <div
+    class="c3"
+  >
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="ubunutu0"
+        name="ubunutu"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="ubunutu0"
+      >
+        ubunutu
+      </label>
+    </div>
+    <div
+      class="c4 disabled"
+    >
+      <input
+        checked=""
+        class="c5"
+        id="debian1"
+        name="debian"
+        type="checkbox"
+      />
+      <label
+        class="c6"
+        for="debian1"
+      >
+        debian
+      </label>
+    </div>
+    <button
+      class="c7 c8"
+      kind="text"
+    >
+      <span
+        class="c9 icon icon-add c10"
+        color="light"
+      />
+      Add new OS User
+    </button>
+  </div>
+  <div
+    class="c11"
+  >
+    
+    <button
+      class="c12"
+      kind="primary"
+      width="165px"
+    >
+      Next
+    </button>
+    <a
+      class="c13"
       href="/web"
       kind="secondary"
       mt="3"

--- a/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
+++ b/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
@@ -91,6 +91,8 @@ export function useLoginTrait({ ctx, props }: Props) {
     staticLogins,
     addLogin,
     fetchLoginTraits,
+    isSsoUser: ctx.storeUser.state.authType === 'sso',
+    canEditUser: ctx.storeUser.getUserAccess().edit,
   };
 }
 

--- a/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
+++ b/packages/teleport/src/Discover/LoginTrait/useLoginTrait.ts
@@ -29,6 +29,9 @@ export function useLoginTrait({ ctx, props }: Props) {
   const [staticLogins, setStaticLogins] = useState<string[]>([]);
   const [dynamicLogins, setDynamicLogins] = useState<string[]>([]);
 
+  const isSsoUser = ctx.storeUser.state.authType === 'sso';
+  const canEditUser = ctx.storeUser.getUserAccess().edit;
+
   useEffect(() => {
     fetchLoginTraits();
   }, []);
@@ -52,18 +55,28 @@ export function useLoginTrait({ ctx, props }: Props) {
     );
   }
 
+  function updateNodeMeta(logins: string[]) {
+    const meta = props.agentMeta as NodeMeta;
+    props.updateAgentMeta({
+      ...meta,
+      node: { ...meta.node, sshLogins: [...staticLogins, ...logins] },
+    });
+  }
+
   async function nextStep(logins: string[]) {
+    if (isSsoUser || !canEditUser) {
+      updateNodeMeta(dynamicLogins);
+      props.nextStep();
+      return;
+    }
+
     // Currently, fetching user for user traits does not
     // include the statically defined OS usernames, so
     // we combine it manually in memory with the logins
     // we previously fetched through querying for the
     // the newly added resource (which returns 'sshLogins' that
     // includes both dynamic + static logins).
-    const meta = props.agentMeta as NodeMeta;
-    props.updateAgentMeta({
-      ...meta,
-      node: { ...meta.node, sshLogins: [...staticLogins, ...logins] },
-    });
+    updateNodeMeta(logins);
 
     // Update the dynamic logins for the user in backend.
     setAttempt({ status: 'processing' });
@@ -91,8 +104,8 @@ export function useLoginTrait({ ctx, props }: Props) {
     staticLogins,
     addLogin,
     fetchLoginTraits,
-    isSsoUser: ctx.storeUser.state.authType === 'sso',
-    canEditUser: ctx.storeUser.getUserAccess().edit,
+    isSsoUser,
+    canEditUser,
   };
 }
 

--- a/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
+++ b/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
@@ -23,6 +23,8 @@ import { render, screen } from 'design/utils/testing';
 import { SelectResource } from 'teleport/Discover/SelectResource/SelectResource';
 import { Access, Acl, makeUserContext } from 'teleport/services/user';
 
+import type { AgentKind } from '../useDiscover';
+
 const fullAccess: Access = {
   list: true,
   read: true,
@@ -73,18 +75,20 @@ const userContextJson = {
 };
 
 describe('select resource', () => {
-  function create(resource: string, userAcl: Acl) {
+  function create(resource: AgentKind, userAcl: Acl) {
     const userContext = makeUserContext({
       ...userContextJson,
       userAcl,
     });
 
     return render(
-      <MemoryRouter initialEntries={[{ state: { entity: resource } }]}>
+      <MemoryRouter>
         <SelectResource
           userContext={userContext}
           isEnterprise={false}
           nextStep={() => null}
+          selectedResource={resource}
+          onSelectResource={() => null}
         />
       </MemoryRouter>
     );

--- a/packages/teleport/src/Discover/Shared.tsx
+++ b/packages/teleport/src/Discover/Shared.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { NavLink } from 'react-router-dom';
+import TextEditor from 'shared/components/TextEditor';
 
 import { Text, ButtonPrimary, Box, ButtonText } from 'design';
 import { ButtonSecondary } from 'design/Button';
@@ -76,9 +77,13 @@ export const ActionButtons = ({
   );
 };
 
+export const ReadOnlyYamlEditor = ({ content }: { content: string }) => {
+  return <TextEditor readOnly={true} data={[{ content, type: 'yaml' }]} />;
+};
+
 export const TextIcon = styled(Text)`
   display: flex;
-  align-items: center;
+  align-items: ${({ alignItems }) => alignItems || 'center'};
 
   .icon {
     margin-right: 8px;

--- a/packages/teleport/src/Discover/Shared.tsx
+++ b/packages/teleport/src/Discover/Shared.tsx
@@ -100,3 +100,10 @@ export const ButtonBlueText = styled(ButtonText)`
   font-size: inherit;
   min-height: auto;
 `;
+
+export const Mark = styled.mark`
+  padding: 2px 5px;
+  border-radius: 6px;
+  background-color: rgb(255 255 255 / 17%);
+  color: inherit;
+`;

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.story.tsx
@@ -58,6 +58,13 @@ export const LoadedWithDiagnosisFailure = () => {
           'Invalid user. Please ensure the principal "debian" is a valid Linux login in the target node. Output from Node: Failed to launch: user: unknown user debian.',
         error: 'ssh: handshake failed: EOF',
       } as ConnectionDiagnosticTrace,
+      {
+        id: '',
+        traceType: 'some trace type',
+        status: 'failed',
+        details: 'Another error',
+        error: 'some other error',
+      } as ConnectionDiagnosticTrace,
     ],
   };
   return (

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.story.tsx
@@ -67,6 +67,12 @@ export const LoadedWithDiagnosisFailure = () => {
   );
 };
 
+export const LoadedNoPerm = () => (
+  <MemoryRouter>
+    <TestConnection {...props} canTestConnection={false} />
+  </MemoryRouter>
+);
+
 export const Failed = () => (
   <MemoryRouter>
     <TestConnection
@@ -125,4 +131,5 @@ const props: State = {
   runConnectionDiagnostic: () => null,
   nextStep: () => null,
   diagnosis: null,
+  canTestConnection: true,
 };

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
@@ -28,7 +28,9 @@ import {
   TextIcon,
   HeaderSubtitle,
   Mark,
+  ReadOnlyYamlEditor,
 } from '../Shared';
+import { ruleConnectionDiagnostic } from '../templates';
 
 import { useTestConnection, State } from './useTestConnection';
 
@@ -124,14 +126,17 @@ export function TestConnection({
               <Box ml={4}>{$diagnosisStateComponent}</Box>
             </>
           ) : (
-            <Text>
-              You don't have permission to test connection.
-              <br />
-              Please ask your Teleport administrator to update your role and add
-              the rules <Mark>connection_diagnostic.update</Mark>,{' '}
-              <Mark>connection_diagnostic.create</Mark>, and{' '}
-              <Mark>connection_diagnostic.read</Mark>.
-            </Text>
+            <Box>
+              <Text>
+                You don't have permission to test connection.
+                <br />
+                Please ask your Teleport administrator to update your role and
+                add the <Mark>connection_diagnostic</Mark> rule:
+              </Text>
+              <Flex minHeight="155px" mt={3}>
+                <ReadOnlyYamlEditor content={ruleConnectionDiagnostic} />
+              </Flex>
+            </Box>
           )}
         </Flex>
         {showDiagnosisOutput && (
@@ -144,11 +149,12 @@ export function TestConnection({
                   if (trace.status === 'failed') {
                     return (
                       <>
-                        <TextIcon>
+                        <TextIcon alignItems="baseline">
                           <Icons.CircleCross mr={1} color="danger" />
                           {trace.details}
+                          <br />
+                          {trace.error}
                         </TextIcon>
-                        <Box mt={2}>{trace.error}</Box>
                       </>
                     );
                   }

--- a/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/TestConnection/TestConnection.tsx
@@ -22,7 +22,13 @@ import Select from 'shared/components/Select';
 
 import useTeleport from 'teleport/useTeleport';
 
-import { Header, ActionButtons, TextIcon, HeaderSubtitle } from '../Shared';
+import {
+  Header,
+  ActionButtons,
+  TextIcon,
+  HeaderSubtitle,
+  Mark,
+} from '../Shared';
 
 import { useTestConnection, State } from './useTestConnection';
 
@@ -43,6 +49,7 @@ export function TestConnection({
   runConnectionDiagnostic,
   diagnosis,
   nextStep,
+  canTestConnection,
 }: State) {
   const [usernameOpts] = useState(() =>
     logins.map(l => ({ value: l, label: l }))
@@ -81,7 +88,8 @@ export function TestConnection({
     <Box>
       <Header>Test Connection</Header>
       <HeaderSubtitle>
-        Verify that you can successfully connect to the server you just added.
+        Optionally verify that you can successfully connect to the server you
+        just added.
       </HeaderSubtitle>
       <StyledBox mb={5}>
         <Text bold>Step 1</Text>
@@ -104,14 +112,27 @@ export function TestConnection({
           Verify that the server is accessible
         </Text>
         <Flex alignItems="center" mt={3}>
-          <ButtonSecondary
-            width="200px"
-            onClick={() => runConnectionDiagnostic(selectedOpt.value)}
-            disabled={attempt.status === 'processing'}
-          >
-            {diagnosis ? 'Restart Test' : 'Test Connection'}
-          </ButtonSecondary>
-          <Box ml={4}>{$diagnosisStateComponent}</Box>
+          {canTestConnection ? (
+            <>
+              <ButtonSecondary
+                width="200px"
+                onClick={() => runConnectionDiagnostic(selectedOpt.value)}
+                disabled={attempt.status === 'processing'}
+              >
+                {diagnosis ? 'Restart Test' : 'Test Connection'}
+              </ButtonSecondary>
+              <Box ml={4}>{$diagnosisStateComponent}</Box>
+            </>
+          ) : (
+            <Text>
+              You don't have permission to test connection.
+              <br />
+              Please ask your Teleport administrator to update your role and add
+              the rules <Mark>connection_diagnostic.update</Mark>,{' '}
+              <Mark>connection_diagnostic.create</Mark>, and{' '}
+              <Mark>connection_diagnostic.read</Mark>.
+            </Text>
+          )}
         </Flex>
         {showDiagnosisOutput && (
           <Box mt={3}>
@@ -162,16 +183,11 @@ export function TestConnection({
         <ButtonSecondary
           width="200px"
           onClick={() => startSshSession(selectedOpt.value)}
-          disabled={attempt.status !== 'success' || !diagnosis?.success}
         >
           Start Session
         </ButtonSecondary>
       </StyledBox>
-      <ActionButtons
-        onProceed={nextStep}
-        lastStep={true}
-        disableProceed={attempt.status !== 'success' || !diagnosis?.success}
-      />
+      <ActionButtons onProceed={nextStep} lastStep={true} />
     </Box>
   );
 }

--- a/packages/teleport/src/Discover/TestConnection/useTestConnection.ts
+++ b/packages/teleport/src/Discover/TestConnection/useTestConnection.ts
@@ -30,6 +30,9 @@ export function useTestConnection({ ctx, props }: Props) {
   const { attempt, run } = useAttempt('');
   const [diagnosis, setDiagnosis] = useState<ConnectionDiagnostic>();
 
+  const access = ctx.storeUser.getConnectionDiagnosticAccess();
+  const canTestConnection = access.create && access.edit && access.read;
+
   function startSshSession(login: string) {
     const meta = props.agentMeta as NodeMeta;
     const url = cfg.getSshConnectRoute({
@@ -62,6 +65,7 @@ export function useTestConnection({ ctx, props }: Props) {
     runConnectionDiagnostic,
     diagnosis,
     nextStep: props.nextStep,
+    canTestConnection,
   };
 }
 

--- a/packages/teleport/src/Discover/templates/index.ts
+++ b/packages/teleport/src/Discover/templates/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import logins from './logins.yaml?raw';
+import loginsAndRuleUsers from './loginsAndRuleUsers.yaml?raw';
+import ruleConnectionDiagnostic from './ruleConnectionDiagnostic.yaml?raw';
+
+export { logins, loginsAndRuleUsers, ruleConnectionDiagnostic };

--- a/packages/teleport/src/Discover/templates/logins.yaml
+++ b/packages/teleport/src/Discover/templates/logins.yaml
@@ -1,0 +1,7 @@
+kind: role
+spec:
+  allow:
+    # Define OS users.
+    logins:
+    - osUser1
+    - osUser2

--- a/packages/teleport/src/Discover/templates/loginsAndRuleUsers.yaml
+++ b/packages/teleport/src/Discover/templates/loginsAndRuleUsers.yaml
@@ -1,0 +1,13 @@
+kind: role
+spec:
+  allow:
+    # Define OS users.
+    logins:
+    - osUser1
+    - osUser2
+    rules:
+    # Rule that allows users to define their own logins.
+    - resources:
+      - user
+      verbs:
+      - update

--- a/packages/teleport/src/Discover/templates/ruleConnectionDiagnostic.yaml
+++ b/packages/teleport/src/Discover/templates/ruleConnectionDiagnostic.yaml
@@ -1,0 +1,10 @@
+kind: role
+spec:
+  allow:
+    rules:
+    - resources:
+      - connection_diagnostic
+      verbs:
+      - create
+      - read
+      - update

--- a/packages/teleport/src/Discover/types.ts
+++ b/packages/teleport/src/Discover/types.ts
@@ -24,6 +24,8 @@ export type AgentStepProps = {
   updateAgentMeta: State['updateAgentMeta'];
   // nextStep increments the `currentStep` to go to the next step.
   nextStep: State['nextStep'];
+  selectedAgentKind: State['selectedAgentKind'];
+  onSelectResource: State['onSelectResource'];
 };
 
 export type AgentStepComponent = (props: AgentStepProps) => JSX.Element;

--- a/packages/teleport/src/stores/storeUserContext.ts
+++ b/packages/teleport/src/stores/storeUserContext.ts
@@ -54,6 +54,10 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state.acl.users;
   }
 
+  getConnectionDiagnosticAccess() {
+    return this.state.acl.connectionDiagnostic;
+  }
+
   getAppServerAccess() {
     return this.state.acl.appServers;
   }
@@ -116,20 +120,10 @@ export default class StoreUserContext extends Store<UserContext> {
 
   // hasPrereqAccessToAddAgents checks if user meets the prerequisite
   // access to add an agent:
-  //  - user should be able to edit themselves to update user traits
   //  - user should be able to create provisioning tokens
-  //  - user should be able to read, create and update connection diagnostics
-  //    to test agent connection
   hasPrereqAccessToAddAgents() {
-    const { users, tokens, connectionDiagnostic } = this.state.acl;
-
-    return (
-      users.edit &&
-      tokens.create &&
-      connectionDiagnostic.create &&
-      connectionDiagnostic.edit &&
-      connectionDiagnostic.read
-    );
+    const { tokens } = this.state.acl;
+    return tokens.create;
   }
 
   // hasAccessToAgentQuery checks for at least one valid query permission.


### PR DESCRIPTION
#### Description
- Permission redo: basically keeps the old functionality, where we just check for `resource listing/reading` and `tokens.create` before allowing the flow. All other permissions will be checked during the flow step and will show different permission messages depending on level of perm
- Prevent showing prompt when user clicks on "manage access" when already on it
- I just noticed that our sidenav titles renders for our unfinished flows, so I removed them from the sidenav

#### Screenshot
Removing sidenav titles for unfinished flows

![image](https://user-images.githubusercontent.com/43280172/189058757-be5326a0-6497-46a7-abf0-3d4cb12ee31e.png)

Test connection perm message

![image](https://user-images.githubusercontent.com/43280172/189198863-e02e2c5d-7557-4ef2-ad45-dc2f670fbd23.png)

LoginTrait message (does not show all combos, just showing the placement of different msgs, storybook will have all combos)

![image](https://user-images.githubusercontent.com/43280172/189198948-c7cc0753-d7b4-48a6-9287-71e77526d7ed.png)

![image](https://user-images.githubusercontent.com/43280172/189199007-db94001d-8658-4ee3-9f66-839f1696b49e.png)

