### PR TITLE
[Discover] Update the Desktop animation to output a v3 config

### DIFF
--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/CreateTeleportConfigAnimation.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/CreateTeleportConfigAnimation.tsx
@@ -7,9 +7,12 @@ import { useJoinTokenValue } from 'teleport/Discover/Desktop/ConnectTeleport/Joi
 
 import type { JoinToken } from 'teleport/services/joinToken';
 
-const pastedLines = (joinToken: JoinToken) => `teleport:
-  auth_token: ${joinToken.id}
-  auth_servers: [ ${window.location.hostname}:${window.location.port || '443'} ]
+const pastedLines = (joinToken: JoinToken) => `version: v3
+teleport:
+  proxy_server: ${window.location.hostname}:${window.location.port || '443'}
+  join_params:
+    method: token
+    token_name: ${joinToken.id}
 
 auth_service:
   enabled: no

--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/CreateTeleportConfigAnimation.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/CreateTeleportConfigAnimation.tsx
@@ -9,10 +9,8 @@ import type { JoinToken } from 'teleport/services/joinToken';
 
 const pastedLines = (joinToken: JoinToken) => `version: v3
 teleport:
+  auth_token: ${joinToken.id}
   proxy_server: ${window.location.hostname}:${window.location.port || '443'}
-  join_params:
-    method: token
-    token_name: ${joinToken.id}
 
 auth_service:
   enabled: no

--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScriptAnimation.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScriptAnimation.tsx
@@ -27,10 +27,8 @@ const lines = (joinToken: JoinToken) => [
     text: `
 version: v3
 teleport:
+  auth_token: ${joinToken.id}
   proxy_server: ${window.location.hostname}:${window.location.port || '443'}
-  join_params:
-    method: token
-    token_name: ${joinToken.id}
 
 auth_service:
   enabled: no
@@ -70,7 +68,7 @@ windows_desktop_service:
 
 const selectedLines = {
   start: 4,
-  end: 31,
+  end: 29,
 };
 
 const highlights: KeywordHighlight[] = [

--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScriptAnimation.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScriptAnimation.tsx
@@ -25,9 +25,12 @@ const lines = (joinToken: JoinToken) => [
   },
   {
     text: `
+version: v3
 teleport:
-  auth_token: ${joinToken.id}
-  auth_servers: [ ${window.location.hostname}:${window.location.port || '443'} ]
+  proxy_server: ${window.location.hostname}:${window.location.port || '443'}
+  join_params:
+    method: token
+    token_name: ${joinToken.id}
 
 auth_service:
   enabled: no
@@ -67,7 +70,7 @@ windows_desktop_service:
 
 const selectedLines = {
   start: 4,
-  end: 28,
+  end: 31,
 };
 
 const highlights: KeywordHighlight[] = [


### PR DESCRIPTION
Once https://github.com/gravitational/teleport/pull/15761 lands, it'll output a v3 config. This needs backporting to v11

This updates the Desktop setup animation flow to match the new v3 config it outputs.