### PR TITLE
[v11] Make linguist correctly classify JS protobuf files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# JS protobuf files, not caught by built-in linguist rules.
+# https://github.com/github/linguist/blob/v7.23.0/lib/linguist/generated.rb#L349-L358
+*_pb.js linguist-generated
+*_pb.d.ts linguist-generated


### PR DESCRIPTION
Backport #1300

Linguist seems to expect that on line 6, those files have a specific string in them but that's not true for our files.

Maybe that's because we use buf and not protoc to generate them.

This should automatically collapse those files in diffs and properly count JavaScript usage in language stats for the repo.

See: https://github.com/github/linguist/blob/master/docs/overrides.md