### PR TITLE
Do not keep assumed roles in `app_state.json`

### DIFF
--- a/packages/teleterm/src/services/tshd/types.ts
+++ b/packages/teleterm/src/services/tshd/types.ts
@@ -42,7 +42,7 @@ export type Cluster = Omit<apiCluster.Cluster.AsObject, 'loggedInUser'> & {
   loggedInUser?: LoggedInUser;
 };
 export type LoggedInUser = apiCluster.LoggedInUser.AsObject & {
-  assumedRequests?: Record<string, AssumedRolesRequest>;
+  assumedRequests?: Record<string, AssumedRequest>;
 };
 export type AuthProvider = apiAuthSettings.AuthProvider.AsObject;
 export type AuthSettings = apiAuthSettings.AuthSettings.AsObject;
@@ -198,7 +198,7 @@ export type CreateAccessRequestParams = {
   resourceIds: { kind: ResourceKind; clusterName: string; id: string }[];
 };
 
-export type AssumedRolesRequest = {
+export type AssumedRequest = {
   id: string;
   expires: Date;
   roles: string[];

--- a/packages/teleterm/src/services/tshd/types.ts
+++ b/packages/teleterm/src/services/tshd/types.ts
@@ -38,8 +38,12 @@ export type GatewayProtocol =
   | 'redis'
   | 'sqlserver';
 export type Database = apiDb.Database.AsObject;
-export type Cluster = apiCluster.Cluster.AsObject;
-export type LoggedInUser = apiCluster.LoggedInUser.AsObject;
+export type Cluster = Omit<apiCluster.Cluster.AsObject, 'loggedInUser'> & {
+  loggedInUser?: LoggedInUser;
+};
+export type LoggedInUser = apiCluster.LoggedInUser.AsObject & {
+  assumedRolesRequests?: Record<string, AssumedRolesRequest>;
+};
 export type AuthProvider = apiAuthSettings.AuthProvider.AsObject;
 export type AuthSettings = apiAuthSettings.AuthSettings.AsObject;
 
@@ -192,4 +196,10 @@ export type CreateAccessRequestParams = {
   roles: string[];
   suggestedReviewers: string[];
   resourceIds: { kind: ResourceKind; clusterName: string; id: string }[];
+};
+
+export type AssumedRolesRequest = {
+  id: string;
+  expires: Date;
+  roles: string[];
 };

--- a/packages/teleterm/src/services/tshd/types.ts
+++ b/packages/teleterm/src/services/tshd/types.ts
@@ -42,7 +42,7 @@ export type Cluster = Omit<apiCluster.Cluster.AsObject, 'loggedInUser'> & {
   loggedInUser?: LoggedInUser;
 };
 export type LoggedInUser = apiCluster.LoggedInUser.AsObject & {
-  assumedRolesRequests?: Record<string, AssumedRolesRequest>;
+  assumedRequests?: Record<string, AssumedRolesRequest>;
 };
 export type AuthProvider = apiAuthSettings.AuthProvider.AsObject;
 export type AuthSettings = apiAuthSettings.AuthSettings.AsObject;

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.story.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.story.tsx
@@ -37,7 +37,6 @@ export const Story = () => {
         location: '',
         localClusterUri: '/clusters/localhost',
         accessRequests: {
-          assumed: {},
           pending: getEmptyPendingAccessRequest(),
           isBarCollapsed: true,
         },

--- a/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -15,6 +15,7 @@ const clusterMock: tsh.Cluster = {
   proxyHost: 'localhost:3080',
   loggedInUser: {
     activeRequestsList: [],
+    assumedRolesRequests: {},
     name: 'admin',
     acl: {},
     sshLoginsList: [],

--- a/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -15,7 +15,7 @@ const clusterMock: tsh.Cluster = {
   proxyHost: 'localhost:3080',
   loggedInUser: {
     activeRequestsList: [],
-    assumedRolesRequests: {},
+    assumedRequests: {},
     name: 'admin',
     acl: {},
     sshLoginsList: [],

--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -404,6 +404,15 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     return this.client.getRequestableRoles(clusterUri);
   }
 
+  getAssumedRolesRequests(clusterUri: string) {
+    const cluster = this.state.clusters.get(clusterUri);
+    if (!cluster?.connected) {
+      return {};
+    }
+
+    return cluster.loggedInUser?.assumedRolesRequests || {};
+  }
+
   async getAccessRequests(clusterUri: string) {
     const cluster = this.state.clusters.get(clusterUri);
     if (!cluster.connected) {
@@ -700,12 +709,43 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
   // with a retryable error in case the certs have expired.
   private async syncClusterInfo(clusterUri: string) {
     const cluster = await this.client.getCluster(clusterUri);
+    const assumedRolesRequests = cluster.loggedInUser
+      ? await this.fetchClusterAssumedRolesRequests(
+          cluster.loggedInUser.activeRequestsList,
+          clusterUri
+        )
+      : undefined;
     this.setState(draft => {
-      draft.clusters.set(
-        clusterUri,
-        this.removeInternalLoginsFromCluster(cluster)
-      );
+      draft.clusters.set(clusterUri, {
+        ...this.removeInternalLoginsFromCluster(cluster),
+        loggedInUser: cluster.loggedInUser
+          ? {
+              ...cluster.loggedInUser,
+              assumedRolesRequests,
+            }
+          : undefined,
+      });
     });
+  }
+
+  private async fetchClusterAssumedRolesRequests(
+    activeRequestsList: string[],
+    clusterUri: string
+  ) {
+    return (
+      await Promise.all(
+        activeRequestsList.map(requestId =>
+          this.getAccessRequest(clusterUri, requestId)
+        )
+      )
+    ).reduce((requestsMap, request) => {
+      requestsMap[request.id] = {
+        id: request.id,
+        expires: new Date(request.expires.seconds * 1000),
+        roles: request.rolesList,
+      };
+      return requestsMap;
+    }, {});
   }
 
   private removeResources(clusterUri: string) {

--- a/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -404,13 +404,13 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     return this.client.getRequestableRoles(clusterUri);
   }
 
-  getAssumedRolesRequests(clusterUri: string) {
+  getAssumedRequests(clusterUri: string) {
     const cluster = this.state.clusters.get(clusterUri);
     if (!cluster?.connected) {
       return {};
     }
 
-    return cluster.loggedInUser?.assumedRolesRequests || {};
+    return cluster.loggedInUser?.assumedRequests || {};
   }
 
   async getAccessRequests(clusterUri: string) {
@@ -709,8 +709,8 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
   // with a retryable error in case the certs have expired.
   private async syncClusterInfo(clusterUri: string) {
     const cluster = await this.client.getCluster(clusterUri);
-    const assumedRolesRequests = cluster.loggedInUser
-      ? await this.fetchClusterAssumedRolesRequests(
+    const assumedRequests = cluster.loggedInUser
+      ? await this.fetchClusterAssumedRequests(
           cluster.loggedInUser.activeRequestsList,
           clusterUri
         )
@@ -721,14 +721,14 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
         loggedInUser: cluster.loggedInUser
           ? {
               ...cluster.loggedInUser,
-              assumedRolesRequests,
+              assumedRequests,
             }
           : undefined,
       });
     });
   }
 
-  private async fetchClusterAssumedRolesRequests(
+  private async fetchClusterAssumedRequests(
     activeRequestsList: string[],
     clusterUri: string
   ) {

--- a/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.ts
+++ b/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.ts
@@ -134,7 +134,6 @@ it('updates the port of a gateway connection when the underlying doc gets update
   workspacesService.setState(draftState => {
     draftState.workspaces['/clusters/localhost'] = {
       accessRequests: {
-        assumed: {},
         pending: getEmptyPendingAccessRequest(),
         isBarCollapsed: false,
       },

--- a/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
+++ b/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
@@ -16,15 +16,22 @@ limitations under the License.
 
 import { FileStorage } from 'teleterm/types';
 import { ConnectionTrackerState } from 'teleterm/ui/services/connectionTracker';
-import { WorkspacesState } from 'teleterm/ui/services/workspacesService';
+import {
+  Workspace,
+  WorkspacesState,
+} from 'teleterm/ui/services/workspacesService';
 
 interface ShareFeedbackState {
   hasBeenOpened: boolean;
 }
 
+export type WorkspacesPersistedState = Omit<WorkspacesState, 'workspaces'> & {
+  workspaces: Record<string, Omit<Workspace, 'accessRequests'>>;
+};
+
 interface StatePersistenceState {
   connectionTracker: ConnectionTrackerState;
-  workspacesState: WorkspacesState;
+  workspacesState: WorkspacesPersistedState;
   shareFeedback: ShareFeedbackState;
 }
 
@@ -43,7 +50,7 @@ export class StatePersistenceService {
     return this.getState().connectionTracker;
   }
 
-  saveWorkspacesState(workspacesState: WorkspacesState): void {
+  saveWorkspacesState(workspacesState: WorkspacesPersistedState): void {
     const newState: StatePersistenceState = {
       ...this.getState(),
       workspacesState,
@@ -51,7 +58,7 @@ export class StatePersistenceService {
     this.putState(newState);
   }
 
-  getWorkspacesState(): WorkspacesState {
+  getWorkspacesState(): WorkspacesPersistedState {
     return this.getState().workspacesState;
   }
 

--- a/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
@@ -30,25 +30,6 @@ function getMockAssumed(assumed = {}): Record<string, AccessRequest> {
   return assumed;
 }
 
-function getMockAccessRequest(): AccessRequest {
-  return {
-    id: '72de9b90-04fd-5621-a55d-432d9fe56ef2',
-    state: 'APPROVED',
-    user: 'Sam',
-    expires: undefined,
-    expiresDuration: '',
-    created: undefined,
-    createdDuration: '',
-    roles: ['dev', 'admin'],
-    resolveReason: 'resolve reason',
-    requestReason: 'request reason',
-    reviews: [],
-    reviewers: [],
-    thresholdNames: ['Default'],
-    resources: [],
-  };
-}
-
 function createService(
   pending: PendingAccessRequest,
   assumed: Record<string, AccessRequest>
@@ -63,12 +44,10 @@ function createService(
     pending,
     assumed,
   };
-  const service = new AccessRequestsService(
+  return new AccessRequestsService(
     () => store.state,
     draftState => store.setState(draftState)
   );
-
-  return service;
 }
 
 test('getCollapsed() returns the bar collapse state', () => {

--- a/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
@@ -83,53 +83,6 @@ test('toggleBar() changes the collapse state', () => {
   expect(service.getCollapsed()).toBe(true);
 });
 
-test('addToAssumed() adds request to assumed', () => {
-  let service = createService(
-    getMockPendingAccessRequest(),
-    getMockAssumed({})
-  );
-  expect(service.getAssumed()).toStrictEqual({});
-  const request = getMockAccessRequest();
-  service.addToAssumed(request);
-  expect(service.getAssumed()).toStrictEqual({
-    [request.id]: {
-      id: request.id,
-      expires: request.expires,
-      roles: request.roles,
-    },
-  });
-});
-
-test('getAssumedRoles() returns assumed roles', () => {
-  const request = getMockAccessRequest();
-  let service = createService(
-    getMockPendingAccessRequest(),
-    getMockAssumed({ [request.id]: request })
-  );
-  expect(service.getAssumedRoles()).toStrictEqual(request.roles);
-});
-
-test('getAssumed() returns assumed map', () => {
-  const request = getMockAccessRequest();
-  let service = createService(
-    getMockPendingAccessRequest(),
-    getMockAssumed({ [request.id]: request })
-  );
-  expect(service.getAssumed()).toStrictEqual({
-    [request.id]: request,
-  });
-});
-
-test('clearAssumed() clears assumed map', () => {
-  const request = getMockAccessRequest();
-  let service = createService(
-    getMockPendingAccessRequest(),
-    getMockAssumed({ [request.id]: request })
-  );
-  service.clearAssumed();
-  expect(service.getAssumed()).toStrictEqual({});
-});
-
 test('clearPendingAccessRequest() clears pending access reuqest', () => {
   let service = createService(
     getMockPendingAccessRequest(),

--- a/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { ResourceKind } from 'e-teleterm/ui/DocumentAccessRequests/NewRequest/useNewRequest';
-import { AccessRequest } from 'e-teleport/services/workflow';
 
 import { PendingAccessRequest } from '../workspacesService';
 
@@ -23,13 +22,11 @@ export class AccessRequestsService {
     private getState: () => {
       isBarCollapsed: boolean;
       pending: PendingAccessRequest;
-      assumed: Record<string, AccessRequest>;
     },
     private setState: (
       draftState: (draft: {
         isBarCollapsed: boolean;
         pending: PendingAccessRequest;
-        assumed: Record<string, AssumedAccessRequest>;
       }) => void
     ) => void
   ) {}
@@ -46,42 +43,6 @@ export class AccessRequestsService {
 
   getPendingAccessRequest() {
     return this.getState().pending;
-  }
-
-  getAssumed() {
-    return this.getState().assumed;
-  }
-
-  getAssumedRoles() {
-    // return only unique roles from the flatMap of all roles
-    // assumed in each request
-    return [
-      ...new Set(
-        Object.values(this.getAssumed()).flatMap(request => request.roles)
-      ),
-    ];
-  }
-
-  addToAssumed({ id, expires, roles }: AccessRequest) {
-    this.setState(draftState => {
-      draftState.assumed[id] = {
-        id,
-        expires,
-        roles,
-      };
-    });
-  }
-
-  removeFromAssumed(request: AccessRequest) {
-    this.setState(draftState => {
-      delete draftState.assumed[request.id];
-    });
-  }
-
-  clearAssumed() {
-    this.setState(draftState => {
-      draftState.assumed = {};
-    });
   }
 
   clearPendingAccessRequest() {
@@ -123,8 +84,3 @@ export function getEmptyPendingAccessRequest() {
     windows_desktop: {},
   };
 }
-
-export type AssumedAccessRequest = Pick<
-  AccessRequest,
-  'id' | 'expires' | 'roles'
->;

--- a/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -69,7 +69,6 @@ describe('restoring workspace', () => {
     const testClusterUri = '/clusters/test-uri';
     const testWorkspace: Workspace = {
       accessRequests: {
-        assumed: {},
         isBarCollapsed: true,
         pending: getEmptyPendingAccessRequest(),
       },
@@ -93,7 +92,6 @@ describe('restoring workspace', () => {
     expect(workspacesService.getWorkspaces()).toStrictEqual({
       [testClusterUri]: {
         accessRequests: {
-          assumed: {},
           pending: {
             app: {},
             db: {},
@@ -127,7 +125,6 @@ describe('restoring workspace', () => {
       [testClusterUri]: {
         accessRequests: {
           isBarCollapsed: false,
-          assumed: {},
           pending: {
             app: {},
             db: {},


### PR DESCRIPTION
[[webapps.e](https://github.com/gravitational/webapps.e/pull/408/files)]
This PR removes assumed requests from `app_state.json`, we shouldn't keep them there, because it means duplicating `tsh` state. 

I added `assumedRolesRequests` to the current `LoggedInUser` type, I treat it as a temporary solution. In the future we'll only be able to assume 1 access request at a time, it will be a good opportunity to change the backend to just return `cluster.loggedInUser.assumedRequest`(containing `id`, `expires` and `roles`) instead of `cluster.loggedInUser.activeRequestsList` (which is a list containing only IDs). 