### PR TITLE
[v11] Connect: Use gap instead of margins for <Label> groups

### DIFF
--- a/packages/teleterm/src/ui/DocumentCluster/ClusterResources/renderLabelCell.tsx
+++ b/packages/teleterm/src/ui/DocumentCluster/ClusterResources/renderLabelCell.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
+
 import { makeLabelTag } from 'teleport/components/formatters';
 import { Cell } from 'design/DataTable';
-import { Label as SingleLabel } from 'design';
-import { Label } from 'teleport/types';
+import { Label, Flex } from 'design';
+import * as types from 'teleport/types';
 
-export function renderLabelCell<T extends { labelsList: Label[] }>(props: T) {
+export function renderLabelCell<T extends { labelsList: types.Label[] }>(
+  props: T
+) {
   const labels = props.labelsList.map(makeLabelTag);
   const $labels = labels.map(label => (
-    <SingleLabel mb="1" mr="1" key={label} kind="secondary">
+    <Label key={label} kind="secondary">
       {label}
-    </SingleLabel>
+    </Label>
   ));
 
-  return <Cell>{$labels}</Cell>;
+  return (
+    <Cell>
+      <Flex flexWrap="wrap" gap={1}>
+        {$labels}
+      </Flex>
+    </Cell>
+  );
 }

--- a/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -32,13 +32,13 @@ export function IdentityList(props: IdentityListProps) {
           <Flex px={3} pt={2} pb={2} justifyContent="space-between">
             <Box>
               <Text bold>{props.loggedInUser.name}</Text>
-              <Text typography="body2" color="text.secondary">
+              <Flex flexWrap="wrap" gap={1}>
                 {props.loggedInUser.rolesList.map(role => (
-                  <Label mb="1" mr="1" key={role} kind="secondary">
+                  <Label key={role} kind="secondary">
                     {role}
                   </Label>
                 ))}
-              </Text>
+              </Flex>
             </Box>
           </Flex>
           <Separator />


### PR DESCRIPTION
Backport #1316.

@avatus Could you merge it to v11 after reviewing? I won't be able to do it tomorrow and I'd like this change to be released together with the other change to the role list that was submitted.