### PR TITLE
Use sessionStorage for Authentication Bearer Token

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -56,6 +56,7 @@
     "@typescript-eslint/parser": "^5.4.0",
     "babel-loader": "^8.2.5",
     "babel-plugin-lodash": "^3.3.4",
+    "broadcast-channel": "4.18.1",
     "clean-webpack-plugin": "4.0.0",
     "core-js": "^3",
     "cross-env": "5.0.5",

--- a/packages/teleport/src/Console/Console.tsx
+++ b/packages/teleport/src/Console/Console.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Flex } from 'design';
 
+import useWebSession from 'teleport/useWebSession';
 import AjaxPoller from 'teleport/components/AjaxPoller';
 
 import { useConsoleContext, useStoreDocs } from './consoleContextProvider';
@@ -37,7 +38,8 @@ const POLL_INTERVAL = 5000; // every 5 sec
 
 export default function Console() {
   const consoleCtx = useConsoleContext();
-  const { verifyAndConfirm } = useOnExitConfirmation(consoleCtx);
+  const webSession = useWebSession();
+  const { verifyAndConfirm } = useOnExitConfirmation(consoleCtx, webSession);
   const { clusterId, activeDocId } = useTabRouting(consoleCtx);
 
   const storeDocs = consoleCtx.storeDocs;
@@ -68,7 +70,7 @@ export default function Console() {
   }
 
   function onLogout() {
-    consoleCtx.logout();
+    webSession.logout();
   }
 
   const disableNewTab = storeDocs.getNodeDocuments().length > 0;

--- a/packages/teleport/src/Console/consoleContext.tsx
+++ b/packages/teleport/src/Console/consoleContext.tsx
@@ -1,12 +1,9 @@
 /*
 Copyright 2019 Gravitational, Inc.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +16,6 @@ import Logger from 'shared/libs/logger';
 import { context, defaultTextMapSetter, trace } from '@opentelemetry/api';
 import { W3CTraceContextPropagator } from '@opentelemetry/core';
 
-import webSession from 'teleport/services/websession';
 import history from 'teleport/services/history';
 import cfg, { UrlResourcesParams, UrlSshParams } from 'teleport/config';
 import { getAccessToken, getHostName } from 'teleport/services/api';
@@ -164,10 +160,6 @@ export default class ConsoleContext {
 
   fetchClusters() {
     return serviceClusters.fetchClusters();
-  }
-
-  logout() {
-    webSession.logout();
   }
 
   createTty(session: Session): Tty {

--- a/packages/teleport/src/Console/useOnExitConfirmation.test.ts
+++ b/packages/teleport/src/Console/useOnExitConfirmation.test.ts
@@ -16,14 +16,18 @@
 
 import renderHook from 'design/utils/renderHook';
 
-import session from 'teleport/services/websession';
+import { getMockWebSession } from 'teleport/services/websession/test-utils';
 
 import ConsoleContext from './consoleContext';
 import useOnExitConfirmation from './useOnExitConfirmation';
 
 test('confirmation dialog before terminating an active ssh session', () => {
   const ctx = new ConsoleContext();
-  const { current } = renderHook(() => useOnExitConfirmation(ctx));
+
+  const mockWebSession = getMockWebSession();
+  const { current } = renderHook(() =>
+    useOnExitConfirmation(ctx, mockWebSession)
+  );
   const event = new Event('beforeunload');
 
   // two prompts that can be called before closing session/window
@@ -79,7 +83,7 @@ test('confirmation dialog before terminating an active ssh session', () => {
   docTerminal.created = new Date('2019-04-01');
 
   // test that expired session does not prompt
-  jest.spyOn(session, '_timeLeft').mockReturnValue(0);
+  jest.spyOn(mockWebSession, '_timeLeft').mockReturnValue(0);
   window.dispatchEvent(event);
   expect(event.preventDefault).not.toHaveBeenCalled();
 
@@ -90,7 +94,7 @@ test('confirmation dialog before terminating an active ssh session', () => {
   expect(window.confirm).toHaveReturnedWith(false);
 
   // test aged terminal doc triggers prompt
-  jest.spyOn(session, '_timeLeft').mockReturnValue(5);
+  jest.spyOn(mockWebSession, '_timeLeft').mockReturnValue(5);
   window.dispatchEvent(event);
   expect(event.preventDefault).toHaveBeenCalledTimes(1);
 });

--- a/packages/teleport/src/Console/useOnExitConfirmation.ts
+++ b/packages/teleport/src/Console/useOnExitConfirmation.ts
@@ -16,7 +16,7 @@
 
 import React from 'react';
 
-import session from 'teleport/services/websession';
+import { WebSession } from 'teleport/services/websession';
 
 import ConsoleContext from './consoleContext';
 import * as stores from './stores/types';
@@ -32,7 +32,7 @@ const TAB_MIN_AGE = 30000;
  *
  * @param ctx data that is shared between Console related components.
  */
-function useOnExitConfirmation(ctx: ConsoleContext) {
+function useOnExitConfirmation(ctx: ConsoleContext, session: WebSession) {
   React.useEffect(() => {
     /**
      * handleBeforeUnload listens for browser closes and refreshes.

--- a/packages/teleport/src/Discover/Discover.test.tsx
+++ b/packages/teleport/src/Discover/Discover.test.tsx
@@ -21,10 +21,12 @@ import { MemoryRouter } from 'react-router';
 import { render, screen } from 'design/utils/testing';
 
 import { Access, Acl, makeUserContext } from 'teleport/services/user';
+import { getMockWebSession } from 'teleport/services/websession/test-utils';
 import TeleportContext from 'teleport/teleportContext';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 import { Discover } from 'teleport/Discover/Discover';
 import { FeaturesContextProvider } from 'teleport/FeaturesContext';
+import { SessionContextProvider } from 'teleport/WebSessionContext';
 
 const fullAccess: Access = {
   list: true,
@@ -79,6 +81,7 @@ const userContextJson = {
 describe('discover', () => {
   function create(initialEntry: string, userAcl: Acl) {
     const ctx = new TeleportContext();
+    const mockWebSession = getMockWebSession();
 
     ctx.storeUser.state = makeUserContext({
       ...userContextJson,
@@ -87,11 +90,13 @@ describe('discover', () => {
 
     return render(
       <MemoryRouter initialEntries={[{ state: { entity: initialEntry } }]}>
-        <TeleportContextProvider ctx={ctx}>
-          <FeaturesContextProvider>
-            <Discover />
-          </FeaturesContextProvider>
-        </TeleportContextProvider>
+        <SessionContextProvider session={mockWebSession}>
+          <TeleportContextProvider ctx={ctx}>
+            <FeaturesContextProvider>
+              <Discover />
+            </FeaturesContextProvider>
+          </TeleportContextProvider>
+        </SessionContextProvider>
       </MemoryRouter>
     );
   }

--- a/packages/teleport/src/Discover/Discover.tsx
+++ b/packages/teleport/src/Discover/Discover.tsx
@@ -27,6 +27,7 @@ import { TopBarContainer } from 'teleport/TopBar';
 import { FeatureBox } from 'teleport/components/Layout';
 import { BannerList } from 'teleport/components/BannerList';
 import cfg from 'teleport/config';
+import useWebSession from 'teleport/useWebSession';
 
 import { ClusterAlert, LINK_LABEL } from 'teleport/services/alerts/alerts';
 import { Sidebar } from 'teleport/Discover/Sidebar/Sidebar';
@@ -53,10 +54,11 @@ function DiscoverContent() {
     currentStep,
     selectedResource,
     onSelectResource,
-    logout,
     views,
     ...agentProps
   } = useDiscover();
+
+  const webSession = useWebSession();
 
   let content;
   // we reserve step 0 for "Select Resource Type", that is present in all resource configs
@@ -135,7 +137,7 @@ function DiscoverContent() {
                   <Text typography="h5" bold>
                     Manage Access
                   </Text>
-                  <DiscoverUserMenuNav logout={logout} />
+                  <DiscoverUserMenuNav logout={webSession.logout} />
                 </TopBarContainer>
                 <FeatureBox pt={4} maxWidth="1450px">
                   {content}

--- a/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.test.tsx
+++ b/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.test.tsx
@@ -17,9 +17,11 @@ limitations under the License.
 import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 
-import { baseContext } from 'teleport/mocks/contexts';
-import makeUserContext from 'teleport/services/user/makeUserContext';
 import { ContextProvider, Context as TeleportContext } from 'teleport';
+import { baseContext } from 'teleport/mocks/contexts';
+import { SessionContextProvider } from 'teleport/WebSessionContext';
+import makeUserContext from 'teleport/services/user/makeUserContext';
+import { getMockWebSession } from 'teleport/services/websession/test-utils';
 
 import { ResourceKind } from '../ResourceKind';
 
@@ -38,11 +40,15 @@ describe('onProceed correctly deduplicates, removes static traits, updates meta,
   jest.spyOn(ctx.userService, 'updateUser').mockResolvedValue(null);
   jest.spyOn(ctx.userService, 'applyUserTraits').mockResolvedValue(null);
 
+  const mockWebSession = getMockWebSession();
+
   let wrapper;
 
   beforeEach(() => {
     wrapper = ({ children }) => (
-      <ContextProvider ctx={ctx}>{children}</ContextProvider>
+      <SessionContextProvider session={mockWebSession}>
+        <ContextProvider ctx={ctx}>{children}</ContextProvider>
+      </SessionContextProvider>
     );
   });
 
@@ -288,6 +294,8 @@ describe('static and dynamic traits are correctly separated and correctly create
     const ctx = createTeleportContext();
     jest.spyOn(ctx.userService, 'fetchUser').mockResolvedValue(getMockUser());
 
+    const mockWebSession = getMockWebSession();
+
     const props = {
       agentMeta: getMeta(resourceKind) as AgentMeta,
       updateAgentMeta: () => null,
@@ -296,7 +304,9 @@ describe('static and dynamic traits are correctly separated and correctly create
     };
 
     const wrapper = ({ children }) => (
-      <ContextProvider ctx={ctx}>{children}</ContextProvider>
+      <SessionContextProvider session={mockWebSession}>
+        <ContextProvider ctx={ctx}>{children}</ContextProvider>
+      </SessionContextProvider>
     );
 
     const { result, waitForNextUpdate } = renderHook(

--- a/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.ts
+++ b/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.ts
@@ -19,6 +19,7 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 
 import { arrayStrDiff } from 'teleport/lib/util';
 import useTeleport from 'teleport/useTeleport';
+import useWebSession from 'teleport/useWebSession';
 import { Option } from 'teleport/Discover/Shared/SelectCreatable';
 
 import { ResourceKind } from '../ResourceKind';
@@ -35,6 +36,7 @@ import type { AgentStepProps } from '../../types';
 //  - provides utility function that makes data objects (type Option) for react-select component
 export function useUserTraits(props: AgentStepProps) {
   const ctx = useTeleport();
+  const webSession = useWebSession();
 
   const [user, setUser] = useState<User>();
   const { attempt, run, setAttempt, handleError } = useAttempt('processing');
@@ -240,7 +242,7 @@ export function useUserTraits(props: AgentStepProps) {
         },
       });
 
-      await ctx.userService.applyUserTraits();
+      await ctx.userService.applyUserTraits(webSession);
       props.nextStep();
     } catch (err) {
       handleError(err);

--- a/packages/teleport/src/Discover/useDiscover.tsx
+++ b/packages/teleport/src/Discover/useDiscover.tsx
@@ -18,7 +18,6 @@ import React, { useContext, useMemo, useState } from 'react';
 
 import { useLocation } from 'react-router';
 
-import session from 'teleport/services/websession';
 import useMain from 'teleport/Main/useMain';
 
 import { ResourceKind } from 'teleport/Discover/Shared';
@@ -56,7 +55,6 @@ interface DiscoverContextState<T = any> {
   customBanners: React.ReactNode[];
   dismissAlert: (name: string) => void;
   initAttempt: any;
-  logout: () => void;
   nextStep: (count?: number) => void;
   prevStep: () => void;
   onSelectResource: (kind: ResourceKind) => void;
@@ -130,10 +128,6 @@ export function DiscoverProvider<T = any>(
     setAgentMeta(meta);
   }
 
-  function logout() {
-    session.logout();
-  }
-
   const value: DiscoverContextState<T> = {
     agentMeta,
     alerts: initState.alerts,
@@ -141,7 +135,6 @@ export function DiscoverProvider<T = any>(
     customBanners: initState.customBanners,
     dismissAlert: initState.dismissAlert,
     initAttempt: { status: initState.status, statusText: initState.statusText },
-    logout,
     nextStep,
     prevStep,
     onSelectResource,

--- a/packages/teleport/src/Login/useLogin.ts
+++ b/packages/teleport/src/Login/useLogin.ts
@@ -91,6 +91,8 @@ export default function useLogin() {
 }
 
 function onSuccess() {
+  localStorage.clear();
+  sessionStorage.clear();
   const redirect = getEntryRoute();
   const withPageRefresh = true;
   history.push(redirect, withPageRefresh);

--- a/packages/teleport/src/Player/Player.tsx
+++ b/packages/teleport/src/Player/Player.tsx
@@ -23,7 +23,7 @@ import { Danger } from 'design/Alert';
 
 import { useParams, useLocation } from 'teleport/components/Router';
 
-import session from 'teleport/services/websession';
+import useWebSession from 'teleport/useWebSession';
 import { colors } from 'teleport/Console/colors';
 import { UrlPlayerParams } from 'teleport/config';
 import { getUrlParameter } from 'teleport/services/history';
@@ -38,6 +38,7 @@ import Tabs, { TabItem } from './PlayerTabs';
 export default function Player() {
   const { sid, clusterId } = useParams<UrlPlayerParams>();
   const { search } = useLocation();
+  const webSession = useWebSession();
 
   const recordingType = getUrlParameter(
     'recordingType',
@@ -54,7 +55,7 @@ export default function Player() {
   document.title = `${clusterId} • Play ${sid}`;
 
   function onLogout() {
-    session.logout();
+    webSession.logout();
   }
 
   if (!validRecordingType) {

--- a/packages/teleport/src/TopBar/useTopBar.ts
+++ b/packages/teleport/src/TopBar/useTopBar.ts
@@ -16,12 +16,13 @@ limitations under the License.
 
 import { matchPath, useHistory } from 'react-router';
 
-import session from 'teleport/services/websession';
+import useWebSession from 'teleport/useWebSession';
 import Ctx from 'teleport/teleportContext';
 import cfg from 'teleport/config';
 import { StickyCluster } from 'teleport/types';
 
 export default function useTopBar(ctx: Ctx, stickyCluster: StickyCluster) {
+  const webSession = useWebSession();
   const history = useHistory();
   const { clusterId, hasClusterUrl } = stickyCluster;
   const popupItems = ctx.storeNav.getTopMenuItems();
@@ -43,7 +44,7 @@ export default function useTopBar(ctx: Ctx, stickyCluster: StickyCluster) {
   }
 
   function logout() {
-    session.logout();
+    webSession.logout();
   }
 
   function changeCluster(value: string) {

--- a/packages/teleport/src/WebSessionContext.tsx
+++ b/packages/teleport/src/WebSessionContext.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Gravitational, Inc.
+Copyright 2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export const KeysEnum = {
-  DISCOVER: 'grv_teleport_discover',
+import React from 'react';
+
+import { WebSession } from './services/websession';
+
+export const SessionContext = React.createContext<WebSession>(null);
+
+export const SessionContextProvider: React.FC<
+  React.PropsWithChildren<Props>
+> = props => {
+  return (
+    <SessionContext.Provider value={props.session} children={props.children} />
+  );
+};
+
+type Props = {
+  session: WebSession;
 };

--- a/packages/teleport/src/services/api/api.js
+++ b/packages/teleport/src/services/api/api.js
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import 'whatwg-fetch';
-import localStorage from './../localStorage';
+
+import { getBearerToken } from '../websession/storeWebSession';
+
 import parseError, { ApiError } from './parseError';
 
 const api = {
@@ -120,7 +122,7 @@ export const getXCSRFToken = () => {
 };
 
 export function getAccessToken() {
-  const bearerToken = localStorage.getBearerToken() || {};
+  const bearerToken = getBearerToken() || {};
   return bearerToken.accessToken;
 }
 

--- a/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/packages/teleport/src/services/localStorage/localStorage.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BearerToken } from 'teleport/services/websession';
 import { OnboardDiscover } from 'teleport/services/user';
 
 import { KeysEnum } from './types';
@@ -22,47 +21,6 @@ import { KeysEnum } from './types';
 const storage = {
   clear() {
     window.localStorage.clear();
-  },
-
-  subscribe(fn) {
-    window.addEventListener('storage', fn);
-  },
-
-  unsubscribe(fn) {
-    window.removeEventListener('storage', fn);
-  },
-
-  setBearerToken(token: BearerToken) {
-    window.localStorage.setItem(KeysEnum.TOKEN, JSON.stringify(token));
-  },
-
-  getBearerToken(): BearerToken {
-    const item = window.localStorage.getItem(KeysEnum.TOKEN);
-    if (item) {
-      return JSON.parse(item);
-    }
-
-    return null;
-  },
-
-  getAccessToken() {
-    const bearerToken = this.getBearerToken();
-    return bearerToken ? bearerToken.accessToken : null;
-  },
-
-  getSessionInactivityTimeout() {
-    const bearerToken = this.getBearerToken();
-    const time = Number(bearerToken.sessionInactiveTimeout);
-    return time ? time : 0;
-  },
-
-  setLastActive(expiry: number) {
-    window.localStorage.setItem(KeysEnum.LAST_ACTIVE, `${expiry}`);
-  },
-
-  getLastActive() {
-    const time = Number(window.localStorage.getItem(KeysEnum.LAST_ACTIVE));
-    return time ? time : 0;
   },
 
   // setOnboardDiscover persists states used to determine if a user should
@@ -78,11 +36,6 @@ const storage = {
       return JSON.parse(item);
     }
     return null;
-  },
-
-  broadcast(messageType, messageBody) {
-    window.localStorage.setItem(messageType, messageBody);
-    window.localStorage.removeItem(messageType);
   },
 };
 

--- a/packages/teleport/src/services/user/user.ts
+++ b/packages/teleport/src/services/user/user.ts
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 import api from 'teleport/services/api';
+import { WebSession } from 'teleport/services/websession';
 import cfg from 'teleport/config';
-import session from 'teleport/services/websession';
 
 import makeUserContext from './makeUserContext';
 import makeResetToken from './makeResetToken';
@@ -68,7 +68,7 @@ const service = {
     return api.delete(cfg.getUserWithUsernameUrl(name));
   },
 
-  applyUserTraits() {
+  applyUserTraits(session: WebSession) {
     return session.renewSession({ reloadUser: true });
   },
 

--- a/packages/teleport/src/services/websession/index.ts
+++ b/packages/teleport/src/services/websession/index.ts
@@ -14,7 +14,5 @@
  * limitations under the License.
  */
 
-import websession from './websession';
-
 export * from './types';
-export default websession;
+export { WebSession } from './websession';

--- a/packages/teleport/src/services/websession/storeWebSession.ts
+++ b/packages/teleport/src/services/websession/storeWebSession.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import history from 'teleport/services/history';
-
 import { KeysEnum, EventKeys } from './types';
 
 import type { BroadcastChannelMessage, BearerToken } from './types';

--- a/packages/teleport/src/services/websession/storeWebSession.ts
+++ b/packages/teleport/src/services/websession/storeWebSession.ts
@@ -1,0 +1,165 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import history from 'teleport/services/history';
+
+import { KeysEnum, EventKeys } from './types';
+
+import type { BroadcastChannelMessage, BearerToken } from './types';
+
+export class StoreWebSession {
+  bcBroadcaster: BroadcastChannel;
+  bcReceiver: BroadcastChannel;
+
+  constructor(bcBroadcaster?: BroadcastChannel, bcReceiver?: BroadcastChannel) {
+    this.initBroadcastChannel(bcBroadcaster, bcReceiver);
+  }
+
+  clear() {
+    this.bcBroadcaster.postMessage({ key: EventKeys.CLEAR });
+  }
+
+  setBearerToken(token: BearerToken) {
+    this.bcBroadcaster.postMessage({ key: EventKeys.UPSERT_TOKEN, token });
+  }
+
+  setIsRenewing(isTokenRenewing: boolean) {
+    this.bcBroadcaster.postMessage({
+      key: EventKeys.UPSERT_TOKEN_IS_RENEWING,
+      isTokenRenewing,
+    });
+  }
+
+  setLastActive(lastActive: number) {
+    this.bcBroadcaster.postMessage({
+      key: EventKeys.UPSERT_LAST_ACTIVE,
+      lastActive,
+    });
+  }
+
+  getIsRenewing(): boolean {
+    return window.sessionStorage.getItem(KeysEnum.TOKEN_RENEW) === 'true';
+  }
+
+  getLastActive() {
+    const time = Number(window.sessionStorage.getItem(KeysEnum.LAST_ACTIVE));
+    return time ? time : 0;
+  }
+
+  getAccessToken() {
+    const bearerToken = getBearerToken();
+    return bearerToken ? bearerToken.accessToken : null;
+  }
+
+  getSessionInactivityTimeout() {
+    const bearerToken = getBearerToken();
+    const time = Number(bearerToken.sessionInactiveTimeout);
+    return time ? time : 0;
+  }
+
+  initBroadcastChannel(
+    bcBroadcaster?: BroadcastChannel,
+    bcReceiver?: BroadcastChannel
+  ) {
+    this.bcBroadcaster =
+      bcBroadcaster || new BroadcastChannel('websession_store');
+    this.bcReceiver = bcReceiver || new BroadcastChannel('websession_store');
+
+    this.bcReceiver.onmessage = ({
+      data,
+    }: MessageEvent<BroadcastChannelMessage>) => {
+      // UPSERT_TOKEN indicates that a token has been upserted from a tab, this
+      // causes all tabs to update their own sessionStorage with that token.
+      if (data.key === EventKeys.UPSERT_TOKEN) {
+        window.sessionStorage.setItem(
+          KeysEnum.TOKEN,
+          JSON.stringify(data.token)
+        );
+      }
+
+      // GET_TOKEN indicates that a tab is asking for the token, if a tab
+      // has a token in its sessionStorage, it upserts it so that other tabs
+      // receive it and update their own sessionStorage with it.
+      if (data.key === EventKeys.GET_TOKEN) {
+        const token = getBearerToken();
+        if (token) {
+          this.bcBroadcaster.postMessage({
+            key: EventKeys.UPSERT_TOKEN,
+            token,
+          });
+        }
+      }
+
+      if (data.key === EventKeys.UPSERT_TOKEN_IS_RENEWING) {
+        window.sessionStorage.setItem(
+          KeysEnum.TOKEN_RENEW,
+          data.isTokenRenewing.toString()
+        );
+      }
+
+      if (data.key === EventKeys.GET_TOKEN_IS_RENEWING) {
+        const isRenewing = this.getIsRenewing();
+        if (isRenewing) {
+          this.bcBroadcaster.postMessage({
+            key: EventKeys.UPSERT_TOKEN_IS_RENEWING,
+            isRenewing,
+          });
+        }
+      }
+
+      if (data.key === EventKeys.UPSERT_LAST_ACTIVE) {
+        window.sessionStorage.setItem(
+          KeysEnum.LAST_ACTIVE,
+          data.lastActive.toString()
+        );
+      }
+
+      if (data.key === EventKeys.GET_LAST_ACTIVE) {
+        const lastActive = this.getLastActive();
+        if (lastActive) {
+          this.bcBroadcaster.postMessage({
+            key: EventKeys.UPSERT_LAST_ACTIVE,
+            lastActive,
+          });
+        }
+      }
+
+      if (data.key === EventKeys.CLEAR) {
+        window.sessionStorage.clear();
+        window.localStorage.clear();
+      }
+    };
+
+    // On page load, call out to other tabs to receive values
+    this.bcBroadcaster.postMessage({
+      key: EventKeys.GET_TOKEN,
+    });
+    this.bcBroadcaster.postMessage({
+      key: EventKeys.GET_TOKEN_IS_RENEWING,
+    });
+    this.bcBroadcaster.postMessage({
+      key: EventKeys.GET_LAST_ACTIVE,
+    });
+  }
+}
+
+export function getBearerToken(): BearerToken {
+  try {
+    return JSON.parse(window.sessionStorage.getItem(KeysEnum.TOKEN));
+  } catch (err) {
+    return err;
+  }
+}

--- a/packages/teleport/src/services/websession/test-utils.ts
+++ b/packages/teleport/src/services/websession/test-utils.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { BroadcastChannel } from 'broadcast-channel';
+
+import { WebSession } from 'teleport/services/websession';
+
+// Creates and returns a mocked webSession to be used in unit tests.
+export function getMockWebSession() {
+  jest.mock('broadcast-channel');
+
+  // The 'broadcast-channel' module is used for mocking in unit tests,
+  // however its type differs slightly from the native BroadcastChannel
+  // used in the app. This type conversion to unknown and then to the native
+  // BroadcastChannel type is done in order for the WebSession constructor
+  // to be able to accept this slightly different type.
+  const mockBcBroadcaster = new BroadcastChannel(
+    'test'
+  ) as unknown as globalThis.BroadcastChannel;
+  const mockBcReceiver = new BroadcastChannel(
+    'test'
+  ) as unknown as globalThis.BroadcastChannel;
+
+  const mockWebSession = new WebSession(mockBcBroadcaster, mockBcReceiver);
+  mockBcReceiver.onmessage = () => {};
+
+  return mockWebSession;
+}

--- a/packages/teleport/src/services/websession/types.ts
+++ b/packages/teleport/src/services/websession/types.ts
@@ -27,3 +27,26 @@ export type BearerToken = {
   sessionExpires: Date;
   sessionInactiveTimeout: number;
 };
+
+export enum KeysEnum {
+  TOKEN = 'grv_teleport_token',
+  TOKEN_RENEW = 'grv_teleport_token_renew',
+  LAST_ACTIVE = 'grv_teleport_last_active',
+}
+
+export enum EventKeys {
+  CLEAR = 'bc_clear_session',
+  GET_TOKEN = 'bc_get_session_token',
+  UPSERT_TOKEN = 'bc_upsert_session_token',
+  GET_TOKEN_IS_RENEWING = 'bc_get_token_is_renewing',
+  UPSERT_TOKEN_IS_RENEWING = 'bc_upsert_token_is_renewing',
+  GET_LAST_ACTIVE = 'bc_get_last_active',
+  UPSERT_LAST_ACTIVE = 'bc_upsert_last_active',
+}
+
+export type BroadcastChannelMessage = {
+  key: EventKeys;
+  token?: BearerToken;
+  isTokenRenewing?: boolean;
+  lastActive?: number;
+};

--- a/packages/teleport/src/useWebSession.ts
+++ b/packages/teleport/src/useWebSession.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Gravitational, Inc.
+Copyright 2022 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export const KeysEnum = {
-  DISCOVER: 'grv_teleport_discover',
-};
+import React from 'react';
+
+import { SessionContext } from './WebSessionContext';
+
+export default function useWebSession() {
+  const sessionContext = React.useContext(SessionContext);
+  if (!sessionContext) {
+    throw new Error('Unable to retrieve WebSession Context');
+  }
+
+  return sessionContext;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,6 +1116,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.16.0", "@babel/runtime@^7.6.2":
+  version "7.20.6"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz#facf4879bfed9b5326326273a64220f099b0fce3"
+  integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@^7.16.3":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
@@ -4865,6 +4872,17 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+broadcast-channel@4.18.1:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.18.1.tgz#23361e531a7af3589e184f65ac89cd387bb263be"
+  integrity sha512-eV1srWgt6H4hbtGqD7THn60me66WA5l0LogpssuX9jK6NK26HzIZr+VsrlD7Obe0BtYnwoo/a4v4z5gfty04DA==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    oblivious-set "1.1.1"
+    p-queue "6.6.2"
+    rimraf "3.0.2"
+    unload "2.3.1"
+
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -6377,7 +6395,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4:
+detect-node@2.1.0, detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -7331,7 +7349,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eventemitter3@^4.0.0:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -11588,6 +11606,11 @@ objectorarray@^1.0.5:
   resolved "https://registry.yarnpkg.com/objectorarray/-/objectorarray-1.0.5.tgz#2c05248bbefabd8f43ad13b41085951aac5e68a5"
   integrity sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==
 
+oblivious-set@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz#d9d38e9491d51f27a5c3ec1681d2ba40aa81e98b"
+  integrity sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w==
+
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
@@ -11831,6 +11854,14 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-queue@6.6.2:
+  version "6.6.2"
+  resolved "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
 p-retry@^4.5.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.1.tgz#8fcddd5cdf7a67a0911a9cf2ef0e5df7f602316c"
@@ -11839,7 +11870,7 @@ p-retry@^4.5.0:
     "@types/retry" "^0.12.0"
     retry "^0.13.1"
 
-p-timeout@^3.1.0:
+p-timeout@^3.1.0, p-timeout@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
   integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
@@ -13051,6 +13082,11 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
@@ -13345,17 +13381,17 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -15080,6 +15116,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/unload/-/unload-2.3.1.tgz#9d16862d372a5ce5cb630ad1309c2fd6e35dacfe"
+  integrity sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "2.1.0"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport-private/issues/158

Resolves a security concern due to using localStorage to store the session token. This is how it was initially but was changed to use localStorage in [this PR](https://github.com/gravitational/webapps/pull/215) due to a Firefox bug involving access request waiting rooms, this bug has been addressed in the `e` counterpart to this PR. 

TODO:
- [x] Fix failing unit tests