### PR TITLE
Add spacing between the text and generate button

### DIFF
--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScript.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScript.tsx
@@ -34,7 +34,7 @@ export function RunConfigureScript(
   if (timedOut) {
     content = (
       <StepInstructions>
-        <Text>That script expired.</Text>
+        <Text mb={4}>That script expired.</Text>
 
         <ButtonPrimary onClick={reloadJoinToken}>
           Generate another


### PR DESCRIPTION
As it stands, the spacing is too little between the text and the button. This adds some spacing between them. This needs backporting to v11.

![image](https://user-images.githubusercontent.com/7922109/195144010-d79effe1-1527-46ff-be6b-7ae2fee2fe75.png)
