### PR TITLE
Remove `raw-loader` completely

### DIFF
--- a/@types/raw-loader.d.ts
+++ b/@types/raw-loader.d.ts
@@ -1,4 +1,0 @@
-declare module 'raw-loader!*' {
-  const contents: string;
-  export = contents;
-}


### PR DESCRIPTION
We still have `raw-loader` usage in our enterprise codebase, which is only working because a dependency of a dependency of a dependency of a dependency (yes, that many levels) of`@storybook/react` has `raw-loader` as a dependency.

This PR removes the custom type we have declared, so TypeScript will complain on any future `raw-loader` usage.

It will also pull in the master commit from the enterprise side, once that PR is merged.