### PR TITLE
Increase the maximum width of the Share Link dialog.

### DIFF
--- a/packages/teleport/src/Users/UserReset/__snapshots__/UserReset.story.test.tsx.snap
+++ b/packages/teleport/src/Users/UserReset/__snapshots__/UserReset.story.test.tsx.snap
@@ -686,7 +686,7 @@ exports[`success state 1`] = `
   position: relative;
   overflow-y: auto;
   max-height: calc(100% - 96px);
-  max-width: 500px;
+  max-width: 550px;
   width: 100%;
 }
 

--- a/packages/teleport/src/Users/UserTokenLink/UserTokenLink.tsx
+++ b/packages/teleport/src/Users/UserTokenLink/UserTokenLink.tsx
@@ -39,7 +39,7 @@ export default function UserTokenLink({
 
   return (
     <Dialog
-      dialogCss={() => ({ maxWidth: '500px', width: '100%' })}
+      dialogCss={() => ({ maxWidth: '550px', width: '100%' })}
       disableEscapeKeyDown={false}
       onClose={close}
       open={true}

--- a/packages/teleport/src/Users/UserTokenLink/__snapshots__/UserTokenLink.story.test.tsx.snap
+++ b/packages/teleport/src/Users/UserTokenLink/__snapshots__/UserTokenLink.story.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`reset link dialog 1`] = `
   position: relative;
   overflow-y: auto;
   max-height: calc(100% - 96px);
-  max-width: 500px;
+  max-width: 550px;
   width: 100%;
 }
 
@@ -445,7 +445,7 @@ exports[`reset link dialog as invite 1`] = `
   position: relative;
   overflow-y: auto;
   max-height: calc(100% - 96px);
-  max-width: 500px;
+  max-width: 550px;
   width: 100%;
 }
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/webapps/issues/1264

Before:
<img width="595" alt="Screen Shot 2022-10-13 at 2 09 50 PM" src="https://user-images.githubusercontent.com/532033/195891792-8efd8805-93e4-41a8-b687-deca659ddb71.png">

After:
<img width="658" alt="Screen Shot 2022-10-14 at 9 57 50 AM" src="https://user-images.githubusercontent.com/532033/195891858-7573ff17-a0eb-457f-bd51-015eedbab916.png">
