### PR TITLE
add cluster alert links to UX

### DIFF
--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -32,6 +32,8 @@ import { FeatureBox } from 'teleport/components/Layout';
 import { BannerList } from 'teleport/components/BannerList';
 import cfg from 'teleport/config';
 
+import { LinkLabel } from 'teleport/services/alerts/alerts';
+
 import { useDiscover, State } from './useDiscover';
 import { SelectResource } from './SelectResource';
 import { DownloadScript } from './DownloadScript';
@@ -106,6 +108,7 @@ export function Discover({
   const banners: BannerType[] = alerts.map(alert => ({
     message: alert.spec.message,
     severity: mapSeverity(alert.spec.severity),
+    link: alert.metadata.labels[LinkLabel],
     id: alert.metadata.name,
   }));
 

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -32,7 +32,7 @@ import { FeatureBox } from 'teleport/components/Layout';
 import { BannerList } from 'teleport/components/BannerList';
 import cfg from 'teleport/config';
 
-import { LinkLabel } from 'teleport/services/alerts/alerts';
+import { LINK_LABEL } from 'teleport/services/alerts/alerts';
 
 import { useDiscover, State } from './useDiscover';
 import { SelectResource } from './SelectResource';
@@ -108,7 +108,7 @@ export function Discover({
   const banners: BannerType[] = alerts.map(alert => ({
     message: alert.spec.message,
     severity: mapSeverity(alert.spec.severity),
-    link: alert.metadata.labels[LinkLabel],
+    link: alert.metadata.labels[LINK_LABEL],
     id: alert.metadata.name,
   }));
 

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -30,7 +30,7 @@ import getFeatures from 'teleport/features';
 import localStorage from 'teleport/services/localStorage';
 import history from 'teleport/services/history';
 
-import { LinkLabel } from 'teleport/services/alerts/alerts';
+import { LINK_LABEL } from 'teleport/services/alerts/alerts';
 
 import { MainContainer } from './MainContainer';
 import { OnboardDiscover } from './OnboardDiscover';
@@ -117,7 +117,7 @@ export function Main(props: State) {
   const banners: BannerType[] = alerts.map(alert => ({
     message: alert.spec.message,
     severity: mapSeverity(alert.spec.severity),
-    link: alert.metadata.labels[LinkLabel],
+    link: alert.metadata.labels[LINK_LABEL],
     id: alert.metadata.name,
   }));
 

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -30,6 +30,8 @@ import getFeatures from 'teleport/features';
 import localStorage from 'teleport/services/localStorage';
 import history from 'teleport/services/history';
 
+import { LinkLabel } from 'teleport/services/alerts/alerts';
+
 import { MainContainer } from './MainContainer';
 import { OnboardDiscover } from './OnboardDiscover';
 import useMain, { State } from './useMain';
@@ -115,6 +117,7 @@ export function Main(props: State) {
   const banners: BannerType[] = alerts.map(alert => ({
     message: alert.spec.message,
     severity: mapSeverity(alert.spec.severity),
+    link: alert.metadata.labels[LinkLabel],
     id: alert.metadata.name,
   }));
 

--- a/packages/teleport/src/components/BannerList/Banner.test.tsx
+++ b/packages/teleport/src/components/BannerList/Banner.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { render, fireEvent, screen } from 'design/utils/testing';
+import { fireEvent, render, screen } from 'design/utils/testing';
 
 import { Banner } from './Banner';
 
@@ -87,5 +87,54 @@ describe('components/BannerList/Banner', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledWith(id);
+  });
+  describe('with link', () => {
+    it('renders valid URLs as links', () => {
+      const message = 'some-message-with-valid-URL';
+      render(
+        <Banner
+          message={message}
+          severity="info"
+          id="some-id"
+          link="https://goteleport.com/docs"
+          onClose={() => {}}
+        />
+      );
+      expect(screen.getByText(message)).toBeInTheDocument();
+      expect(screen.getByText(message).closest('a')).toHaveAttribute(
+        'href',
+        'https://goteleport.com/docs'
+      );
+    });
+
+    it('renders invalid URLs as text', () => {
+      const message = 'some-message';
+      render(
+        <Banner
+          message={message}
+          severity="info"
+          id="some-id"
+          link="{https://goteleport.com/docs"
+          onClose={() => {}}
+        />
+      );
+      expect(screen.getByText(message)).toBeInTheDocument();
+      expect(screen.queryByText(message).closest('a')).not.toBeInTheDocument();
+    });
+
+    it('renders non-teleport URL as text', () => {
+      const message = 'message';
+      render(
+        <Banner
+          message={message}
+          severity="info"
+          id="some-id"
+          link="https://www.google.com/"
+          onClose={() => {}}
+        />
+      );
+      expect(screen.getByText(message)).toBeInTheDocument();
+      expect(screen.queryByText(message).closest('a')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/teleport/src/components/BannerList/Banner.test.tsx
+++ b/packages/teleport/src/components/BannerList/Banner.test.tsx
@@ -88,6 +88,7 @@ describe('components/BannerList/Banner', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledWith(id);
   });
+
   describe('with link', () => {
     it('renders valid URLs as links', () => {
       const message = 'some-message-with-valid-URL';
@@ -101,7 +102,7 @@ describe('components/BannerList/Banner', () => {
         />
       );
       expect(screen.getByText(message)).toBeInTheDocument();
-      expect(screen.getByText(message).closest('a')).toHaveAttribute(
+      expect(screen.getByRole('link', { name: message })).toHaveAttribute(
         'href',
         'https://goteleport.com/docs'
       );
@@ -119,7 +120,9 @@ describe('components/BannerList/Banner', () => {
         />
       );
       expect(screen.getByText(message)).toBeInTheDocument();
-      expect(screen.queryByText(message).closest('a')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: message })
+      ).not.toBeInTheDocument();
     });
 
     it('renders non-teleport URL as text', () => {
@@ -134,7 +137,9 @@ describe('components/BannerList/Banner', () => {
         />
       );
       expect(screen.getByText(message)).toBeInTheDocument();
-      expect(screen.queryByText(message).closest('a')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: message })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/teleport/src/components/BannerList/Banner.tsx
+++ b/packages/teleport/src/components/BannerList/Banner.tsx
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
-import { Box, Flex, Text } from 'design';
+import { Box, Flex, Link, Text } from 'design';
 import { Cross, Info, Warning } from 'design/Icon';
 
 export type Severity = 'info' | 'warning' | 'danger';
@@ -26,6 +26,7 @@ export type Props = {
   message: string;
   severity: Severity;
   id: string;
+  link?: string;
   onClose: (id: string) => void;
 };
 
@@ -33,6 +34,7 @@ export function Banner({
   id,
   message = '',
   severity = 'info',
+  link = '',
   onClose,
 }: Props) {
   const icon = {
@@ -41,11 +43,34 @@ export function Banner({
     danger: <Warning mr={3} fontSize="3" role="icon" />,
   }[severity];
 
+  const getLink = useMemo(() => {
+    // link is also validated on the back end, adding extra precautions
+    try {
+      const url = new URL(link);
+      if (url.hostname != 'goteleport.com') {
+        return <Text bold>{message}</Text>;
+      }
+    } catch (_) {
+      return <Text bold>{message}</Text>;
+    }
+
+    return (
+      <Link
+        href={link}
+        target="_blank"
+        color="light"
+        style={{ fontWeight: 'bold' }}
+      >
+        {message}
+      </Link>
+    );
+  }, [link]);
+
   return (
     <Box bg={severity} p={1} pl={2}>
       <Flex alignItems="center">
         {icon}
-        <Text bold>{message}</Text>
+        {link != '' ? getLink : <Text bold>{message}</Text>}
         <CloseButton
           onClick={() => {
             onClose(id);

--- a/packages/teleport/src/components/BannerList/Banner.tsx
+++ b/packages/teleport/src/components/BannerList/Banner.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { Box, Flex, Link, Text } from 'design';
@@ -43,34 +43,31 @@ export function Banner({
     danger: <Warning mr={3} fontSize="3" role="icon" />,
   }[severity];
 
-  const getLink = useMemo(() => {
-    // link is also validated on the back end, adding extra precautions
+  const isValidTeleportLink = (link: string) => {
     try {
       const url = new URL(link);
-      if (url.hostname != 'goteleport.com') {
-        return <Text bold>{message}</Text>;
-      }
-    } catch (_) {
-      return <Text bold>{message}</Text>;
+      return url.hostname === 'goteleport.com';
+    } catch {
+      return false;
     }
-
-    return (
-      <Link
-        href={link}
-        target="_blank"
-        color="light"
-        style={{ fontWeight: 'bold' }}
-      >
-        {message}
-      </Link>
-    );
-  }, [link]);
+  };
 
   return (
     <Box bg={severity} p={1} pl={2}>
       <Flex alignItems="center">
         {icon}
-        {link != '' ? getLink : <Text bold>{message}</Text>}
+        {isValidTeleportLink(link) ? (
+          <Link
+            href={link}
+            target="_blank"
+            color="light"
+            style={{ fontWeight: 'bold' }}
+          >
+            {message}
+          </Link>
+        ) : (
+          <Text bold>{message}</Text>
+        )}
         <CloseButton
           onClick={() => {
             onClose(id);

--- a/packages/teleport/src/components/BannerList/BannerList.tsx
+++ b/packages/teleport/src/components/BannerList/BannerList.tsx
@@ -62,6 +62,7 @@ export const BannerList = ({
           message={banner.message}
           severity={banner.severity}
           id={banner.id}
+          link={banner.link}
           onClose={removeBanner}
           key={banner.id}
         />
@@ -94,5 +95,6 @@ export type BannerType = {
   message: string;
   severity: Severity;
   id: string;
+  link?: string;
   hidden?: boolean;
 };

--- a/packages/teleport/src/components/BannerList/useAlerts.test.tsx
+++ b/packages/teleport/src/components/BannerList/useAlerts.test.tsx
@@ -33,6 +33,7 @@ const ALERTS = [
       labels: {
         'teleport.internal/alert-on-login': 'yes',
         'teleport.internal/alert-permit-all': 'yes',
+        'teleport.internal/link': 'some-URL',
       },
       expires: '2022-08-31T17:26:05.728149Z',
     },

--- a/packages/teleport/src/services/alerts/alerts.tsx
+++ b/packages/teleport/src/services/alerts/alerts.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 
-export const LinkLabel = 'teleport.internal/link';
+export const LINK_LABEL = 'teleport.internal/link';
 
 export type ClusterAlert = {
   kind: string;

--- a/packages/teleport/src/services/alerts/alerts.tsx
+++ b/packages/teleport/src/services/alerts/alerts.tsx
@@ -17,6 +17,8 @@ limitations under the License.
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 
+export const LinkLabel = 'teleport.internal/link';
+
 export type ClusterAlert = {
   kind: string;
   version: string;


### PR DESCRIPTION
Supports: https://github.com/gravitational/teleport/issues/16425
Teleport PR: https://github.com/gravitational/teleport/pull/16426

Renders "teleport.internal/link" label as link in UX