### PR TITLE
Minor kube fixes

### DIFF
--- a/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -22,11 +22,8 @@ export default function createMainProcessClient(): MainProcessClient {
     openTabContextMenu,
     configService: createConfigServiceClient(),
     fileStorage: createFileStorageClient(),
-    removeKubeConfig(kubeConfigName) {
-      return ipcRenderer.invoke(
-        'main-process-remove-kube-config',
-        kubeConfigName
-      );
+    removeKubeConfig(options) {
+      return ipcRenderer.invoke('main-process-remove-kube-config', options);
     },
   };
 }

--- a/packages/teleterm/src/mainProcess/types.ts
+++ b/packages/teleterm/src/mainProcess/types.ts
@@ -31,7 +31,10 @@ export type MainProcessClient = {
   openTabContextMenu(options: TabContextMenuOptions): void;
   configService: ConfigService;
   fileStorage: FileStorage;
-  removeKubeConfig(kubeConfigName: string): Promise<void>;
+  removeKubeConfig(options: {
+    relativePath: string;
+    isDirectory?: boolean;
+  }): Promise<void>;
 };
 
 export type ChildProcessAddresses = {
@@ -43,17 +46,25 @@ export type Platform = NodeJS.Platform;
 
 export interface ClusterContextMenuOptions {
   isClusterConnected: boolean;
+
   onRefresh(): void;
+
   onLogin(): void;
+
   onLogout(): void;
+
   onRemove(): void;
 }
 
 export interface TabContextMenuOptions {
   documentKind: Kind;
+
   onClose(): void;
+
   onCloseOthers(): void;
+
   onCloseToRight(): void;
+
   onDuplicatePty(): void;
 }
 

--- a/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -87,7 +87,14 @@ function getPtyProcessOptions(
         ' ',
         isWindows ? '` ' : '\\ '
       );
-      const kubeLoginCommand = `${escapedBinaryPath} --proxy=${cmd.rootClusterId} kube login ${cmd.kubeId} --cluster=${cmd.clusterName}`;
+      const kubeLoginCommand = [
+        escapedBinaryPath,
+        `--proxy=${cmd.rootClusterId}`,
+        `kube login ${cmd.kubeId} --cluster=${cmd.clusterName}`,
+        settings.tshd.insecure && '--insecure',
+      ]
+        .filter(Boolean)
+        .join(' ');
       const bashCommandArgs = ['-c', `${kubeLoginCommand};$SHELL`];
       const powershellCommandArgs = ['-NoExit', '-c', kubeLoginCommand];
       return {

--- a/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -134,5 +134,5 @@ function getKubeConfigFilePath(
   command: TshKubeLoginCommand,
   settings: RuntimeSettings
 ): string {
-  return path.join(settings.kubeConfigsDir, command.kubeConfigName);
+  return path.join(settings.kubeConfigsDir, command.kubeConfigRelativePath);
 }

--- a/packages/teleterm/src/services/pty/types.ts
+++ b/packages/teleterm/src/services/pty/types.ts
@@ -39,7 +39,7 @@ export type TshLoginCommand = PtyCommandBase & {
 export type TshKubeLoginCommand = PtyCommandBase & {
   kind: 'pty.tsh-kube-login';
   kubeId: string;
-  kubeConfigName: string;
+  kubeConfigRelativePath: string;
   rootClusterId: string;
   leafClusterId?: string;
 };

--- a/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
+++ b/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
@@ -6,9 +6,7 @@ import { useAppContext } from '../appContextProvider';
 export function useClusterLogout({ clusterUri, onClose, clusterTitle }: Props) {
   const ctx = useAppContext();
   const [{ status, statusText }, removeCluster] = useAsync(async () => {
-    // TODO(gzdunek): logout and removeCluster should be combined into a single acton in tshd
     await ctx.clustersService.logout(clusterUri);
-    await ctx.clustersService.removeCluster(clusterUri);
 
     if (ctx.workspacesService.getRootClusterUri() === clusterUri) {
       const [firstConnectedWorkspace] =
@@ -19,7 +17,7 @@ export function useClusterLogout({ clusterUri, onClose, clusterTitle }: Props) {
         await ctx.workspacesService.setActiveWorkspace(null);
       }
     }
-    await ctx.connectionTracker.removeItemsBelongingToRootCluster(clusterUri);
+    ctx.connectionTracker.removeItemsBelongingToRootCluster(clusterUri);
     ctx.workspacesService.removeWorkspace(clusterUri);
   });
 

--- a/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
+++ b/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
@@ -19,8 +19,8 @@ export function useClusterLogout({ clusterUri, onClose, clusterTitle }: Props) {
         await ctx.workspacesService.setActiveWorkspace(null);
       }
     }
+    await ctx.connectionTracker.removeItemsBelongingToRootCluster(clusterUri);
     ctx.workspacesService.removeWorkspace(clusterUri);
-    ctx.connectionTracker.removeItemsBelongingToRootCluster(clusterUri);
   });
 
   useEffect(() => {

--- a/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
+++ b/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
@@ -17,8 +17,8 @@ export function useClusterLogout({ clusterUri, onClose, clusterTitle }: Props) {
         await ctx.workspacesService.setActiveWorkspace(null);
       }
     }
-    ctx.connectionTracker.removeItemsBelongingToRootCluster(clusterUri);
     ctx.workspacesService.removeWorkspace(clusterUri);
+    ctx.connectionTracker.removeItemsBelongingToRootCluster(clusterUri);
   });
 
   useEffect(() => {

--- a/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
+++ b/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
@@ -46,7 +46,7 @@ export function ExpanderConnections() {
     },
     async activateItem() {},
     async disconnectItem() {},
-    removeItem() {},
+    async removeItem() {},
     useState() {
       return null;
     },

--- a/packages/teleterm/src/ui/commandLauncher.ts
+++ b/packages/teleterm/src/ui/commandLauncher.ts
@@ -100,7 +100,8 @@ const commands = {
       ) as TrackedKubeConnection;
       documentsService.add({
         ...kubeDoc,
-        kubeConfigName: connection?.kubeConfigName || kubeDoc.kubeConfigName,
+        kubeConfigRelativePath:
+          connection?.kubeConfigRelativePath || kubeDoc.kubeConfigRelativePath,
       });
       documentsService.open(kubeDoc.uri);
     },

--- a/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -1,6 +1,7 @@
 import { tsh, SyncStatus } from 'teleterm/ui/services/clusters/types';
 
 import { NotificationsService } from 'teleterm/ui/services/notifications';
+import { MainProcessClient } from 'teleterm/mainProcess/types';
 
 import { ClustersService } from './clustersService';
 
@@ -95,7 +96,9 @@ function createService(
 ): ClustersService {
   return new ClustersService(
     client as tsh.TshClient,
-    undefined,
+    {
+      removeKubeConfig: jest.fn().mockResolvedValueOnce(undefined),
+    } as unknown as MainProcessClient,
     notificationsService
   );
 }
@@ -206,9 +209,10 @@ test('login into cluster and sync resources', async () => {
 });
 
 test('logout from cluster and clean its resources', async () => {
-  const { logout } = getClientMocks();
+  const { logout, removeCluster } = getClientMocks();
   const service = createService({
     logout,
+    removeCluster,
     getCluster: () => Promise.resolve({ ...clusterMock, connected: false }),
   });
   service.setState(draftState => {
@@ -218,7 +222,7 @@ test('logout from cluster and clean its resources', async () => {
   await service.logout(clusterUri);
 
   expect(logout).toHaveBeenCalledWith(clusterUri);
-  expect(service.findCluster(clusterUri).connected).toBe(false);
+  expect(service.findCluster(clusterUri)).toBeUndefined();
   testIfClusterResourcesHaveBeenCleared(service);
 });
 

--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -604,9 +604,9 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     });
   }
 
-  async removeKubeConfig(kubeConfigName: string): Promise<void> {
+  async removeKubeConfig(kubeConfigRelativePath: string): Promise<void> {
     return this.mainProcessClient.removeKubeConfig({
-      relativePath: kubeConfigName,
+      relativePath: kubeConfigRelativePath,
     });
   }
 

--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -598,11 +598,6 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     const {
       params: { rootClusterId },
     } = routing.parseClusterUri(clusterUri);
-    if (!rootClusterId) {
-      throw new Error(
-        'Could not remove kube configs, `rootClusterId` is missing.'
-      );
-    }
     return this.mainProcessClient.removeKubeConfig({
       relativePath: rootClusterId,
       isDirectory: true,

--- a/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -135,9 +135,7 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
       return;
     }
 
-    await this._trackedConnectionOperationsFactory
-      .create(connection)
-      .remove?.();
+    await this._trackedConnectionOperationsFactory.create(connection).remove();
 
     this.setState(draft => {
       draft.connections = draft.connections.filter(i => i.id !== id);

--- a/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -142,17 +142,14 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
     });
   }
 
-  async removeItemsBelongingToRootCluster(clusterUri: string): Promise<void> {
-    await Promise.all(
-      this.getConnections().map(async connection => {
+  removeItemsBelongingToRootCluster(clusterUri: string): void {
+    this.setState(draft => {
+      draft.connections = draft.connections.filter(i => {
         const { rootClusterUri } =
-          this._trackedConnectionOperationsFactory.create(connection);
-        if (rootClusterUri === clusterUri) {
-          await this.disconnectItem(connection.id);
-          await this.removeItem(connection.id);
-        }
-      })
-    );
+          this._trackedConnectionOperationsFactory.create(i);
+        return rootClusterUri !== clusterUri;
+      });
+    });
   }
 
   dispose(): void {

--- a/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
@@ -71,6 +71,7 @@ export class TrackedConnectionOperationsFactory {
             documentsService.close(document.uri);
           });
       },
+      remove: async () => {},
     };
   }
 
@@ -123,6 +124,7 @@ export class TrackedConnectionOperationsFactory {
               });
           });
       },
+      remove: async () => {},
     };
   }
 
@@ -205,5 +207,5 @@ interface TrackedConnectionOperations {
 
   disconnect(): Promise<void>;
 
-  remove?(): Promise<void>;
+  remove(): Promise<void>;
 }

--- a/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
@@ -167,7 +167,9 @@ export class TrackedConnectionOperationsFactory {
           });
       },
       remove: () => {
-        this._clustersService.removeKubeConfig(connection.kubeConfigName);
+        return this._clustersService.removeKubeConfig(
+          connection.kubeConfigName
+        );
       },
     };
   }
@@ -203,5 +205,5 @@ interface TrackedConnectionOperations {
 
   disconnect(): Promise<void>;
 
-  remove?(): void;
+  remove?(): Promise<void>;
 }

--- a/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
@@ -153,7 +153,7 @@ export class TrackedConnectionOperationsFactory {
         if (!kubeConn) {
           kubeConn = documentsService.createTshKubeDocument({
             kubeUri: connection.kubeUri,
-            kubeConfigName: connection.kubeConfigName,
+            kubeConfigRelativePath: connection.kubeConfigRelativePath,
           });
 
           documentsService.add(kubeConn);
@@ -170,7 +170,7 @@ export class TrackedConnectionOperationsFactory {
       },
       remove: () => {
         return this._clustersService.removeKubeConfig(
-          connection.kubeConfigName
+          connection.kubeConfigRelativePath
         );
       },
     };

--- a/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
@@ -91,7 +91,7 @@ export function createKubeConnection(
     connected: document.status === 'connected',
     id: unique(),
     title: document.title,
-    kubeConfigName: document.kubeConfigName,
+    kubeConfigRelativePath: document.kubeConfigRelativePath,
     kubeUri: document.kubeUri,
   };
 }

--- a/packages/teleterm/src/ui/services/connectionTracker/types.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/types.ts
@@ -23,7 +23,7 @@ export interface TrackedGatewayConnection extends TrackedConnectionBase {
 
 export interface TrackedKubeConnection extends TrackedConnectionBase {
   kind: 'connection.kube';
-  kubeConfigName: string;
+  kubeConfigRelativePath: string;
   kubeUri: string;
 }
 

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -74,7 +74,9 @@ export class DocumentsService {
       leafClusterId: params.leafClusterId,
       kubeId: params.kubeId,
       kubeUri: options.kubeUri,
-      kubeConfigName: options.kubeConfigName || `${params.kubeId}-${unique(5)}`,
+      kubeConfigName:
+        options.kubeConfigName ||
+        `${params.rootClusterId}/${params.kubeId}-${unique(5)}`,
       title: params.kubeId,
     };
   }

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -74,8 +74,11 @@ export class DocumentsService {
       leafClusterId: params.leafClusterId,
       kubeId: params.kubeId,
       kubeUri: options.kubeUri,
-      kubeConfigName:
-        options.kubeConfigName ||
+      kubeConfigRelativePath:
+        options.kubeConfigRelativePath ||
+        // We prepend the name with `rootClusterId/` to create a kube config
+        // inside this directory. When the user logs out of the cluster,
+        // the entire directory is deleted.
         `${params.rootClusterId}/${params.kubeId}-${unique(5)}`,
       title: params.kubeId,
     };

--- a/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -47,7 +47,7 @@ export interface DocumentTshKube extends DocumentBase {
   status: 'connecting' | 'connected' | 'disconnected';
   kubeId: string;
   kubeUri: string;
-  kubeConfigName: string;
+  kubeConfigRelativePath: string;
   rootClusterId: string;
   leafClusterId?: string;
 }
@@ -102,7 +102,7 @@ export type CreateClusterDocumentOpts = {
 
 export type CreateTshKubeDocumentOptions = {
   kubeUri: string;
-  kubeConfigName?: string;
+  kubeConfigRelativePath?: string;
 };
 
 export type CreateNewTerminalOpts = {


### PR DESCRIPTION
I didn't want to add new things to the previous PR, so I'm starting a new one.

It fixes two issues:
- connection resources are now correctly cleaned up when user logs out
- `insecure` flag is passed to `kube login` when you run the app in that mode 