### PR TITLE
Change Desktop page to link to Discover, fix k8s typo

### DIFF
--- a/packages/teleport/src/Desktops/Desktops.tsx
+++ b/packages/teleport/src/Desktops/Desktops.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Indicator, Box, ButtonPrimary } from 'design';
+import { Indicator, Box } from 'design';
 
 import useTeleport from 'teleport/useTeleport';
 import {
@@ -25,6 +25,8 @@ import {
 } from 'teleport/components/Layout';
 import Empty, { EmptyStateInfo } from 'teleport/components/Empty';
 import ErrorMessage from 'teleport/components/AgentErrorMessage';
+
+import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 
 import DesktopList from './DesktopList';
 import useDesktops, { State } from './useDesktops';
@@ -70,15 +72,12 @@ export function Desktops(props: State) {
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Desktops</FeatureHeaderTitle>
         {attempt.status === 'success' && !hasNoDesktops && (
-          <ButtonPrimary
-            as="a"
-            width="240px"
-            target="_blank"
-            href={DOC_URL}
-            rel="noreferrer"
-          >
-            View documentation
-          </ButtonPrimary>
+          <AgentButtonAdd
+            agent="desktop"
+            beginsWithVowel={false}
+            isLeafCluster={isLeafCluster}
+            canCreate={canCreate}
+          />
         )}
       </FeatureHeader>
       {attempt.status === 'processing' && (

--- a/packages/teleport/src/Kubes/Kubes.tsx
+++ b/packages/teleport/src/Kubes/Kubes.tsx
@@ -127,7 +127,7 @@ export function Kubes(props: State) {
 const emptyStateInfo: EmptyStateInfo = {
   title: 'Add your first Kubernetes cluster to Teleport',
   byline:
-    'Teleport Kubenetes Access provides secure access to Kubernetes clusters.',
+    'Teleport Kubernetes Access provides secure access to Kubernetes clusters.',
   docsURL: DOC_URL,
   resourceType: 'kubernetes',
   readOnly: {

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -256,7 +256,7 @@ exports[`empty state 1`] = `
             font-weight="400"
             style="opacity: 0.6;"
           >
-            Teleport Kubenetes Access provides secure access to Kubernetes clusters.
+            Teleport Kubernetes Access provides secure access to Kubernetes clusters.
           </div>
         </div>
         <div


### PR DESCRIPTION
This changes the desktop list to have a button to add a desktop which goes through to the Discover flow, similar to k8s and servers.

I also noticed kubernetes was spelt wrong so thought I'd throw it in with this PR.

This needs backporting to v11