### PR TITLE
Add `type-check` step to CI checks

### DIFF
--- a/.cloudbuild/ci/test.yaml
+++ b/.cloudbuild/ci/test.yaml
@@ -15,6 +15,16 @@ steps:
       - "go run ./cmd/checkout -w=/workspace"
 
   - name: gcr.io/cloud-builders/docker
+    id: type-check
+    args:
+      - build
+      - '--build-arg'
+      - NPM_SCRIPT=type-check
+      - '--build-arg'
+      - YARN_FROZEN_LOCKFILE=true
+      - .
+
+  - name: gcr.io/cloud-builders/docker
     id: test
     args:
       - build


### PR DESCRIPTION
## Purpose

This adds a `yarn type-check` step to the CI checks run on every webapps PR. This prevents inadvertently merging changes containing type errors.