### PR TITLE
File Transfer UI fixes

### DIFF
--- a/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileListItem.tsx
+++ b/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileListItem.tsx
@@ -16,7 +16,7 @@
 
 import React, { FC, useEffect } from 'react';
 import styled from 'styled-components';
-import { Box, ButtonIcon, Flex, Text } from 'design';
+import { ButtonIcon, Flex, Text } from 'design';
 import { CircleCheck, Cross, Warning } from 'design/Icon';
 
 import { TransferredFile } from '../types';
@@ -35,52 +35,52 @@ export function FileListItem(props: FileListItemProps) {
 
   return (
     <Li>
-      <Box>
-        <Flex justifyContent="space-between" alignItems="baseline">
-          <Flex alignItems="baseline">
-            <Text
-              mb={1}
-              typography="body2"
-              css={`
-                word-break: break-word;
-              `}
-            >
-              {name}
-            </Text>
-            {transferState.type === 'completed' && (
-              <CircleCheck
-                ml={2}
-                fontSize="14px"
-                color="progressBarColor"
-                title="Transfer completed"
-              />
-            )}
-          </Flex>
-          {transferState.type === 'processing' && (
-            <ButtonIcon
-              title="Cancel"
-              size={0}
-              onClick={() => props.onCancel(id)}
-            >
-              <Cross />
-            </ButtonIcon>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Flex alignItems="center">
+          <Text
+            typography="body2"
+            css={`
+              word-break: break-all;
+            `}
+          >
+            {name}
+          </Text>
+          {transferState.type === 'completed' && (
+            <CircleCheck
+              ml={2}
+              fontSize="14px"
+              color="progressBarColor"
+              title="Transfer completed"
+            />
           )}
         </Flex>
-        {(transferState.type === 'processing' ||
-          transferState.type === 'error') && (
-          <Flex alignItems="baseline">
-            <ProgressPercentage mr={1}>
-              {transferState.progress}%
-            </ProgressPercentage>
-            <ProgressBackground>
-              <ProgressIndicator
-                progress={transferState.progress}
-                isFailure={transferState.type === 'error'}
-              />
-            </ProgressBackground>
-          </Flex>
+        {transferState.type === 'processing' && (
+          <ButtonIcon
+            title="Cancel"
+            size={0}
+            // prevents the icon from changing the height of the line
+            mt="-4px"
+            mb="-4px"
+            onClick={() => props.onCancel(id)}
+          >
+            <Cross />
+          </ButtonIcon>
         )}
-      </Box>
+      </Flex>
+      {(transferState.type === 'processing' ||
+        transferState.type === 'error') && (
+        <Flex alignItems="baseline" mt={1}>
+          <ProgressPercentage mr={1}>
+            {transferState.progress}%
+          </ProgressPercentage>
+          <ProgressBackground>
+            <ProgressIndicator
+              progress={transferState.progress}
+              isFailure={transferState.type === 'error'}
+            />
+          </ProgressBackground>
+        </Flex>
+      )}
       {transferState.type === 'error' && (
         <Error>{transferState.error.message}</Error>
       )}
@@ -98,7 +98,7 @@ const Error: FC = props => {
 };
 
 const ProgressPercentage = styled(Text)`
-  line-height: 14px;
+  line-height: 16px;
   width: 36px;
 `;
 

--- a/packages/shared/components/FileTransfer/FileTransferStateless/UploadForm/UploadForm.tsx
+++ b/packages/shared/components/FileTransfer/FileTransferStateless/UploadForm/UploadForm.tsx
@@ -134,6 +134,7 @@ const Dropzone = styled.button`
   opacity: ${props => (props.disabled ? 0.7 : 1)};
   pointer-events: ${props => (props.disabled ? 'none' : 'unset')};
   border-radius: ${props => props.theme.radii[2]}px;
+  font-family: inherit;
 
   :focus {
     border-color: ${props => props.theme.colors.action.selected};

--- a/packages/shared/components/FileTransfer/useFilesStore.ts
+++ b/packages/shared/components/FileTransfer/useFilesStore.ts
@@ -52,7 +52,7 @@ function reducer(
   switch (action.type) {
     case 'add': {
       return {
-        ids: [...state.ids, action.payload.id],
+        ids: [action.payload.id, ...state.ids],
         filesById: {
           ...state.filesById,
           [action.payload.id]: {

--- a/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
+++ b/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
@@ -85,7 +85,7 @@ export default function DocumentSsh({ doc, visible }: PropTypes) {
             window.confirm('Are you sure you want to cancel file transfers?')
           }
           afterClose={handleCloseFileTransfer}
-          backgroundColor={colors.terminalDark}
+          backgroundColor={colors.primary.light}
           transferHandlers={{
             getDownloader: async (location, abortController) =>
               getHttpFileTransferHandlers().download(


### PR DESCRIPTION
This PR contains small UI changes:
- makes new items to be shown at the top (instead of the bottom), so they are not hidden under the scroll when the user has already transferred many files
- changes the background color in WebUI for better readability - it is the same color as in the **console** servers table 
- improves the spacing in the files list (some margins were too large before) and icons alignment 

**Before**
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/20583051/196674613-42e0154d-1dca-45ac-91e4-30ff94f0ad77.png">

**After**
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/20583051/196674529-7bb97bf5-2e0b-4af5-9cca-69b22ce7b576.png">
