### PR TITLE
[v10] Create a FeatureContext to replace passing features as a prop (#1211)

### DIFF
--- a/packages/teleport/src/Discover/Discover.test.tsx
+++ b/packages/teleport/src/Discover/Discover.test.tsx
@@ -24,6 +24,7 @@ import { Access, Acl, makeUserContext } from 'teleport/services/user';
 import TeleportContext from 'teleport/teleportContext';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 import { Discover } from 'teleport/Discover/Discover';
+import { FeaturesContextProvider } from 'teleport/FeaturesContext';
 
 const fullAccess: Access = {
   list: true,
@@ -86,7 +87,9 @@ describe('discover', () => {
     return render(
       <MemoryRouter initialEntries={[{ state: { entity: initialEntry } }]}>
         <TeleportContextProvider ctx={ctx}>
-          <Discover />
+          <FeaturesContextProvider>
+            <Discover />
+          </FeaturesContextProvider>
         </TeleportContextProvider>
       </MemoryRouter>
     );

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { Indicator, Text } from 'design';
@@ -22,7 +22,6 @@ import { Danger } from 'design/Alert';
 
 import { Prompt } from 'react-router-dom';
 
-import getFeatures from 'teleport/features';
 import * as main from 'teleport/Main';
 import { TopBarContainer } from 'teleport/TopBar';
 import { FeatureBox } from 'teleport/components/Layout';
@@ -46,8 +45,6 @@ interface DiscoverProps {
 }
 
 export function Discover(props: DiscoverProps) {
-  const [features] = useState(() => getFeatures());
-
   const {
     alerts,
     initAttempt,
@@ -60,7 +57,6 @@ export function Discover(props: DiscoverProps) {
     views,
     ...agentProps
   } = useDiscover({
-    features,
     initialAlerts: props.initialAlerts,
     customBanners: props.customBanners,
   });

--- a/packages/teleport/src/FeaturesContext.tsx
+++ b/packages/teleport/src/FeaturesContext.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Gravitational, Inc.
+Copyright 2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/teleport/src/FeaturesContext.tsx
+++ b/packages/teleport/src/FeaturesContext.tsx
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useContext } from 'react';
+
+import { Feature } from 'teleport/types';
+import { getOSSFeatures } from 'teleport/features';
+
+interface FeaturesContextState {
+  features: Feature[];
+}
+
+interface FeaturesContextProviderProps {
+  value?: Feature[];
+}
+
+const FeaturesContext = React.createContext<FeaturesContextState>(null);
+
+export function FeaturesContextProvider(
+  props: React.PropsWithChildren<FeaturesContextProviderProps>
+) {
+  return (
+    <FeaturesContext.Provider
+      value={{ features: props.value || getOSSFeatures() }}
+    >
+      {props.children}
+    </FeaturesContext.Provider>
+  );
+}
+
+export function useFeatures() {
+  const { features } = useContext(FeaturesContext);
+
+  return features;
+}

--- a/packages/teleport/src/Main/Main.story.tsx
+++ b/packages/teleport/src/Main/Main.story.tsx
@@ -20,7 +20,7 @@ import { Router } from 'react-router';
 import { Flex } from 'design';
 
 import { ContextProvider, Context } from 'teleport';
-import getFeatures from 'teleport/features';
+import { getOSSFeatures } from 'teleport/features';
 
 import { clusters } from 'teleport/Clusters/fixtures';
 import { nodes } from 'teleport/Nodes/fixtures';
@@ -31,6 +31,8 @@ import { databases } from 'teleport/Databases/fixtures';
 
 import { kubes } from 'teleport/Kubes/fixtures';
 import { desktops } from 'teleport/Desktops/fixtures';
+
+import { FeaturesContextProvider } from 'teleport/FeaturesContext';
 
 import { userContext } from './fixtures';
 import { Main } from './Main';
@@ -52,7 +54,7 @@ function createTeleportContext() {
   ctx.desktopService.fetchDesktops = () =>
     Promise.resolve({ agents: desktops });
   ctx.storeUser.setState(userContext);
-  getFeatures().forEach(f => f.register(ctx));
+  getOSSFeatures().forEach(f => f.register(ctx));
 
   return ctx;
 }
@@ -66,9 +68,11 @@ export function OSS() {
   return (
     <Flex my={-3} mx={-4}>
       <ContextProvider ctx={ctx}>
-        <Router history={history}>
-          <Main customBanners={[]} />
-        </Router>
+        <FeaturesContextProvider value={getOSSFeatures()}>
+          <Router history={history}>
+            <Main customBanners={[]} />
+          </Router>
+        </FeaturesContextProvider>
       </ContextProvider>
     </Flex>
   );

--- a/packages/teleport/src/Main/Main.tsx
+++ b/packages/teleport/src/Main/Main.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import * as RouterDOM from 'react-router-dom';
-import React, { Suspense, useState } from 'react';
+import React, { Suspense } from 'react';
 import styled from 'styled-components';
 import { Indicator } from 'design';
 import { Failed } from 'design/CardError';
@@ -26,7 +26,6 @@ import cfg from 'teleport/config';
 import SideNav from 'teleport/SideNav';
 import TopBar from 'teleport/TopBar';
 import { BannerList } from 'teleport/components/BannerList';
-import getFeatures from 'teleport/features';
 import localStorage from 'teleport/services/localStorage';
 import history from 'teleport/services/history';
 
@@ -44,11 +43,8 @@ interface MainProps {
 }
 
 export function Main(props: MainProps) {
-  const [features] = useState(() => getFeatures());
-
   const { alerts, ctx, customBanners, dismissAlert, status, statusText } =
     useMain({
-      features,
       initialAlerts: props.initialAlerts,
       customBanners: props.customBanners,
     });

--- a/packages/teleport/src/Main/useMain.ts
+++ b/packages/teleport/src/Main/useMain.ts
@@ -18,13 +18,13 @@ import React, { useEffect } from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 import useTeleport from 'teleport/useTeleport';
-import { Feature } from 'teleport/types';
 import { useAlerts } from 'teleport/components/BannerList/useAlerts';
+
+import { useFeatures } from 'teleport/FeaturesContext';
 
 import type { ClusterAlert } from 'teleport/services/alerts';
 
 export interface UseMainConfig {
-  features: Feature[];
   customBanners?: React.ReactNode[];
   initialAlerts?: ClusterAlert[];
 }
@@ -33,6 +33,8 @@ export default function useMain(config: UseMainConfig) {
   const ctx = useTeleport();
   const { attempt, setAttempt, run } = useAttempt('processing');
   const { alerts, dismissAlert } = useAlerts(config.initialAlerts);
+
+  const features = useFeatures();
 
   useEffect(() => {
     // Two routes that uses this hook that can trigger this effect:
@@ -50,7 +52,7 @@ export default function useMain(config: UseMainConfig) {
       return;
     }
 
-    run(() => ctx.init(config.features));
+    run(() => ctx.init(features));
   }, []);
 
   return {

--- a/packages/teleport/src/Teleport.tsx
+++ b/packages/teleport/src/Teleport.tsx
@@ -21,6 +21,12 @@ import { Router, Route, Switch } from 'teleport/components/Router';
 import CatchError from 'teleport/components/CatchError';
 import Authenticated from 'teleport/components/Authenticated';
 
+import { FeaturesContextProvider } from 'teleport/FeaturesContext';
+
+import { getOSSFeatures } from 'teleport/features';
+
+import { Feature } from 'teleport/types';
+
 import { Main } from './Main';
 import Welcome from './Welcome';
 import Login, { LoginSuccess, LoginFailed } from './Login';
@@ -40,6 +46,8 @@ const Teleport: React.FC<Props> = props => {
   const publicRoutes = props.renderPublicRoutes || renderPublicRoutes;
   const privateRoutes = props.renderPrivateRoutes || renderPrivateRoutes;
 
+  const features = props.features || getOSSFeatures();
+
   return (
     <CatchError>
       <ThemeProvider>
@@ -49,13 +57,15 @@ const Teleport: React.FC<Props> = props => {
             <Route path={cfg.routes.root}>
               <Authenticated>
                 <TeleportContextProvider ctx={ctx}>
-                  <Switch>
-                    <Route
-                      path={cfg.routes.appLauncher}
-                      component={AppLauncher}
-                    />
-                    <Route>{privateRoutes()}</Route>
-                  </Switch>
+                  <FeaturesContextProvider value={features}>
+                    <Switch>
+                      <Route
+                        path={cfg.routes.appLauncher}
+                        component={AppLauncher}
+                      />
+                      <Route>{privateRoutes()}</Route>
+                    </Switch>
+                  </FeaturesContextProvider>
                 </TeleportContextProvider>
               </Authenticated>
             </Route>
@@ -122,6 +132,7 @@ export function renderPrivateRoutes(
 export default Teleport;
 
 export type Props = {
+  features?: Feature[];
   ctx: TeleportContext;
   history: History;
   renderPublicRoutes?(children?: JSX.Element[]): JSX.Element[];

--- a/packages/teleport/src/features.ts
+++ b/packages/teleport/src/features.ts
@@ -459,7 +459,7 @@ export class FeatureDesktops extends Feature {
   }
 }
 
-export default function getFeatures(): Feature[] {
+export function getOSSFeatures(): Feature[] {
   return [
     new FeatureNodes(),
     new FeatureApps(),


### PR DESCRIPTION
backport #1211 to teleport-v10

#### TODO
- [x] requires updating e-ref from https://github.com/gravitational/webapps.e/pull/401