### PR TITLE
Add kube support

### DIFF
--- a/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -45,4 +45,8 @@ export class MockMainProcessClient implements MainProcessClient {
   } as unknown as ConfigService;
 
   fileStorage = createMockFileStorage();
+
+  removeKubeConfig(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
 }

--- a/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -8,8 +8,9 @@ export class MockMainProcessClient implements MainProcessClient {
       platform: 'darwin',
       dev: true,
       userDataDir: '',
-      binDir: undefined,
-      certsDir: undefined,
+      binDir: '',
+      certsDir: '',
+      kubeConfigsDir: '',
       defaultShell: '',
       tshd: {
         insecure: true,

--- a/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -22,5 +22,11 @@ export default function createMainProcessClient(): MainProcessClient {
     openTabContextMenu,
     configService: createConfigServiceClient(),
     fileStorage: createFileStorageClient(),
+    removeKubeConfig(kubeConfigName) {
+      return ipcRenderer.invoke(
+        'main-process-remove-kube-config',
+        kubeConfigName
+      );
+    },
   };
 }

--- a/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -64,6 +64,7 @@ function getRuntimeSettings(): RuntimeSettings {
     binDir,
     certsDir: getCertsDir(),
     defaultShell: getDefaultShell(),
+    kubeConfigsDir: getKubeConfigsDir(),
     platform: process.platform,
   };
 }
@@ -78,6 +79,14 @@ function getCertsDir() {
     fs.mkdirSync(certsPath);
   }
   return certsPath;
+}
+
+function getKubeConfigsDir(): string {
+  const kubeConfigsPath = path.resolve(app.getPath('userData'), 'kube');
+  if (!fs.existsSync(kubeConfigsPath)) {
+    fs.mkdirSync(kubeConfigsPath);
+  }
+  return kubeConfigsPath;
 }
 
 function getTshHomeDir() {

--- a/packages/teleterm/src/mainProcess/types.ts
+++ b/packages/teleterm/src/mainProcess/types.ts
@@ -31,6 +31,7 @@ export type MainProcessClient = {
   openTabContextMenu(options: TabContextMenuOptions): void;
   configService: ConfigService;
   fileStorage: FileStorage;
+  removeKubeConfig(kubeConfigName: string): Promise<void>;
 };
 
 export type ChildProcessAddresses = {

--- a/packages/teleterm/src/mainProcess/types.ts
+++ b/packages/teleterm/src/mainProcess/types.ts
@@ -9,6 +9,7 @@ export type RuntimeSettings = {
   // Points to a directory that should be prepended to PATH. Only present in the packaged version.
   binDir: string | undefined;
   certsDir: string;
+  kubeConfigsDir: string;
   defaultShell: string;
   platform: Platform;
   tshd: {

--- a/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -80,7 +80,7 @@ function getPtyProcessOptions(
       };
 
     case 'pty.tsh-kube-login': {
-      const kubeLoginCommand = `${settings.tshd.binaryPath} --proxy=${cmd.rootClusterId} kube login ${cmd.kubeId}`;
+      const kubeLoginCommand = `${settings.tshd.binaryPath} --proxy=${cmd.rootClusterId} kube login ${cmd.kubeId} --cluster=${cmd.clusterName}`;
       const bashCommandArgs = ['-c', `${kubeLoginCommand};$SHELL`];
       const powershellCommandArgs = ['-NoExit', '-c', kubeLoginCommand];
       return {

--- a/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -80,15 +80,19 @@ function getPtyProcessOptions(
       };
 
     case 'pty.tsh-kube-login': {
-      const kubeLoginCommand = `${settings.tshd.binaryPath} --proxy=${cmd.rootClusterId} kube login ${cmd.kubeId} --cluster=${cmd.clusterName}`;
+      const isWindows = settings.platform === 'win32';
+
+      // backtick (PowerShell) and backslash (Bash) are used to escape a whitespace
+      const escapedBinaryPath = settings.tshd.binaryPath.replaceAll(
+        ' ',
+        isWindows ? '` ' : '\\ '
+      );
+      const kubeLoginCommand = `${escapedBinaryPath} --proxy=${cmd.rootClusterId} kube login ${cmd.kubeId} --cluster=${cmd.clusterName}`;
       const bashCommandArgs = ['-c', `${kubeLoginCommand};$SHELL`];
       const powershellCommandArgs = ['-NoExit', '-c', kubeLoginCommand];
       return {
         path: settings.defaultShell,
-        args:
-          settings.platform === 'win32'
-            ? powershellCommandArgs
-            : bashCommandArgs,
+        args: isWindows ? powershellCommandArgs : bashCommandArgs,
         env: { ...env, KUBECONFIG: getKubeConfigFilePath(cmd, settings) },
       };
     }

--- a/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -1,9 +1,13 @@
-import { delimiter } from 'path';
+import path, { delimiter } from 'path';
 
 import { RuntimeSettings } from 'teleterm/mainProcess/types';
 import { PtyProcessOptions } from 'teleterm/sharedProcess/ptyHost';
 
-import { PtyCommand, PtyProcessCreationStatus } from '../types';
+import {
+  PtyCommand,
+  PtyProcessCreationStatus,
+  TshKubeLoginCommand,
+} from '../types';
 
 import {
   resolveShellEnvCached,
@@ -75,20 +79,19 @@ function getPtyProcessOptions(
         initCommand: cmd.initCommand,
       };
 
-    case 'pty.tsh-kube-login':
+    case 'pty.tsh-kube-login': {
+      const kubeLoginCommand = `${settings.tshd.binaryPath} --proxy=${cmd.rootClusterId} kube login ${cmd.kubeId}`;
+      const bashCommandArgs = ['-c', `${kubeLoginCommand};$SHELL`];
+      const powershellCommandArgs = ['-NoExit', '-c', kubeLoginCommand];
       return {
-        //path: settings.tshd.binaryPath,
         path: settings.defaultShell,
-        args: [
-          `-c`,
-          `${settings.tshd.binaryPath}`,
-          `--proxy=${cmd.rootClusterId}`,
-          `kube`,
-          `login`,
-          `${cmd.kubeId}`,
-        ],
-        env,
+        args:
+          settings.platform === 'win32'
+            ? powershellCommandArgs
+            : bashCommandArgs,
+        env: { ...env, KUBECONFIG: getKubeConfigFilePath(cmd, settings) },
       };
+    }
 
     case 'pty.tsh-login':
       const loginHost = cmd.login
@@ -114,4 +117,11 @@ function prependBinDirToPath(
     .map(path => path?.trim())
     .filter(Boolean)
     .join(delimiter);
+}
+
+function getKubeConfigFilePath(
+  command: TshKubeLoginCommand,
+  settings: RuntimeSettings
+): string {
+  return path.join(settings.kubeConfigsDir, command.kubeConfigName);
 }

--- a/packages/teleterm/src/services/pty/types.ts
+++ b/packages/teleterm/src/services/pty/types.ts
@@ -39,6 +39,7 @@ export type TshLoginCommand = PtyCommandBase & {
 export type TshKubeLoginCommand = PtyCommandBase & {
   kind: 'pty.tsh-kube-login';
   kubeId: string;
+  kubeConfigName: string;
   rootClusterId: string;
   leafClusterId?: string;
 };

--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/SideNav/SideNav.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/SideNav/SideNav.tsx
@@ -61,7 +61,7 @@ const StyledNav = styled(Flex)`
 function createItems(ctx: ClusterContext): SideNavItem[] {
   const serverCount = ctx.getServers().length;
   const dbCount = ctx.getDbs().length;
-  // const kubeCount = ctx.getKubes().length;
+  const kubeCount = ctx.getKubes().length;
   // const appCount = ctx.getApps().length;
 
   return [
@@ -73,10 +73,10 @@ function createItems(ctx: ClusterContext): SideNavItem[] {
       to: '/resources/databases',
       title: `Databases (${dbCount})`,
     },
-    // {
-    //   to: '/resources/kubes',
-    //   title: `Kubes (${kubeCount})`,
-    // },
+    {
+      to: '/resources/kubes',
+      title: `Kubes (${kubeCount})`,
+    },
     // {
     //   to: '/resources/apps',
     //   title: `Apps (${appCount})`,

--- a/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 import { Close as CloseIcon } from 'design/Icon';
 import { ButtonIcon, Text } from 'design';
 
-import LinearProgress from '../../ui/components/LinearProgress';
+import LinearProgress from 'teleterm/ui/components/LinearProgress';
 
 import { useTabDnD } from './useTabDnD';
 

--- a/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -19,6 +19,8 @@ import styled from 'styled-components';
 import { Close as CloseIcon } from 'design/Icon';
 import { ButtonIcon, Text } from 'design';
 
+import LinearProgress from '../../ui/components/LinearProgress';
+
 import { useTabDnD } from './useTabDnD';
 
 type TabItemProps = {
@@ -26,6 +28,7 @@ type TabItemProps = {
   name?: string;
   active?: boolean;
   closeTabTooltip?: string;
+  isLoading?: boolean;
   onClick?(): void;
   onClose?(): void;
   onMoved?(oldIndex: number, newIndex: number): void;
@@ -40,6 +43,7 @@ export function TabItem(props: TabItemProps) {
     onClose,
     index,
     onMoved,
+    isLoading,
     onContextMenu,
     closeTabTooltip,
   } = props;
@@ -70,6 +74,7 @@ export function TabItem(props: TabItemProps) {
       <Title color="inherit" fontWeight={700} fontSize="12px">
         {name}
       </Title>
+      {isLoading && active && <LinearProgress transparentBackground={true} />}
       {onClose && (
         <ButtonIcon
           size={0}
@@ -103,6 +108,7 @@ const StyledTabItem = styled.div(({ theme, active, dragging, canDrag }) => {
       color: theme.colors.primary.contrastText,
       transition: 'color .3s',
     },
+    position: 'relative',
   };
 
   if (active) {

--- a/packages/teleterm/src/ui/Tabs/Tabs.tsx
+++ b/packages/teleterm/src/ui/Tabs/Tabs.tsx
@@ -59,6 +59,7 @@ export function Tabs(props: Props) {
               onClose={() => onClose(item)}
               onContextMenu={() => onContextMenu(item)}
               onMoved={onMoved}
+              isLoading={getIsLoading(item)}
               closeTabTooltip={closeTabTooltip}
             />
             <Separator />
@@ -83,6 +84,16 @@ export function Tabs(props: Props) {
       </ButtonIcon>
     </StyledTabs>
   );
+}
+
+function getIsLoading(doc: Document): boolean {
+  switch (doc.kind) {
+    case 'doc.terminal_tsh_kube':
+    case 'doc.terminal_tsh_node':
+      return doc.status === 'connecting';
+    default:
+      return false;
+  }
 }
 
 type Props = {

--- a/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -128,6 +128,8 @@ function getKindName(kind: ExtendedTrackedConnection['kind']): string {
       return 'DB';
     case 'connection.server':
       return 'SSH';
+    case 'connection.kube':
+      return 'KUBE';
     default:
       assertUnreachable(kind);
   }

--- a/packages/teleterm/src/ui/appContext.ts
+++ b/packages/teleterm/src/ui/appContext.ts
@@ -52,6 +52,7 @@ export default class AppContext implements IAppContext {
     this.notificationsService = new NotificationsService();
     this.clustersService = new ClustersService(
       tshClient,
+      this.mainProcessClient,
       this.notificationsService
     );
     this.workspacesService = new WorkspacesService(

--- a/packages/teleterm/src/ui/commandLauncher.ts
+++ b/packages/teleterm/src/ui/commandLauncher.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { IAppContext } from 'teleterm/ui/types';
 import { routing } from 'teleterm/ui/uri';
 import { tsh } from 'teleterm/ui/services/clusters/types';
+import { TrackedKubeConnection } from 'teleterm/ui/services/connectionTracker';
 
 const commands = {
   // For handling "tsh ssh" executed from the command bar.
@@ -91,8 +92,16 @@ const commands = {
     run(ctx: IAppContext, args: { kubeUri: string }) {
       const documentsService =
         ctx.workspacesService.getActiveWorkspaceDocumentService();
-      const kubeDoc = documentsService.createTshKubeDocument(args.kubeUri);
-      documentsService.add(kubeDoc);
+      const kubeDoc = documentsService.createTshKubeDocument({
+        kubeUri: args.kubeUri,
+      });
+      const connection = ctx.connectionTracker.findConnectionByDocument(
+        kubeDoc
+      ) as TrackedKubeConnection;
+      documentsService.add({
+        ...kubeDoc,
+        kubeConfigName: connection?.kubeConfigName || kubeDoc.kubeConfigName,
+      });
       documentsService.open(kubeDoc.uri);
     },
   },

--- a/packages/teleterm/src/ui/components/LinearProgress/LinearProgress.tsx
+++ b/packages/teleterm/src/ui/components/LinearProgress/LinearProgress.tsx
@@ -17,7 +17,11 @@ limitations under the License.
 import React from 'react';
 import styled from 'styled-components';
 
-const LinearProgress: React.FC = () => {
+interface LinearProgressProps {
+  transparentBackground?: boolean;
+}
+
+const LinearProgress = (props: LinearProgressProps) => {
   return (
     <div
       style={{
@@ -27,7 +31,7 @@ const LinearProgress: React.FC = () => {
         bottom: '0',
       }}
     >
-      <StyledProgress>
+      <StyledProgress transparentBackground={props.transparentBackground}>
         <div className="parent-bar-2" />
       </StyledProgress>
     </div>
@@ -40,7 +44,8 @@ const StyledProgress = styled.div`
   display: block;
   height: 1px;
   z-index: 0;
-  background-color: #222c59;
+  background-color: ${props =>
+    props.transparentBackground ? 'transparent' : '#222c59'};
 
   .parent-bar-2 {
     position: absolute;
@@ -51,7 +56,7 @@ const StyledProgress = styled.div`
     transform-origin: left;
     background-color: #1976d2;
     animation: animation-linear-progress 2s cubic-bezier(0.165, 0.84, 0.44, 1)
-      1s infinite;
+      0.1s infinite;
   }
 
   @keyframes animation-linear-progress {

--- a/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -93,7 +93,11 @@ function createService(
   client: Partial<tsh.TshClient>,
   notificationsService?: NotificationsService
 ): ClustersService {
-  return new ClustersService(client as tsh.TshClient, notificationsService);
+  return new ClustersService(
+    client as tsh.TshClient,
+    undefined,
+    notificationsService
+  );
 }
 
 function getClientMocks(): Partial<tsh.TshClient> {

--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -7,6 +7,7 @@ import { Label } from 'teleport/types';
 import { routing } from 'teleterm/ui/uri';
 import { NotificationsService } from 'teleterm/ui/services/notifications';
 import { Cluster } from 'teleterm/services/tshd/types';
+import { MainProcessClient } from 'teleterm/mainProcess/types';
 
 import { ImmutableStore } from '../immutableStore';
 
@@ -41,6 +42,7 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
 
   constructor(
     public client: tsh.TshClient,
+    private mainProcessClient: MainProcessClient,
     private notificationsService: NotificationsService
   ) {
     super();
@@ -589,6 +591,10 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
 
   async getDbUsers(dbUri: string): Promise<string[]> {
     return await this.client.listDatabaseUsers(dbUri);
+  }
+
+  async removeKubeConfig(kubeConfigName: string): Promise<void> {
+    return this.mainProcessClient.removeKubeConfig(kubeConfigName);
   }
 
   useState() {

--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -156,7 +156,6 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
       //
       // Arguably, it is a bit of a race condition, as we assume that syncClusterInfo will return
       // before syncLeafClusters, but for now this is a condition we can live with.
-      this.syncKubes(clusterUri);
       this.syncApps(clusterUri);
       this.syncDbs(clusterUri);
       this.syncServers(clusterUri);
@@ -178,7 +177,6 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
 
   private async syncLeafClusterResourcesAndCatchErrors(clusterUri: string) {
     // Functions below handle their own errors, so we don't need to await them.
-    this.syncKubes(clusterUri);
     this.syncApps(clusterUri);
     this.syncDbs(clusterUri);
     this.syncServers(clusterUri);

--- a/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.ts
@@ -30,7 +30,7 @@ function getTestSetup({ connections }: { connections: TrackedConnection[] }) {
   return new ConnectionTrackerService(
     new StatePersistenceService(undefined),
     new WorkspacesService(undefined, undefined, undefined, undefined),
-    new ClustersService(undefined, undefined)
+    new ClustersService(undefined, undefined, undefined)
   );
 }
 
@@ -113,7 +113,7 @@ it('updates the port of a gateway connection when the underlying doc gets update
   const connectionTrackerService = new ConnectionTrackerService(
     mockedStatePersistenceService,
     workspacesService,
-    new ClustersServiceMock(undefined, undefined)
+    new ClustersServiceMock(undefined, undefined, undefined)
   );
 
   const document: DocumentGateway = {

--- a/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -120,6 +120,10 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
 
   async disconnectItem(id: string): Promise<void> {
     const connection = this.state.connections.find(c => c.id === id);
+    if (!connection) {
+      return;
+    }
+
     return this._trackedConnectionOperationsFactory
       .create(connection)
       .disconnect();
@@ -127,6 +131,10 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
 
   removeItem(id: string): void {
     const connection = this.state.connections.find(c => c.id === id);
+    if (!connection) {
+      return;
+    }
+
     this._trackedConnectionOperationsFactory.create(connection).remove?.();
 
     this.setState(draft => {

--- a/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -30,8 +30,10 @@ import { ImmutableStore } from '../immutableStore';
 import { TrackedConnectionOperationsFactory } from './trackedConnectionOperationsFactory';
 import {
   createGatewayConnection,
+  createKubeConnection,
   createServerConnection,
   getGatewayConnectionByDocument,
+  getKubeConnectionByDocument,
   getServerConnectionByDocument,
 } from './trackedConnectionUtils';
 import {
@@ -96,6 +98,10 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
         return this.state.connections.find(
           getServerConnectionByDocument(document)
         );
+      case 'doc.terminal_tsh_kube':
+        return this.state.connections.find(
+          getKubeConnectionByDocument(document)
+        );
       case 'doc.gateway':
         return this.state.connections.find(
           getGatewayConnectionByDocument(document)
@@ -114,12 +120,15 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
 
   async disconnectItem(id: string): Promise<void> {
     const connection = this.state.connections.find(c => c.id === id);
-    const { disconnect } =
-      this._trackedConnectionOperationsFactory.create(connection);
-    return disconnect();
+    return this._trackedConnectionOperationsFactory
+      .create(connection)
+      .disconnect();
   }
 
   removeItem(id: string): void {
+    const connection = this.state.connections.find(c => c.id === id);
+    this._trackedConnectionOperationsFactory.create(connection).remove?.();
+
     this.setState(draft => {
       draft.connections = draft.connections.filter(i => i.id !== id);
     });
@@ -163,7 +172,10 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
         })
         .filter(Boolean)
         .filter(
-          d => d.kind === 'doc.gateway' || d.kind === 'doc.terminal_tsh_node'
+          d =>
+            d.kind === 'doc.gateway' ||
+            d.kind === 'doc.terminal_tsh_node' ||
+            d.kind === 'doc.terminal_tsh_kube'
         );
 
       if (!docs) {
@@ -175,7 +187,7 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
 
         switch (doc.kind) {
           // process gateway connections
-          case 'doc.gateway':
+          case 'doc.gateway': {
             if (!doc.port) {
               break;
             }
@@ -194,10 +206,10 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
                 doc.gatewayUri
               );
             }
-
             break;
+          }
           // process tsh connections
-          case 'doc.terminal_tsh_node':
+          case 'doc.terminal_tsh_node': {
             const tshConn = draft.connections.find(
               getServerConnectionByDocument(doc)
             );
@@ -209,6 +221,21 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
               draft.connections.push(newItem);
             }
             break;
+          }
+          // process kube connections
+          case 'doc.terminal_tsh_kube': {
+            const kubeConn = draft.connections.find(
+              getKubeConnectionByDocument(doc)
+            );
+
+            if (kubeConn) {
+              kubeConn.connected = doc.status === 'connected';
+            } else {
+              const newItem = createKubeConnection(doc);
+              draft.connections.push(newItem);
+            }
+            break;
+          }
         }
       }
     });

--- a/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
@@ -1,10 +1,15 @@
 import {
   DocumentGateway,
+  DocumentTshKube,
   DocumentTshNode,
 } from 'teleterm/ui/services/workspacesService';
 import { unique } from 'teleterm/ui/utils/uid';
 
-import { TrackedGatewayConnection, TrackedServerConnection } from './types';
+import {
+  TrackedGatewayConnection,
+  TrackedKubeConnection,
+  TrackedServerConnection,
+} from './types';
 
 export function getGatewayConnectionByDocument(document: DocumentGateway) {
   return (i: TrackedGatewayConnection) =>
@@ -20,6 +25,11 @@ export function getServerConnectionByDocument(document: DocumentTshNode) {
     i.login === document.login;
 }
 
+export function getKubeConnectionByDocument(document: DocumentTshKube) {
+  return (i: TrackedKubeConnection) =>
+    i.kind === 'connection.kube' && i.kubeUri === document.kubeUri;
+}
+
 export function getGatewayDocumentByConnection(
   connection: TrackedGatewayConnection
 ) {
@@ -27,6 +37,11 @@ export function getGatewayDocumentByConnection(
     i.kind === 'doc.gateway' &&
     i.targetUri === connection.targetUri &&
     i.targetUser === connection.targetUser;
+}
+
+export function getKubeDocumentByConnection(connection: TrackedKubeConnection) {
+  return (i: DocumentTshKube) =>
+    i.kind === 'doc.terminal_tsh_kube' && i.kubeUri === connection.kubeUri;
 }
 
 export function getServerDocumentByConnection(
@@ -65,5 +80,18 @@ export function createServerConnection(
     title: document.title,
     login: document.login,
     serverUri: document.serverUri,
+  };
+}
+
+export function createKubeConnection(
+  document: DocumentTshKube
+): TrackedKubeConnection {
+  return {
+    kind: 'connection.kube',
+    connected: document.status === 'connected',
+    id: unique(),
+    title: document.title,
+    kubeConfigName: document.kubeConfigName,
+    kubeUri: document.kubeUri,
   };
 }

--- a/packages/teleterm/src/ui/services/connectionTracker/types.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/types.ts
@@ -1,20 +1,18 @@
 type TrackedConnectionBase = {
-  kind: 'connection.server' | 'connection.gateway';
   connected: boolean;
+  id: string;
+  title: string;
 };
 
 export interface TrackedServerConnection extends TrackedConnectionBase {
   kind: 'connection.server';
   title: string;
-  id: string;
   serverUri: string;
   login: string;
 }
 
 export interface TrackedGatewayConnection extends TrackedConnectionBase {
   kind: 'connection.gateway';
-  title: string;
-  id: string;
   targetUri: string;
   targetName: string;
   targetUser?: string;
@@ -23,9 +21,16 @@ export interface TrackedGatewayConnection extends TrackedConnectionBase {
   targetSubresourceName?: string;
 }
 
+export interface TrackedKubeConnection extends TrackedConnectionBase {
+  kind: 'connection.kube';
+  kubeConfigName: string;
+  kubeUri: string;
+}
+
 export type TrackedConnection =
   | TrackedServerConnection
-  | TrackedGatewayConnection;
+  | TrackedGatewayConnection
+  | TrackedKubeConnection;
 
 export type ExtendedTrackedConnection = TrackedConnection & {
   clusterName: string;

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.test.ts
@@ -60,7 +60,7 @@ test('getAutocompleteResult returns correct result for a command suggestion with
   );
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -80,7 +80,7 @@ test('getAutocompleteResult returns correct result for a command suggestion', ()
   );
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -117,7 +117,7 @@ test('getAutocompleteResult returns correct result for an SSH login suggestion',
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -158,7 +158,7 @@ test('getAutocompleteResult returns correct result for an SSH login suggestion w
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -209,7 +209,7 @@ test('getAutocompleteResult returns correct result for a database name suggestio
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -250,7 +250,7 @@ test("getAutocompleteResult doesn't return any suggestions if the only suggestio
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -279,7 +279,7 @@ test('getAutocompleteResult returns no match if any of the pickers returns parti
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -295,7 +295,7 @@ test("the SSH login autocomplete isn't shown if there's no space after `tsh ssh`
   );
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -328,7 +328,7 @@ test("the SSH login autocomplete is shown only if there's at least one space aft
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -370,7 +370,7 @@ test('getAutocompleteResult returns correct result for an SSH host suggestion ri
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -415,7 +415,7 @@ test('getAutocompleteResult returns correct result for a partial match on an SSH
     }));
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -457,7 +457,7 @@ test("getAutocompleteResult returns the first argument as loginHost when there's
     });
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
 
@@ -477,7 +477,7 @@ test("getAutocompleteResult returns the first argument as loginHost when there's
 test('picking a command suggestion in an empty input autocompletes the command', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
   quickInputService.setState({ inputValue: '' });
@@ -503,7 +503,7 @@ test('picking a command suggestion in an empty input autocompletes the command',
 test('picking a command suggestion in an input with a single space preserves the space', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
   quickInputService.setState({ inputValue: ' ' });
@@ -529,7 +529,7 @@ test('picking a command suggestion in an input with a single space preserves the
 test('picking an SSH login suggestion replaces target token in input value', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
   quickInputService.setState({ inputValue: 'tsh ssh roo --foo' });
@@ -552,7 +552,7 @@ test('picking an SSH login suggestion replaces target token in input value', () 
 test('pickSuggestion appends the appendToToken field to the token', () => {
   const quickInputService = new QuickInputService(
     new CommandLauncherMock(undefined),
-    new ClustersServiceMock(undefined, undefined),
+    new ClustersServiceMock(undefined, undefined, undefined),
     new WorkspacesServiceMock(undefined, undefined, undefined, undefined)
   );
   quickInputService.setState({ inputValue: 'tsh ssh foo' });

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -22,6 +22,7 @@ import {
   CreateClusterDocumentOpts,
   CreateGatewayDocumentOpts,
   CreateNewTerminalOpts,
+  CreateTshKubeDocumentOptions,
   Document,
   DocumentCluster,
   DocumentGateway,
@@ -60,8 +61,10 @@ export class DocumentsService {
     };
   }
 
-  createTshKubeDocument(kubeUri: string): DocumentTshKube {
-    const { params } = routing.parseKubeUri(kubeUri);
+  createTshKubeDocument(
+    options: CreateTshKubeDocumentOptions
+  ): DocumentTshKube {
+    const { params } = routing.parseKubeUri(options.kubeUri);
     const uri = routing.getDocUri({ docId: unique() });
     return {
       uri,
@@ -70,7 +73,8 @@ export class DocumentsService {
       rootClusterId: params.rootClusterId,
       leafClusterId: params.leafClusterId,
       kubeId: params.kubeId,
-      kubeUri,
+      kubeUri: options.kubeUri,
+      kubeConfigName: options.kubeConfigName || `${params.kubeId}-${unique(5)}`,
       title: params.kubeId,
     };
   }

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -47,6 +47,7 @@ export interface DocumentTshKube extends DocumentBase {
   status: 'connecting' | 'connected' | 'disconnected';
   kubeId: string;
   kubeUri: string;
+  kubeConfigName: string;
   rootClusterId: string;
   leafClusterId?: string;
 }
@@ -97,6 +98,11 @@ export type CreateGatewayDocumentOpts = {
 
 export type CreateClusterDocumentOpts = {
   clusterUri: string;
+};
+
+export type CreateTshKubeDocumentOptions = {
+  kubeUri: string;
+  kubeConfigName?: string;
 };
 
 export type CreateNewTerminalOpts = {

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -237,7 +237,22 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
   private reopenPreviousDocuments(clusterUri: string): void {
     this.setState(draftState => {
       const workspace = draftState.workspaces[clusterUri];
-      workspace.documents = workspace.previous.documents;
+      workspace.documents = workspace.previous.documents.map(d => {
+        //TODO: create a function that will prepare a new document, it will be used in:
+        // DocumentsService
+        // TrackedConnectionOperationsFactory
+        // here
+        if (
+          d.kind === 'doc.terminal_tsh_kube' ||
+          d.kind === 'doc.terminal_tsh_node'
+        ) {
+          return {
+            ...d,
+            status: 'connecting',
+          };
+        }
+        return d;
+      });
       workspace.location = workspace.previous.location;
       workspace.previous = undefined;
     });


### PR DESCRIPTION
Closes https://github.com/gravitational/webapps.e/issues/284 

I extended Zac's idea a bit, we will create a separate kubeconfig per kube cluster (not per tab). The file is deleted when the user removes the connection. Multiple tabs opened to the same kube cluster share the same kubeconfig.     
This is conceptually similar to db access, where we keep a port for a given connection. 

I also added a loading indicator for tsh and kube tabs.