### PR TITLE
Disable hostname comparison when proxying by default, add feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,36 @@ export WEBPACK_HTTPS_KEY=/Users/you/go/src/github.com/gravitational/webapps/cert
 The `certs/` directory in this repo is ignored by git, so you can place your certificate/keys
 in there without having to worry that they'll end up in a commit.
 
+#### Making application access work locally
+
+For application access to work, you should have it set so you're running Webpack on the same machine
+as Teleport. This is so you can access both Webpack and Teleport via the same domain.
+
+Imagine you're using the domain `go.teleport` instead of `localhost`.
+
+You should setup `/etc/hosts.yml` like so:
+
+```
+0.0.0.0 go.teleport
+0.0.0.0 dumper.go.teleport
+```
+
+Then, run Webpack with the environment variable `WEBPACK_PROXY_APP_ACCESS` set to `true`. This will
+check the incoming `Host` header and compare it against the hostname of the given target flag.
+
+```
+WEBPACK_PROXY_APP_ACCESS=true yarn start-teleport --target=https://go.teleport:3080/web
+```
+
+Going to `go.teleport`, Webpack will compare the `Host` header (`go.teleport`) and the hostname of the target (also
+`go.teleport`). It will therefore only proxy API requests through to Teleport, and serve the Webpack content for all
+other requests.
+
+Going to `dumper.go.teleport`, comparing the `Host` header (`dumper.go.teleport`) and the hostname of the target
+(`go.teleport`). It will proxy every request for this host through to Teleport, making application access work properly.
+
+Note: this only works for local Teleport instances, and won't work for Cloud.
+
 ### Unit-Tests
 
 We use [jest](https://jestjs.io/) as our testing framework.

--- a/packages/build/devserver/index.js
+++ b/packages/build/devserver/index.js
@@ -79,6 +79,10 @@ function getWebpackDevServerConfig() {
             return true;
           }
 
+          if (!process.env.WEBPACK_PROXY_APP_ACCESS) {
+            return false;
+          }
+
           // Proxy requests to any hostname that does not match the proxy hostname
           // This is to make application access work:
           // - When proxying to https://go.teleport, we want to serve Webpack for


### PR DESCRIPTION
Checking the `Host` header against the hostname for the given `--target` flag probably isn't a desirable by-default behaviour. This is because it assumes some kind of completely local configured setup.

I've made it so it requires the environment variable `WEBPACK_PROXY_APP_ACCESS` to be set , so it's now opt-in and configurable.

This means that when trying to run Webpack in front of a Cloud host, it'll work properly now (whereas it wouldn't before, as it would see there was a mismatch in hostnames and proxy all the traffic to Cloud).