### PR TITLE
Create TextSelectCopyMulti that allows multi lines and adding comments

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -30,6 +30,7 @@
     "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^27.3.1",
     "@types/lodash": "4.14.149",
     "@types/node": "^16.11.10",

--- a/packages/design/src/Icon/Icon.jsx
+++ b/packages/design/src/Icon/Icon.jsx
@@ -77,6 +77,7 @@ export const ChatBubble = makeFontIcon(
   'ChatBubble',
   'icon-chat_bubble_outline'
 );
+export const Check = makeFontIcon('Check', 'icon-check');
 export const ChevronCircleDown = makeFontIcon(
   'ChevronCircleDown',
   'icon-chevron-down-circle'
@@ -124,6 +125,7 @@ export const Code = makeFontIcon('Code', 'icon-code');
 export const Cog = makeFontIcon('Cog', 'icon-cog');
 export const Config = makeFontIcon('Config', 'icon-config');
 export const Contract = makeFontIcon('Contract', 'icon-frame-contract');
+export const Copy = makeFontIcon('Copy', 'icon-copy');
 export const CreditCard = makeFontIcon('CreditCard', 'icon-credit-card1');
 export const CreditCardAlt = makeFontIcon(
   'CreditCardAlt',

--- a/packages/design/src/Icon/Icon.story.js
+++ b/packages/design/src/Icon/Icon.story.js
@@ -58,6 +58,7 @@ export const ListOfIcons = () => (
     <IconBox IconCmpt={Icon.CarrotUp} text="CarrotUp" />
     <IconBox IconCmpt={Icon.Cash} text="Cash" />
     <IconBox IconCmpt={Icon.ChatBubble} text="ChatBubble" />
+    <IconBox IconCmpt={Icon.Check} text="Check" />
     <IconBox IconCmpt={Icon.ChevronCircleDown} text="ChevronCircleDown" />
     <IconBox IconCmpt={Icon.ChevronCircleLeft} text="ChevronCircleLeft" />
     <IconBox IconCmpt={Icon.ChevronCircleRight} text="ChevronCircleRight" />
@@ -87,6 +88,7 @@ export const ListOfIcons = () => (
     <IconBox IconCmpt={Icon.Cog} text="Cog" />
     <IconBox IconCmpt={Icon.Config} text="Config" />
     <IconBox IconCmpt={Icon.Contract} text="Contract" />
+    <IconBox IconCmpt={Icon.Copy} text="Copy" />
     <IconBox IconCmpt={Icon.CreditCard} text="CreditCard" />
     <IconBox IconCmpt={Icon.CreditCardAlt} text="CreditCardAlt" />
     <IconBox IconCmpt={Icon.CreditCardAlt2} text="CreditCardAlt2" />

--- a/packages/design/src/utils/copyToClipboard.ts
+++ b/packages/design/src/utils/copyToClipboard.ts
@@ -20,32 +20,8 @@
  * @param textToCopy the text to copy to clipboard
  */
 export default function copyToClipboard(textToCopy: string): Promise<any> {
-  // DELETE when navigator.clipboard is not a working draft
-  if (fallbackCopyToClipboard(textToCopy)) {
-    return Promise.resolve();
-  }
-
   return navigator.clipboard.writeText(textToCopy).catch(err => {
     // This can happen if the user denies clipboard permissions:
     window.prompt('Cannot copy to clipboard. Use ctrl/cmd + c', err);
   });
-}
-
-/**
- * fallbackCopyToClipboard is used when navigator.clipboard is not supported.
- * Note: document.execCommand is marked obselete.
- *
- * @param textToCopy the text to copy to clipboard
- */
-function fallbackCopyToClipboard(textToCopy: string): boolean {
-  let aux = document.createElement('textarea');
-  aux.value = textToCopy;
-  document.body.appendChild(aux);
-  aux.select();
-
-  // returns false if the command is not supported or enabled
-  let isSuccess = document.execCommand('copy');
-  document.body.removeChild(aux);
-
-  return isSuccess;
 }

--- a/packages/design/src/utils/testing.tsx
+++ b/packages/design/src/utils/testing.tsx
@@ -24,6 +24,7 @@ import {
   prettyDOM,
   getByTestId,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter as Router } from 'react-router-dom';
 
 import ThemeProvider from 'design/ThemeProvider';
@@ -58,4 +59,5 @@ export {
   waitFor,
   getByTestId,
   Router,
+  userEvent,
 };

--- a/packages/teleport/src/components/TextSelectCopy/TextSelectCopy.story.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/TextSelectCopy.story.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 
-import Component from './TextSelectCopy';
+import { TextSelectCopy as Component } from './TextSelectCopy';
 
 export default {
   title: 'Teleport/TextSelectCopy',

--- a/packages/teleport/src/components/TextSelectCopy/TextSelectCopy.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/TextSelectCopy.tsx
@@ -20,7 +20,7 @@ import selectElementContent from 'design/utils/selectElementContent';
 import { ButtonPrimary, Box, Flex } from 'design';
 import { useTheme } from 'styled-components';
 
-export default function TextSelectCopy({
+export function TextSelectCopy({
   text,
   fontFamily,
   allowMultiline,

--- a/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.story.test.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.story.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { render } from 'design/utils/testing';
+
+import * as stories from './TextSelectCopyMulti.story';
+
+test('render multi bash texts', () => {
+  const { container } = render(<stories.BashMulti />);
+  expect(container).toMatchSnapshot();
+});
+
+test('render multi bash texts with comment', () => {
+  const { container } = render(<stories.BashMultiWithComment />);
+  expect(container).toMatchSnapshot();
+});
+
+test('render single bash text', () => {
+  const { container } = render(<stories.BashSingle />);
+  expect(container).toMatchSnapshot();
+});
+
+test('render single bash text with comment', () => {
+  const { container } = render(<stories.BashSingleWithComment />);
+  expect(container).toMatchSnapshot();
+});
+
+test('render non bash single text', () => {
+  const { container } = render(<stories.NonBash />);
+  expect(container).toMatchSnapshot();
+});

--- a/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.story.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.story.tsx
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { TextSelectCopyMulti as Component } from './TextSelectCopyMulti';
+
+export default {
+  title: 'Teleport/TextSelectCopy/Multi',
+};
+
+export const BashMulti = () => {
+  return (
+    <Component
+      lines={[
+        {
+          text: `sudo tctl -c cfg-all users add --roles=access,editor george_washington`,
+        },
+        {
+          text: 'sudo DEBUG=1 teleport start -c cfg-all -d',
+        },
+        {
+          text: 'yarn start-teleport-e --target=https://localhost:3080/web',
+        },
+      ]}
+    />
+  );
+};
+
+export const BashMultiWithComment = () => {
+  return (
+    <Component
+      lines={[
+        {
+          text: `sudo curl https://apt.releases.teleport.dev/gpg \\\n-o /usr/share/keyrings/teleport-archive-keyring.asc`,
+          comment: `Download Teleport's PGP public key`,
+        },
+        {
+          text: 'sudo DEBUG=1 teleport start -c cfg-all -d',
+        },
+        {
+          text:
+            `echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \\\n` +
+            `https://apt.releases.teleport.dev/stable/v10" \\\n` +
+            `| sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null`,
+          comment:
+            `Add the Teleport APT repository for v10. You'll need to update this` +
+            `\nfile for each major release of Teleport.\n` +
+            `Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'\n` +
+            `and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.\n`,
+        },
+      ]}
+    />
+  );
+};
+
+export const BashSingle = () => {
+  return (
+    <Component
+      lines={[
+        {
+          text: `sudo tctl -c cfg-all users add --roles=access,editor george_washington`,
+        },
+      ]}
+    />
+  );
+};
+
+export const BashSingleWithComment = () => {
+  return (
+    <Component
+      lines={[
+        {
+          text: `sudo tctl -c cfg-all users add --roles=access,editor george_washington`,
+          comment: `Add the Teleport API repository for v10. You'll need to update this.`,
+        },
+      ]}
+    />
+  );
+};
+
+export const NonBash = () => {
+  return (
+    <Component
+      lines={[
+        {
+          text: 'some -c text to be copied and it is super long to test scrolling',
+        },
+      ]}
+      bash={false}
+    />
+  );
+};

--- a/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.test.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { render, screen, fireEvent, waitFor } from 'design/utils/testing';
+
+import { TextSelectCopyMulti } from './TextSelectCopyMulti';
+
+const originalNavigator = window.navigator;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  Object.assign(window.navigator, {
+    clipboard: {
+      writeText: jest.fn().mockImplementation(() => Promise.resolve()),
+    },
+  });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  Object.assign(window.navigator, originalNavigator);
+});
+
+test('changing of icon when button is clicked', async () => {
+  render(<TextSelectCopyMulti lines={[{ text: 'some text to copy' }]} />);
+
+  // Init button states.
+  expect(screen.queryByTestId('btn-copy')).toBeVisible();
+  expect(screen.queryByTestId('btn-check')).not.toBeVisible();
+
+  // Clicking copy button should change the button icon to "check".
+  fireEvent.click(screen.getByTestId('btn-copy'));
+  await waitFor(() => expect(screen.getByTestId('btn-check')).toBeVisible());
+  expect(screen.queryByTestId('btn-copy')).not.toBeVisible();
+  expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+    'some text to copy'
+  );
+
+  // After set time out, the buttons should return to its initial state.
+  jest.runAllTimers();
+  expect(screen.queryByTestId('btn-copy')).toBeVisible();
+  expect(screen.queryByTestId('btn-check')).not.toBeVisible();
+});
+
+test('correct copying of texts', async () => {
+  render(
+    <TextSelectCopyMulti
+      lines={[
+        { text: 'text to copy1', comment: 'first comment' },
+        { text: 'text to copy2', comment: 'second comment' },
+      ]}
+    />
+  );
+
+  // Test copying of each text.
+  const btns = screen.queryAllByRole('button');
+  expect(btns).toHaveLength(2);
+
+  fireEvent.click(btns[1]);
+  expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+    'text to copy2'
+  );
+
+  fireEvent.click(btns[0]);
+  expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+    'text to copy1'
+  );
+});

--- a/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.test.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.test.tsx
@@ -16,11 +16,9 @@
 
 import React from 'react';
 
-import { render, screen, fireEvent, waitFor } from 'design/utils/testing';
+import { render, screen, fireEvent } from 'design/utils/testing';
 
 import { TextSelectCopyMulti } from './TextSelectCopyMulti';
-
-const originalNavigator = window.navigator;
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -33,7 +31,6 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.resetAllMocks();
-  Object.assign(window.navigator, originalNavigator);
 });
 
 test('changing of icon when button is clicked', async () => {
@@ -45,7 +42,7 @@ test('changing of icon when button is clicked', async () => {
 
   // Clicking copy button should change the button icon to "check".
   fireEvent.click(screen.getByTestId('btn-copy'));
-  await waitFor(() => expect(screen.getByTestId('btn-check')).toBeVisible());
+  await expect(screen.findByTestId('btn-check')).resolves.toBeVisible();
   expect(screen.queryByTestId('btn-copy')).not.toBeVisible();
   expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
     'some text to copy'

--- a/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/TextSelectCopyMulti.tsx
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useCallback, useRef } from 'react';
+import styled from 'styled-components';
+import copyToClipboard from 'design/utils/copyToClipboard';
+import selectElementContent from 'design/utils/selectElementContent';
+import { ButtonSecondary, Box, Flex } from 'design';
+import { Copy, Check } from 'design/Icon';
+
+const ONE_SECOND_IN_MS = 1000;
+
+export function TextSelectCopyMulti({ lines, bash = true }: Props) {
+  const btnRefs = useRef<HTMLElement[]>([]);
+  const [lineEls, setLineEls] = useState<HTMLElement[]>([]);
+
+  const linesRef = useCallback((node: HTMLElement) => {
+    // Grab the mounted line childrens to be able to calculate spacers
+    // for button placements.
+    if (node) {
+      const childElements: HTMLElement[] = Array(node.children.length);
+      for (var i = 0; i < node.children.length; i++) {
+        childElements[i] = node.children[i] as HTMLElement;
+      }
+      setLineEls(childElements);
+    }
+  }, []);
+
+  function onCopyClick(index) {
+    copyToClipboard(lines[index].text).then(() => {
+      const targetEl =
+        btnRefs.current[index].getElementsByClassName('icon-container')[0];
+      targetEl.classList.toggle('copied');
+
+      setTimeout(() => {
+        targetEl.classList.toggle('copied');
+      }, ONE_SECOND_IN_MS);
+    });
+
+    const targetEl = lineEls[index].getElementsByClassName('text-to-copy')[0];
+    selectElementContent(targetEl as HTMLElement);
+  }
+
+  const isFirefox = window.navigator?.userAgent
+    ?.toLowerCase()
+    .includes('firefox');
+
+  return (
+    <Flex
+      bg="bgTerminal"
+      px={3}
+      pt={2}
+      // Firefox does not add space for visible scrollbars
+      // like it does for chrome and safari.
+      pb={isFirefox ? 3 : 2}
+      alignItems="flex-start"
+      justifyContent="space-between"
+      borderRadius={2}
+      css={{
+        // Make it visible to user only when we have buttons to render
+        // to avoid possible flashing between renders.
+        visibility: lineEls.length > 0 ? 'none' : 'hidden',
+      }}
+    >
+      <Lines mr={1} ref={linesRef}>
+        {lines.map((line, index) => {
+          const isLastText = index === lines.length - 1;
+          return (
+            <Box pt={2} pb={isLastText ? 0 : 2} key={index}>
+              {line.comment && <Comment>{line.comment}</Comment>}
+              <Flex key={index}>
+                {bash && <Box mr="1">{`$`}</Box>}
+                <div className="text-to-copy">{line.text}</div>
+              </Flex>
+            </Box>
+          );
+        })}
+      </Lines>
+      <Box>
+        {lineEls.map((el, index) => {
+          const isLastText = index === lines.length - 1;
+          let spacer;
+          if (lines[index].comment) {
+            spacer = (
+              <Box
+                height={(el.firstElementChild as HTMLElement).offsetHeight}
+                mt={isLastText ? 0 : 1}
+              />
+            );
+          }
+
+          return (
+            <Box
+              height={el.offsetHeight}
+              key={index}
+              pt={1}
+              ref={s => (btnRefs.current[index] = s)}
+            >
+              {spacer}
+              <ButtonCopyCheck onClick={() => onCopyClick(index)}>
+                <Icon className="icon-container">
+                  <Copy data-testid="btn-copy" />
+                  <Check data-testid="btn-check" />
+                </Icon>
+              </ButtonCopyCheck>
+            </Box>
+          );
+        })}
+      </Box>
+    </Flex>
+  );
+}
+
+const Icon = styled.div`
+  .icon-check {
+    display: none;
+  }
+  .icon-copy {
+    display: block;
+  }
+
+  &.copied {
+    .icon-check {
+      display: block;
+    }
+    .icon-copy {
+      display: none;
+    }
+  }
+`;
+
+const Comment = styled.div`
+  color: rgb(117 113 94 / 80%);
+`;
+
+const ButtonCopyCheck = styled(ButtonSecondary)`
+  height: 28px;
+  width: 28px;
+  border-radius: 20px;
+  min-height: auto;
+  padding: 0;
+`;
+
+const Lines = styled(Box)`
+  white-space: pre;
+  word-break: break-all;
+  font-size: 12px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  overflow: scroll;
+  line-height: 20px;
+`;
+
+type Line = {
+  // text is the text to copy.
+  text: string;
+  // comment is an optional grayed out text that
+  // will render above the text to copy.
+  comment?: string;
+};
+
+export type Props = {
+  lines: Line[];
+  // bash is a flag that when true will append a
+  // `$` sign in front of the lines text.
+  bash?: boolean;
+};

--- a/packages/teleport/src/components/TextSelectCopy/__snapshots__/TextSelectCopyMulti.story.test.tsx.snap
+++ b/packages/teleport/src/components/TextSelectCopy/__snapshots__/TextSelectCopyMulti.story.test.tsx.snap
@@ -12,590 +12,10 @@ exports[`render multi bash texts 1`] = `
   margin-right: 4px;
 }
 
-.c5 {
-  box-sizing: border-box;
-  padding-bottom: 0px;
-  padding-top: 8px;
-}
-
-.c6 {
-  box-sizing: border-box;
-}
-
-.c7 {
-  box-sizing: border-box;
-  padding-top: 4px;
-  height: 0px;
-}
-
-.c8 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #222C59;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-}
-
-.c8:active {
-  opacity: 0.56;
-}
-
-.c8:hover,
-.c8:focus {
-  background: #2C3A73;
-}
-
-.c8:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c11 {
-  display: inline-block;
-  transition: color 0.3s;
-  color: #FFFFFF;
-}
-
-.c3 {
-  box-sizing: border-box;
-  display: flex;
-}
-
-.c10 .icon-check {
-  display: none;
-}
-
-.c10 .icon-copy {
-  display: block;
-}
-
-.c10.copied .icon-check {
-  display: block;
-}
-
-.c10.copied .icon-copy {
-  display: none;
-}
-
-.c9 {
-  height: 28px;
-  width: 28px;
-  border-radius: 20px;
-  min-height: auto;
-  padding: 0;
-}
-
-.c1 {
-  box-sizing: border-box;
-  margin-right: 4px;
-  white-space: pre;
-  word-break: break-all;
-  font-size: 12px;
-  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
-  overflow: scroll;
-  line-height: 20px;
-}
-
-.c0 {
-  box-sizing: border-box;
-  padding-bottom: 8px;
-  padding-top: 8px;
-  padding-left: 16px;
-  padding-right: 16px;
-  background-color: #010B1C;
-  border-radius: 4px;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  visibility: none;
-}
-
-<div>
-  <div
-    class="c0"
-  >
-    <div
-      class="c1"
-    >
-      <div
-        class="c2"
-      >
-        <div
-          class="c3"
-        >
-          <div
-            class="c4"
-          >
-            $
-          </div>
-          <div
-            class="text-to-copy"
-          >
-            sudo tctl -c cfg-all users add --roles=access,editor george_washington
-          </div>
-        </div>
-      </div>
-      <div
-        class="c2"
-      >
-        <div
-          class="c3"
-        >
-          <div
-            class="c4"
-          >
-            $
-          </div>
-          <div
-            class="text-to-copy"
-          >
-            sudo DEBUG=1 teleport start -c cfg-all -d
-          </div>
-        </div>
-      </div>
-      <div
-        class="c5"
-      >
-        <div
-          class="c3"
-        >
-          <div
-            class="c4"
-          >
-            $
-          </div>
-          <div
-            class="text-to-copy"
-          >
-            yarn start-teleport-e --target=https://localhost:3080/web
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="c6"
-    >
-      <div
-        class="c7"
-        height="0"
-      >
-        <button
-          class="c8 c9"
-          kind="secondary"
-        >
-          <div
-            class="c10 icon-container"
-          >
-            <span
-              class="c11 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c11 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
-          </div>
-        </button>
-      </div>
-      <div
-        class="c7"
-        height="0"
-      >
-        <button
-          class="c8 c9"
-          kind="secondary"
-        >
-          <div
-            class="c10 icon-container"
-          >
-            <span
-              class="c11 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c11 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
-          </div>
-        </button>
-      </div>
-      <div
-        class="c7"
-        height="0"
-      >
-        <button
-          class="c8 c9"
-          kind="secondary"
-        >
-          <div
-            class="c10 icon-container"
-          >
-            <span
-              class="c11 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c11 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
-          </div>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`render multi bash texts with comment 1`] = `
-.c2 {
-  box-sizing: border-box;
-  padding-bottom: 8px;
-  padding-top: 8px;
-}
-
-.c5 {
-  box-sizing: border-box;
-  margin-right: 4px;
-}
-
-.c6 {
-  box-sizing: border-box;
-  padding-bottom: 0px;
-  padding-top: 8px;
-}
-
-.c7 {
-  box-sizing: border-box;
-}
-
-.c8 {
-  box-sizing: border-box;
-  padding-top: 4px;
-  height: 0px;
-}
-
-.c9 {
-  box-sizing: border-box;
-  margin-top: 4px;
-  height: 0px;
-}
-
-.c14 {
-  box-sizing: border-box;
-  margin-top: 0px;
-  height: 0px;
-}
-
 .c10 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  background: #222C59;
-  color: rgba(255,255,255,0.87);
-  min-height: 32px;
-  font-size: 12px;
-  padding: 0px 24px;
-}
-
-.c10:active {
-  opacity: 0.56;
-}
-
-.c10:hover,
-.c10:focus {
-  background: #2C3A73;
-}
-
-.c10:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-}
-
-.c13 {
-  display: inline-block;
-  transition: color 0.3s;
-  color: #FFFFFF;
-}
-
-.c4 {
-  box-sizing: border-box;
-  display: flex;
-}
-
-.c12 .icon-check {
-  display: none;
-}
-
-.c12 .icon-copy {
-  display: block;
-}
-
-.c12.copied .icon-check {
-  display: block;
-}
-
-.c12.copied .icon-copy {
-  display: none;
-}
-
-.c3 {
-  color: rgb(117 113 94 / 80%);
-}
-
-.c11 {
-  height: 28px;
-  width: 28px;
-  border-radius: 20px;
-  min-height: auto;
-  padding: 0;
-}
-
-.c1 {
-  box-sizing: border-box;
-  margin-right: 4px;
-  white-space: pre;
-  word-break: break-all;
-  font-size: 12px;
-  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
-  overflow: scroll;
-  line-height: 20px;
-}
-
-.c0 {
-  box-sizing: border-box;
-  padding-bottom: 8px;
-  padding-top: 8px;
-  padding-left: 16px;
-  padding-right: 16px;
-  background-color: #010B1C;
-  border-radius: 4px;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  visibility: none;
-}
-
-<div>
-  <div
-    class="c0"
-  >
-    <div
-      class="c1"
-    >
-      <div
-        class="c2"
-      >
-        <div
-          class="c3"
-        >
-          Download Teleport's PGP public key
-        </div>
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            $
-          </div>
-          <div
-            class="text-to-copy"
-          >
-            sudo curl https://apt.releases.teleport.dev/gpg \\
--o /usr/share/keyrings/teleport-archive-keyring.asc
-          </div>
-        </div>
-      </div>
-      <div
-        class="c2"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            $
-          </div>
-          <div
-            class="text-to-copy"
-          >
-            sudo DEBUG=1 teleport start -c cfg-all -d
-          </div>
-        </div>
-      </div>
-      <div
-        class="c6"
-      >
-        <div
-          class="c3"
-        >
-          Add the Teleport APT repository for v10. You'll need to update this
-file for each major release of Teleport.
-Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
-and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
-
-        </div>
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            $
-          </div>
-          <div
-            class="text-to-copy"
-          >
-            echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \\
-https://apt.releases.teleport.dev/stable/v10" \\
-| sudo tee /etc/apt/sources.list.d/teleport.list &gt; /dev/null
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="c7"
-    >
-      <div
-        class="c8"
-        height="0"
-      >
-        <div
-          class="c9"
-          height="0"
-        />
-        <button
-          class="c10 c11"
-          kind="secondary"
-        >
-          <div
-            class="c12 icon-container"
-          >
-            <span
-              class="c13 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c13 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
-          </div>
-        </button>
-      </div>
-      <div
-        class="c8"
-        height="0"
-      >
-        <button
-          class="c10 c11"
-          kind="secondary"
-        >
-          <div
-            class="c12 icon-container"
-          >
-            <span
-              class="c13 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c13 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
-          </div>
-        </button>
-      </div>
-      <div
-        class="c8"
-        height="0"
-      >
-        <div
-          class="c14"
-          height="0"
-        />
-        <button
-          class="c10 c11"
-          kind="secondary"
-        >
-          <div
-            class="c12 icon-container"
-          >
-            <span
-              class="c13 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c13 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
-          </div>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`render non bash single text 1`] = `
-.c2 {
   box-sizing: border-box;
   padding-bottom: 0px;
   padding-top: 8px;
-}
-
-.c4 {
-  box-sizing: border-box;
-}
-
-.c5 {
-  box-sizing: border-box;
-  padding-top: 4px;
-  height: 0px;
 }
 
 .c6 {
@@ -671,6 +91,7 @@ exports[`render non bash single text 1`] = `
   border-radius: 20px;
   min-height: auto;
   padding: 0;
+  margin-top: -4px;
 }
 
 .c1 {
@@ -687,15 +108,19 @@ exports[`render non bash single text 1`] = `
 .c0 {
   box-sizing: border-box;
   padding-bottom: 8px;
-  padding-top: 8px;
   padding-left: 16px;
-  padding-right: 16px;
+  padding-right: 48px;
+  padding-top: 8px;
   background-color: #010B1C;
   border-radius: 4px;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  visibility: none;
+  position: relative;
+}
+
+.c5 {
+  box-sizing: border-box;
+  padding-right: 16px;
+  position: absolute;
+  right: 0px;
 }
 
 <div>
@@ -712,65 +137,155 @@ exports[`render non bash single text 1`] = `
           class="c3"
         >
           <div
-            class="text-to-copy"
+            class="c3"
           >
-            some -c text to be copied and it is super long to test scrolling
+            <div
+              class="c4"
+            >
+              $
+            </div>
+            <div
+              class="text-to-copy"
+            >
+              sudo tctl -c cfg-all users add --roles=access,editor george_washington
+            </div>
+          </div>
+          <div
+            class="c5"
+          >
+            <button
+              class="c6 c7"
+              kind="secondary"
+            >
+              <div
+                class="c8 icon-container"
+              >
+                <span
+                  class="c9 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c9 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c4"
-    >
       <div
-        class="c5"
-        height="0"
+        class="c2"
       >
-        <button
-          class="c6 c7"
-          kind="secondary"
+        <div
+          class="c3"
         >
           <div
-            class="c8 icon-container"
+            class="c3"
           >
-            <span
-              class="c9 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c9 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
+            <div
+              class="c4"
+            >
+              $
+            </div>
+            <div
+              class="text-to-copy"
+            >
+              sudo DEBUG=1 teleport start -c cfg-all -d
+            </div>
           </div>
-        </button>
+          <div
+            class="c5"
+          >
+            <button
+              class="c6 c7"
+              kind="secondary"
+            >
+              <div
+                class="c8 icon-container"
+              >
+                <span
+                  class="c9 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c9 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c10"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c3"
+          >
+            <div
+              class="c4"
+            >
+              $
+            </div>
+            <div
+              class="text-to-copy"
+            >
+              yarn start-teleport-e --target=https://localhost:3080/web
+            </div>
+          </div>
+          <div
+            class="c5"
+          >
+            <button
+              class="c6 c7"
+              kind="secondary"
+            >
+              <div
+                class="c8 icon-container"
+              >
+                <span
+                  class="c9 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c9 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`render single bash text 1`] = `
+exports[`render multi bash texts with comment 1`] = `
 .c2 {
   box-sizing: border-box;
-  padding-bottom: 0px;
+  padding-bottom: 8px;
   padding-top: 8px;
-}
-
-.c4 {
-  box-sizing: border-box;
-  margin-right: 4px;
 }
 
 .c5 {
   box-sizing: border-box;
+  margin-right: 4px;
 }
 
-.c6 {
+.c11 {
   box-sizing: border-box;
-  padding-top: 4px;
-  height: 0px;
+  padding-bottom: 0px;
+  padding-top: 8px;
 }
 
 .c7 {
@@ -819,7 +334,7 @@ exports[`render single bash text 1`] = `
   color: #FFFFFF;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   display: flex;
 }
@@ -840,12 +355,17 @@ exports[`render single bash text 1`] = `
   display: none;
 }
 
+.c3 {
+  color: rgb(117 113 94 / 80%);
+}
+
 .c8 {
   height: 28px;
   width: 28px;
   border-radius: 20px;
   min-height: auto;
   padding: 0;
+  margin-top: -4px;
 }
 
 .c1 {
@@ -862,15 +382,19 @@ exports[`render single bash text 1`] = `
 .c0 {
   box-sizing: border-box;
   padding-bottom: 8px;
-  padding-top: 8px;
   padding-left: 16px;
-  padding-right: 16px;
+  padding-right: 48px;
+  padding-top: 8px;
   background-color: #010B1C;
   border-radius: 4px;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  visibility: none;
+  position: relative;
+}
+
+.c6 {
+  box-sizing: border-box;
+  padding-right: 16px;
+  position: absolute;
+  right: 0px;
 }
 
 <div>
@@ -886,52 +410,158 @@ exports[`render single bash text 1`] = `
         <div
           class="c3"
         >
+          Download Teleport's PGP public key
+        </div>
+        <div
+          class="c4"
+        >
           <div
             class="c4"
           >
-            $
+            <div
+              class="c5"
+            >
+              $
+            </div>
+            <div
+              class="text-to-copy"
+            >
+              sudo curl https://apt.releases.teleport.dev/gpg \\
+-o /usr/share/keyrings/teleport-archive-keyring.asc
+            </div>
           </div>
           <div
-            class="text-to-copy"
+            class="c6"
           >
-            sudo tctl -c cfg-all users add --roles=access,editor george_washington
+            <button
+              class="c7 c8"
+              kind="secondary"
+            >
+              <div
+                class="c9 icon-container"
+              >
+                <span
+                  class="c10 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c10 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="c5"
-    >
       <div
-        class="c6"
-        height="0"
+        class="c2"
       >
-        <button
-          class="c7 c8"
-          kind="secondary"
+        <div
+          class="c4"
         >
           <div
-            class="c9 icon-container"
+            class="c4"
           >
-            <span
-              class="c10 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c10 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
+            <div
+              class="c5"
+            >
+              $
+            </div>
+            <div
+              class="text-to-copy"
+            >
+              sudo DEBUG=1 teleport start -c cfg-all -d
+            </div>
           </div>
-        </button>
+          <div
+            class="c6"
+          >
+            <button
+              class="c7 c8"
+              kind="secondary"
+            >
+              <div
+                class="c9 icon-container"
+              >
+                <span
+                  class="c10 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c10 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c11"
+      >
+        <div
+          class="c3"
+        >
+          Add the Teleport APT repository for v10. You'll need to update this
+file for each major release of Teleport.
+Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
+and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
+
+        </div>
+        <div
+          class="c4"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              $
+            </div>
+            <div
+              class="text-to-copy"
+            >
+              echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \\
+https://apt.releases.teleport.dev/stable/v10" \\
+| sudo tee /etc/apt/sources.list.d/teleport.list &gt; /dev/null
+            </div>
+          </div>
+          <div
+            class="c6"
+          >
+            <button
+              class="c7 c8"
+              kind="secondary"
+            >
+              <div
+                class="c9 icon-container"
+              >
+                <span
+                  class="c10 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c10 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`render single bash text with comment 1`] = `
+exports[`render non bash single text 1`] = `
 .c2 {
   box-sizing: border-box;
   padding-bottom: 0px;
@@ -939,27 +569,6 @@ exports[`render single bash text with comment 1`] = `
 }
 
 .c5 {
-  box-sizing: border-box;
-  margin-right: 4px;
-}
-
-.c6 {
-  box-sizing: border-box;
-}
-
-.c7 {
-  box-sizing: border-box;
-  padding-top: 4px;
-  height: 0px;
-}
-
-.c8 {
-  box-sizing: border-box;
-  margin-top: 0px;
-  height: 0px;
-}
-
-.c9 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -985,57 +594,54 @@ exports[`render single bash text with comment 1`] = `
   padding: 0px 24px;
 }
 
-.c9:active {
+.c5:active {
   opacity: 0.56;
 }
 
-.c9:hover,
-.c9:focus {
+.c5:hover,
+.c5:focus {
   background: #2C3A73;
 }
 
-.c9:disabled {
+.c5:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
 }
 
-.c12 {
+.c8 {
   display: inline-block;
   transition: color 0.3s;
   color: #FFFFFF;
 }
 
-.c4 {
+.c3 {
   box-sizing: border-box;
   display: flex;
 }
 
-.c11 .icon-check {
+.c7 .icon-check {
   display: none;
 }
 
-.c11 .icon-copy {
+.c7 .icon-copy {
   display: block;
 }
 
-.c11.copied .icon-check {
+.c7.copied .icon-check {
   display: block;
 }
 
-.c11.copied .icon-copy {
+.c7.copied .icon-copy {
   display: none;
 }
 
-.c3 {
-  color: rgb(117 113 94 / 80%);
-}
-
-.c10 {
+.c6 {
   height: 28px;
   width: 28px;
   border-radius: 20px;
   min-height: auto;
   padding: 0;
+  margin-top: -4px;
 }
 
 .c1 {
@@ -1052,15 +658,366 @@ exports[`render single bash text with comment 1`] = `
 .c0 {
   box-sizing: border-box;
   padding-bottom: 8px;
-  padding-top: 8px;
   padding-left: 16px;
-  padding-right: 16px;
+  padding-right: 48px;
+  padding-top: 8px;
   background-color: #010B1C;
   border-radius: 4px;
+  position: relative;
+}
+
+.c4 {
+  box-sizing: border-box;
+  padding-right: 16px;
+  position: absolute;
+  right: 0px;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c3"
+          >
+            <div
+              class="text-to-copy"
+            >
+              some -c text to be copied and it is super long to test scrolling
+            </div>
+          </div>
+          <div
+            class="c4"
+          >
+            <button
+              class="c5 c6"
+              kind="secondary"
+            >
+              <div
+                class="c7 icon-container"
+              >
+                <span
+                  class="c8 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c8 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`render single bash text 1`] = `
+.c2 {
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  padding-top: 8px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-right: 4px;
+}
+
+.c6 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+}
+
+.c6:active {
+  opacity: 0.56;
+}
+
+.c6:hover,
+.c6:focus {
+  background: #2C3A73;
+}
+
+.c6:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c9 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c3 {
+  box-sizing: border-box;
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  visibility: none;
+}
+
+.c8 .icon-check {
+  display: none;
+}
+
+.c8 .icon-copy {
+  display: block;
+}
+
+.c8.copied .icon-check {
+  display: block;
+}
+
+.c8.copied .icon-copy {
+  display: none;
+}
+
+.c7 {
+  height: 28px;
+  width: 28px;
+  border-radius: 20px;
+  min-height: auto;
+  padding: 0;
+  margin-top: -4px;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-right: 4px;
+  white-space: pre;
+  word-break: break-all;
+  font-size: 12px;
+  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
+  overflow: scroll;
+  line-height: 20px;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 48px;
+  padding-top: 8px;
+  background-color: #010B1C;
+  border-radius: 4px;
+  position: relative;
+}
+
+.c5 {
+  box-sizing: border-box;
+  padding-right: 16px;
+  position: absolute;
+  right: 0px;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c3"
+          >
+            <div
+              class="c4"
+            >
+              $
+            </div>
+            <div
+              class="text-to-copy"
+            >
+              sudo tctl -c cfg-all users add --roles=access,editor george_washington
+            </div>
+          </div>
+          <div
+            class="c5"
+          >
+            <button
+              class="c6 c7"
+              kind="secondary"
+            >
+              <div
+                class="c8 icon-container"
+              >
+                <span
+                  class="c9 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c9 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`render single bash text with comment 1`] = `
+.c2 {
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  padding-top: 8px;
+}
+
+.c5 {
+  box-sizing: border-box;
+  margin-right: 4px;
+}
+
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: #2C3A73;
+}
+
+.c7:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c9 .icon-check {
+  display: none;
+}
+
+.c9 .icon-copy {
+  display: block;
+}
+
+.c9.copied .icon-check {
+  display: block;
+}
+
+.c9.copied .icon-copy {
+  display: none;
+}
+
+.c3 {
+  color: rgb(117 113 94 / 80%);
+}
+
+.c8 {
+  height: 28px;
+  width: 28px;
+  border-radius: 20px;
+  min-height: auto;
+  padding: 0;
+  margin-top: -4px;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-right: 4px;
+  white-space: pre;
+  word-break: break-all;
+  font-size: 12px;
+  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
+  overflow: scroll;
+  line-height: 20px;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 48px;
+  padding-top: 8px;
+  background-color: #010B1C;
+  border-radius: 4px;
+  position: relative;
+}
+
+.c6 {
+  box-sizing: border-box;
+  padding-right: 16px;
+  position: absolute;
+  right: 0px;
 }
 
 <div>
@@ -1082,48 +1039,43 @@ exports[`render single bash text with comment 1`] = `
           class="c4"
         >
           <div
-            class="c5"
+            class="c4"
           >
-            $
+            <div
+              class="c5"
+            >
+              $
+            </div>
+            <div
+              class="text-to-copy"
+            >
+              sudo tctl -c cfg-all users add --roles=access,editor george_washington
+            </div>
           </div>
           <div
-            class="text-to-copy"
+            class="c6"
           >
-            sudo tctl -c cfg-all users add --roles=access,editor george_washington
+            <button
+              class="c7 c8"
+              kind="secondary"
+            >
+              <div
+                class="c9 icon-container"
+              >
+                <span
+                  class="c10 icon icon-copy "
+                  color="light"
+                  data-testid="btn-copy"
+                />
+                <span
+                  class="c10 icon icon-check "
+                  color="light"
+                  data-testid="btn-check"
+                />
+              </div>
+            </button>
           </div>
         </div>
-      </div>
-    </div>
-    <div
-      class="c6"
-    >
-      <div
-        class="c7"
-        height="0"
-      >
-        <div
-          class="c8"
-          height="0"
-        />
-        <button
-          class="c9 c10"
-          kind="secondary"
-        >
-          <div
-            class="c11 icon-container"
-          >
-            <span
-              class="c12 icon icon-copy "
-              color="light"
-              data-testid="btn-copy"
-            />
-            <span
-              class="c12 icon icon-check "
-              color="light"
-              data-testid="btn-check"
-            />
-          </div>
-        </button>
       </div>
     </div>
   </div>

--- a/packages/teleport/src/components/TextSelectCopy/__snapshots__/TextSelectCopyMulti.story.test.tsx.snap
+++ b/packages/teleport/src/components/TextSelectCopy/__snapshots__/TextSelectCopyMulti.story.test.tsx.snap
@@ -1,0 +1,1131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render multi bash texts 1`] = `
+.c2 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-top: 8px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-right: 4px;
+}
+
+.c5 {
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  padding-top: 8px;
+}
+
+.c6 {
+  box-sizing: border-box;
+}
+
+.c7 {
+  box-sizing: border-box;
+  padding-top: 4px;
+  height: 0px;
+}
+
+.c8 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+}
+
+.c8:active {
+  opacity: 0.56;
+}
+
+.c8:hover,
+.c8:focus {
+  background: #2C3A73;
+}
+
+.c8:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c11 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c3 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c10 .icon-check {
+  display: none;
+}
+
+.c10 .icon-copy {
+  display: block;
+}
+
+.c10.copied .icon-check {
+  display: block;
+}
+
+.c10.copied .icon-copy {
+  display: none;
+}
+
+.c9 {
+  height: 28px;
+  width: 28px;
+  border-radius: 20px;
+  min-height: auto;
+  padding: 0;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-right: 4px;
+  white-space: pre;
+  word-break: break-all;
+  font-size: 12px;
+  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
+  overflow: scroll;
+  line-height: 20px;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-top: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #010B1C;
+  border-radius: 4px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  visibility: none;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            $
+          </div>
+          <div
+            class="text-to-copy"
+          >
+            sudo tctl -c cfg-all users add --roles=access,editor george_washington
+          </div>
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            $
+          </div>
+          <div
+            class="text-to-copy"
+          >
+            sudo DEBUG=1 teleport start -c cfg-all -d
+          </div>
+        </div>
+      </div>
+      <div
+        class="c5"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            $
+          </div>
+          <div
+            class="text-to-copy"
+          >
+            yarn start-teleport-e --target=https://localhost:3080/web
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+        height="0"
+      >
+        <button
+          class="c8 c9"
+          kind="secondary"
+        >
+          <div
+            class="c10 icon-container"
+          >
+            <span
+              class="c11 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c11 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+      <div
+        class="c7"
+        height="0"
+      >
+        <button
+          class="c8 c9"
+          kind="secondary"
+        >
+          <div
+            class="c10 icon-container"
+          >
+            <span
+              class="c11 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c11 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+      <div
+        class="c7"
+        height="0"
+      >
+        <button
+          class="c8 c9"
+          kind="secondary"
+        >
+          <div
+            class="c10 icon-container"
+          >
+            <span
+              class="c11 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c11 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`render multi bash texts with comment 1`] = `
+.c2 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-top: 8px;
+}
+
+.c5 {
+  box-sizing: border-box;
+  margin-right: 4px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  padding-top: 8px;
+}
+
+.c7 {
+  box-sizing: border-box;
+}
+
+.c8 {
+  box-sizing: border-box;
+  padding-top: 4px;
+  height: 0px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-top: 4px;
+  height: 0px;
+}
+
+.c14 {
+  box-sizing: border-box;
+  margin-top: 0px;
+  height: 0px;
+}
+
+.c10 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+}
+
+.c10:active {
+  opacity: 0.56;
+}
+
+.c10:hover,
+.c10:focus {
+  background: #2C3A73;
+}
+
+.c10:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c13 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c12 .icon-check {
+  display: none;
+}
+
+.c12 .icon-copy {
+  display: block;
+}
+
+.c12.copied .icon-check {
+  display: block;
+}
+
+.c12.copied .icon-copy {
+  display: none;
+}
+
+.c3 {
+  color: rgb(117 113 94 / 80%);
+}
+
+.c11 {
+  height: 28px;
+  width: 28px;
+  border-radius: 20px;
+  min-height: auto;
+  padding: 0;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-right: 4px;
+  white-space: pre;
+  word-break: break-all;
+  font-size: 12px;
+  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
+  overflow: scroll;
+  line-height: 20px;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-top: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #010B1C;
+  border-radius: 4px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  visibility: none;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          Download Teleport's PGP public key
+        </div>
+        <div
+          class="c4"
+        >
+          <div
+            class="c5"
+          >
+            $
+          </div>
+          <div
+            class="text-to-copy"
+          >
+            sudo curl https://apt.releases.teleport.dev/gpg \\
+-o /usr/share/keyrings/teleport-archive-keyring.asc
+          </div>
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <div
+          class="c4"
+        >
+          <div
+            class="c5"
+          >
+            $
+          </div>
+          <div
+            class="text-to-copy"
+          >
+            sudo DEBUG=1 teleport start -c cfg-all -d
+          </div>
+        </div>
+      </div>
+      <div
+        class="c6"
+      >
+        <div
+          class="c3"
+        >
+          Add the Teleport APT repository for v10. You'll need to update this
+file for each major release of Teleport.
+Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
+and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
+
+        </div>
+        <div
+          class="c4"
+        >
+          <div
+            class="c5"
+          >
+            $
+          </div>
+          <div
+            class="text-to-copy"
+          >
+            echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \\
+https://apt.releases.teleport.dev/stable/v10" \\
+| sudo tee /etc/apt/sources.list.d/teleport.list &gt; /dev/null
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+        height="0"
+      >
+        <div
+          class="c9"
+          height="0"
+        />
+        <button
+          class="c10 c11"
+          kind="secondary"
+        >
+          <div
+            class="c12 icon-container"
+          >
+            <span
+              class="c13 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c13 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+      <div
+        class="c8"
+        height="0"
+      >
+        <button
+          class="c10 c11"
+          kind="secondary"
+        >
+          <div
+            class="c12 icon-container"
+          >
+            <span
+              class="c13 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c13 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+      <div
+        class="c8"
+        height="0"
+      >
+        <div
+          class="c14"
+          height="0"
+        />
+        <button
+          class="c10 c11"
+          kind="secondary"
+        >
+          <div
+            class="c12 icon-container"
+          >
+            <span
+              class="c13 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c13 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`render non bash single text 1`] = `
+.c2 {
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  padding-top: 8px;
+}
+
+.c4 {
+  box-sizing: border-box;
+}
+
+.c5 {
+  box-sizing: border-box;
+  padding-top: 4px;
+  height: 0px;
+}
+
+.c6 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+}
+
+.c6:active {
+  opacity: 0.56;
+}
+
+.c6:hover,
+.c6:focus {
+  background: #2C3A73;
+}
+
+.c6:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c9 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c3 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c8 .icon-check {
+  display: none;
+}
+
+.c8 .icon-copy {
+  display: block;
+}
+
+.c8.copied .icon-check {
+  display: block;
+}
+
+.c8.copied .icon-copy {
+  display: none;
+}
+
+.c7 {
+  height: 28px;
+  width: 28px;
+  border-radius: 20px;
+  min-height: auto;
+  padding: 0;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-right: 4px;
+  white-space: pre;
+  word-break: break-all;
+  font-size: 12px;
+  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
+  overflow: scroll;
+  line-height: 20px;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-top: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #010B1C;
+  border-radius: 4px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  visibility: none;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="text-to-copy"
+          >
+            some -c text to be copied and it is super long to test scrolling
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+        height="0"
+      >
+        <button
+          class="c6 c7"
+          kind="secondary"
+        >
+          <div
+            class="c8 icon-container"
+          >
+            <span
+              class="c9 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c9 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`render single bash text 1`] = `
+.c2 {
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  padding-top: 8px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-right: 4px;
+}
+
+.c5 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  box-sizing: border-box;
+  padding-top: 4px;
+  height: 0px;
+}
+
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: #2C3A73;
+}
+
+.c7:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c10 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c3 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c9 .icon-check {
+  display: none;
+}
+
+.c9 .icon-copy {
+  display: block;
+}
+
+.c9.copied .icon-check {
+  display: block;
+}
+
+.c9.copied .icon-copy {
+  display: none;
+}
+
+.c8 {
+  height: 28px;
+  width: 28px;
+  border-radius: 20px;
+  min-height: auto;
+  padding: 0;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-right: 4px;
+  white-space: pre;
+  word-break: break-all;
+  font-size: 12px;
+  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
+  overflow: scroll;
+  line-height: 20px;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-top: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #010B1C;
+  border-radius: 4px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  visibility: none;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            $
+          </div>
+          <div
+            class="text-to-copy"
+          >
+            sudo tctl -c cfg-all users add --roles=access,editor george_washington
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c5"
+    >
+      <div
+        class="c6"
+        height="0"
+      >
+        <button
+          class="c7 c8"
+          kind="secondary"
+        >
+          <div
+            class="c9 icon-container"
+          >
+            <span
+              class="c10 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c10 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`render single bash text with comment 1`] = `
+.c2 {
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  padding-top: 8px;
+}
+
+.c5 {
+  box-sizing: border-box;
+  margin-right: 4px;
+}
+
+.c6 {
+  box-sizing: border-box;
+}
+
+.c7 {
+  box-sizing: border-box;
+  padding-top: 4px;
+  height: 0px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  margin-top: 0px;
+  height: 0px;
+}
+
+.c9 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #222C59;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+}
+
+.c9:active {
+  opacity: 0.56;
+}
+
+.c9:hover,
+.c9:focus {
+  background: #2C3A73;
+}
+
+.c9:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c12 {
+  display: inline-block;
+  transition: color 0.3s;
+  color: #FFFFFF;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c11 .icon-check {
+  display: none;
+}
+
+.c11 .icon-copy {
+  display: block;
+}
+
+.c11.copied .icon-check {
+  display: block;
+}
+
+.c11.copied .icon-copy {
+  display: none;
+}
+
+.c3 {
+  color: rgb(117 113 94 / 80%);
+}
+
+.c10 {
+  height: 28px;
+  width: 28px;
+  border-radius: 20px;
+  min-height: auto;
+  padding: 0;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-right: 4px;
+  white-space: pre;
+  word-break: break-all;
+  font-size: 12px;
+  font-family: "Droid Sans Mono","monospace",monospace,"Droid Sans Fallback";
+  overflow: scroll;
+  line-height: 20px;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-bottom: 8px;
+  padding-top: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #010B1C;
+  border-radius: 4px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  visibility: none;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          Add the Teleport API repository for v10. You'll need to update this.
+        </div>
+        <div
+          class="c4"
+        >
+          <div
+            class="c5"
+          >
+            $
+          </div>
+          <div
+            class="text-to-copy"
+          >
+            sudo tctl -c cfg-all users add --roles=access,editor george_washington
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+        height="0"
+      >
+        <div
+          class="c8"
+          height="0"
+        />
+        <button
+          class="c9 c10"
+          kind="secondary"
+        >
+          <div
+            class="c11 icon-container"
+          >
+            <span
+              class="c12 icon icon-copy "
+              color="light"
+              data-testid="btn-copy"
+            />
+            <span
+              class="c12 icon icon-check "
+              color="light"
+              data-testid="btn-check"
+            />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/teleport/src/components/TextSelectCopy/index.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/index.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-import TextSelectCopy from './TextSelectCopy';
+import { TextSelectCopy } from './TextSelectCopy';
+import { TextSelectCopyMulti } from './TextSelectCopyMulti';
 
-export default TextSelectCopy;
+export { TextSelectCopy, TextSelectCopyMulti };

--- a/packages/teleport/src/components/TextSelectCopy/index.tsx
+++ b/packages/teleport/src/components/TextSelectCopy/index.tsx
@@ -17,4 +17,7 @@
 import { TextSelectCopy } from './TextSelectCopy';
 import { TextSelectCopyMulti } from './TextSelectCopyMulti';
 
-export { TextSelectCopy, TextSelectCopyMulti };
+export { TextSelectCopyMulti };
+// TODO (lisa): will remove this entirely after
+// TextSelectCopyMulti replaces existing use of TextSelectCopy.
+export default TextSelectCopy;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2544,6 +2544,11 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
#### Description 
Create a `TextSelectCopyMulti` matching figma design (below) and allows multi text selects and adding comments

Note: Will update and delete the original single text copy `TextSelectCopy` after this PR is approved and merged

#### Figma design
https://www.figma.com/file/8DQZl1mYUPLgvKgmA6zPOM/In-Progress-Work?node-id=444%3A49313
<img width="993" alt="Screen Shot 2022-09-15 at 1 55 30 PM" src="https://user-images.githubusercontent.com/43280172/190507096-570e9288-13b1-47fd-b3e3-5c59512defed.png">

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/43280172/190508383-d54bdb86-1eca-49b9-936e-3c2094ac8f00.png">


#### Screenshots
<img width="634" alt="image" src="https://user-images.githubusercontent.com/43280172/190507234-21fa3726-9ec6-4a03-bfed-694f270bc521.png">

<img width="732" alt="image" src="https://user-images.githubusercontent.com/43280172/190507312-3a678b39-4ca8-4226-9a7c-4ee4f6bcdf65.png">

<img width="629" alt="image" src="https://user-images.githubusercontent.com/43280172/190507364-4cc4e1dc-61e3-4a7a-82b4-b9059a684f43.png">

scrollbar appearances

<img width="509" alt="image" src="https://user-images.githubusercontent.com/43280172/190507480-c6955841-e6bf-4cd3-97ef-df8546b10a87.png">

<img width="444" alt="image" src="https://user-images.githubusercontent.com/43280172/190507625-ef479931-06a6-41ce-b5fd-972b187b6849.png">
