### PR TITLE
Remove auto-refresh for Active Sessions list

### DIFF
--- a/packages/teleport/src/Sessions/Sessions.story.tsx
+++ b/packages/teleport/src/Sessions/Sessions.story.tsx
@@ -26,7 +26,6 @@ export default {
 export function Loaded() {
   const props = {
     sessions,
-    onRefresh,
     attempt: {
       isSuccess: true,
       isProcessing: false,
@@ -37,7 +36,3 @@ export function Loaded() {
 
   return <Sessions {...props} />;
 }
-
-const onRefresh = () => {
-  return Promise.resolve();
-};

--- a/packages/teleport/src/Sessions/Sessions.tsx
+++ b/packages/teleport/src/Sessions/Sessions.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import { Indicator, Box } from 'design';
 import { Danger } from 'design/Alert';
 
-import AjaxPoller from 'teleport/components/AjaxPoller';
 import {
   FeatureBox,
   FeatureHeader,
@@ -30,7 +29,6 @@ import useStickerClusterId from 'teleport/useStickyClusterId';
 
 import SessionList from './SessionList';
 import useSessions from './useSessions';
-const POLLING_INTERVAL = 3000; // every 3 sec
 
 export default function Container() {
   const ctx = useTeleport();
@@ -40,7 +38,7 @@ export default function Container() {
 }
 
 export function Sessions(props: ReturnType<typeof useSessions>) {
-  const { attempt, onRefresh, sessions } = props;
+  const { attempt, sessions } = props;
   return (
     <FeatureBox>
       <FeatureHeader alignItems="center">
@@ -52,12 +50,7 @@ export function Sessions(props: ReturnType<typeof useSessions>) {
           <Indicator />
         </Box>
       )}
-      {attempt.isSuccess && (
-        <>
-          <SessionList sessions={sessions} />
-          <AjaxPoller time={POLLING_INTERVAL} onFetch={onRefresh} />
-        </>
-      )}
+      {attempt.isSuccess && <SessionList sessions={sessions} />}
     </FeatureBox>
   );
 }

--- a/packages/teleport/src/Sessions/useSessions.ts
+++ b/packages/teleport/src/Sessions/useSessions.ts
@@ -35,6 +35,5 @@ export default function useSessions(ctx: Ctx, clusterId: string) {
   return {
     attempt,
     sessions,
-    onRefresh,
   };
 }


### PR DESCRIPTION
### Purpose

This PR resolves https://github.com/gravitational/teleport/issues/16515

Removes the auto-refresh from the Active Sessions page which occurs every 3 seconds. The active sessions are now only fetched on page load.