### PR TITLE
[v11] Connect: Adjust size of sync button & search input

### DIFF
--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/ClusterSearch.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/ClusterSearch.tsx
@@ -42,7 +42,7 @@ const Input = styled.input(props => {
     boxSizing: 'border-box',
     color: theme.colors.text.primary,
     width: '100%',
-    minHeight: '30px',
+    minHeight: '24px',
     minWidth: '300px',
     outline: 'none',
     borderRadius: '4px',

--- a/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
@@ -93,12 +93,7 @@ export function Cluster() {
         </Text>
         <Flex alignItems="center">
           <ClusterSearch onChange={clusterCtx.changeSearchValue} />
-          <ButtonPrimary
-            ml={2}
-            size="small"
-            height="30px"
-            onClick={clusterCtx.sync}
-          >
+          <ButtonPrimary ml={2} size="small" onClick={clusterCtx.sync}>
             Sync
           </ButtonPrimary>
         </Flex>


### PR DESCRIPTION
Backport #1280

The size of the sync button was changed to match the refresh button of access requests (https://github.com/gravitational/webapps.e/pull/396#discussion_r982842537). The change was reverted in #1269.

Instead of making the sync button to be of custom height, I think we should just change the size of the search input.

It also has the added bonus of making the sync and refresh button be on a matching height on both tabs, so they don't shift when switching between access requests and cluster resources.