### PR TITLE
Remove database reference when undefined in session start, end for Audit Log

### DIFF
--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -2563,7 +2563,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [alice@example.com] has disconnected from database [] on [mongo-primary]
+          User [alice@example.com] has disconnected on [mongo-primary]
         </td>
         <td
           style="min-width: 120px;"
@@ -2674,7 +2674,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [alice@example.com] has connected to database [] as [alice] on [mongo-primary]
+          User [alice@example.com] has connected as [alice] on [mongo-primary]
         </td>
         <td
           style="min-width: 120px;"

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -699,7 +699,9 @@ export const formatters: Formatters = {
     type: 'db.session.start',
     desc: 'Database Session Started',
     format: ({ user, db_service, db_name, db_user }) =>
-      `User [${user}] has connected to database [${db_name}] as [${db_user}] on [${db_service}]`,
+      `User [${user}] has connected ${
+        db_name ? 'to database [' + db_name + '] ' : ''
+      }as [${db_user}] on [${db_service}]`,
   },
   [eventCodes.DATABASE_SESSION_STARTED_FAILURE]: {
     type: 'db.session.start',
@@ -711,7 +713,9 @@ export const formatters: Formatters = {
     type: 'db.session.end',
     desc: 'Database Session Ended',
     format: ({ user, db_service, db_name }) =>
-      `User [${user}] has disconnected from database [${db_name}] on [${db_service}]`,
+      `User [${user}] has disconnected ${
+          db_name ? 'from database [' + db_name + '] ' : ''
+        }on [${db_service}]`,
   },
   [eventCodes.DATABASE_SESSION_QUERY]: {
     type: 'db.session.query',

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -714,8 +714,8 @@ export const formatters: Formatters = {
     desc: 'Database Session Ended',
     format: ({ user, db_service, db_name }) =>
       `User [${user}] has disconnected ${
-          db_name ? 'from database [' + db_name + '] ' : ''
-        }on [${db_service}]`,
+        db_name ? 'from database [' + db_name + '] ' : ''
+      }on [${db_service}]`,
   },
   [eventCodes.DATABASE_SESSION_QUERY]: {
     type: 'db.session.query',

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -700,7 +700,7 @@ export const formatters: Formatters = {
     desc: 'Database Session Started',
     format: ({ user, db_service, db_name, db_user }) =>
       `User [${user}] has connected ${
-        db_name ? 'to database [' + db_name + '] ' : ''
+        db_name ? `to database [${db_name}] ` : ''
       }as [${db_user}] on [${db_service}]`,
   },
   [eventCodes.DATABASE_SESSION_STARTED_FAILURE]: {

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -714,7 +714,7 @@ export const formatters: Formatters = {
     desc: 'Database Session Ended',
     format: ({ user, db_service, db_name }) =>
       `User [${user}] has disconnected ${
-        db_name ? 'from database [' + db_name + '] ' : ''
+        db_name ? `from database [${db_name}] ` : ''
       }on [${db_service}]`,
   },
   [eventCodes.DATABASE_SESSION_QUERY]: {


### PR DESCRIPTION
Connecting to some DB sessions does not have a db name.  Then you get a undefined database in the log.

Modifies 
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/60704961/193412054-0fbf1991-3b46-4a86-9ee4-6d85c40292ba.png">
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/60704961/193412079-0d481d04-3371-4d56-972c-0fe83e9e5732.png">

To show as

<img width="592" alt="image" src="https://user-images.githubusercontent.com/60704961/193412123-16d724cd-22f0-477f-ab76-4578925ff3d3.png">

<img width="528" alt="image" src="https://user-images.githubusercontent.com/60704961/193412131-d9d3fd48-af1f-466e-9b9c-49bbbcac71cd.png">

When available it will still show as in this postgres

<img width="795" alt="image" src="https://user-images.githubusercontent.com/60704961/193412202-bfa5d49c-cb7f-4711-9636-de40c50995f6.png">


