### PR TITLE
Add caching to Webpack during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ requests to the given target.
 > Keep in mind that you have to use a local user because social
 > logins (google/github) are not supported by development server.
 
+#### Caching
+
+By default, Webpack will store a cache in `node_modules/.cache/webpack` during development. This
+makes starting `webpack-dev-server` really quick after having ran it once, as it will re-use the
+cache from the last time it was running.
+
+If you want to change the location of the cache, you can set `WEBPACK_CACHE_DIRECTORY` to an 
+absolute file path of the folder where you want to store Webpack's cache.
+
+If you wish to disable the cache, you can set `WEBPACK_DISABLE_CACHE` to `yes`.
+
 #### Source Maps
 
 During development, Webpack will default to generating source maps using `eval-source-map`.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cache from the last time it was running.
 If you want to change the location of the cache, you can set `WEBPACK_CACHE_DIRECTORY` to an 
 absolute file path of the folder where you want to store Webpack's cache.
 
-If you wish to disable the cache, you can set `WEBPACK_DISABLE_CACHE` to `yes`.
+If you wish to disable the cache, you can set `WEBPACK_CACHE_DISABLED` to `yes`.
 
 #### Source Maps
 

--- a/packages/build/webpack/webpack.dev.config.js
+++ b/packages/build/webpack/webpack.dev.config.js
@@ -19,11 +19,28 @@ const configFactory = require('./webpack.base');
 process.env.BABEL_ENV = 'development';
 process.env.NODE_ENV = 'development';
 
+function getCacheConfig() {
+  if (process.env.WEBPACK_CACHE_DISABLED === 'yes') {
+    return undefined;
+  }
+
+  const cache = {
+    type: 'filesystem',
+  };
+
+  if (process.env.WEBPACK_CACHE_DIRECTORY) {
+    cache.cacheDirectory = process.env.WEBPACK_CACHE_DIRECTORY;
+  }
+
+  return cache;
+}
+
 /**
  * @type { import('webpack').webpack.Configuration }
  */
 module.exports = {
   ...configFactory.createDefaultConfig(),
+  cache: getCacheConfig(),
   output: {
     ...configFactory.createDefaultConfig().output,
     filename: '[name].js',


### PR DESCRIPTION
This adds file system based caching to Webpack during development, so subsequent re-runs of `webpack-dev-server` will start up really quickly as it'll reuse the cache from when it last ran.

I've added environment variables to disable this behaviour and to configure the path if wanted.

Initial compile time: 10317ms.

Stopping and then starting Webpack again, compile time: 697ms.