### PR TITLE
[Discover] Fix bug where user traits were not updated in cert

### DIFF
--- a/packages/teleport/src/Discover/Kubernetes/LoginTrait/useLoginTrait.ts
+++ b/packages/teleport/src/Discover/Kubernetes/LoginTrait/useLoginTrait.ts
@@ -84,6 +84,8 @@ export function useLoginTrait({ ctx, props }: Props) {
           kubeGroups: dynamicTraits.groups,
         },
       });
+
+      await ctx.userService.applyUserTraits();
       props.nextStep();
     } catch (err) {
       handleError(err);


### PR DESCRIPTION
The bug was that after a user updated their trait, the cert was not updated so it was referring to stale user traits.