### PR TITLE
Change `teleport configure` to use `--proxy`

### DIFF
--- a/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
+++ b/packages/teleport/src/Apps/AddApp/Manually/Manually.tsx
@@ -85,7 +85,7 @@ const startCmd = `teleport start --config=${configFile}`;
 
 function getConfigCmd(token: string, host: string) {
   return `teleport configure --output=${configFile} --app-name=[example-app] --app-uri=http://localhost/ \
---roles=app --token=${token} --auth-server=${host} --data-dir=${cfg.configDir}`;
+--roles=app --token=${token} --proxy=${host} --data-dir=${cfg.configDir}`;
 }
 
 type StepsWithoutTokenProps = {

--- a/packages/teleport/src/Apps/AddApp/__snapshots__/AddApp.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/AddApp/__snapshots__/AddApp.story.test.tsx.snap
@@ -1500,7 +1500,7 @@ exports[`render manual tab with local user 1`] = `
                   $
                 </div>
                 <div>
-                  teleport configure --output=$HOME/.config/app_config.yaml --app-name=[example-app] --app-uri=http://localhost/ --roles=app --token=[generated-join-token] --auth-server=localhost:443 --data-dir=$HOME/.config
+                  teleport configure --output=$HOME/.config/app_config.yaml --app-name=[example-app] --app-uri=http://localhost/ --roles=app --token=[generated-join-token] --proxy=localhost:443 --data-dir=$HOME/.config
                 </div>
               </div>
               <button
@@ -1972,7 +1972,7 @@ exports[`render manual tab with sso user 1`] = `
                   $
                 </div>
                 <div>
-                  teleport configure --output=$HOME/.config/app_config.yaml --app-name=[example-app] --app-uri=http://localhost/ --roles=app --token=[generated-join-token] --auth-server=localhost:443 --data-dir=$HOME/.config
+                  teleport configure --output=$HOME/.config/app_config.yaml --app-name=[example-app] --app-uri=http://localhost/ --roles=app --token=[generated-join-token] --proxy=localhost:443 --data-dir=$HOME/.config
                 </div>
               </div>
               <button
@@ -2407,7 +2407,7 @@ exports[`render manual tab with token 1`] = `
                   $
                 </div>
                 <div>
-                  teleport configure --output=$HOME/.config/app_config.yaml --app-name=[example-app] --app-uri=http://localhost/ --roles=app --token=join-token --auth-server=localhost:443 --data-dir=$HOME/.config
+                  teleport configure --output=$HOME/.config/app_config.yaml --app-name=[example-app] --app-uri=http://localhost/ --roles=app --token=join-token --proxy=localhost:443 --data-dir=$HOME/.config
                 </div>
               </div>
               <button


### PR DESCRIPTION
As part of config v3, `teleport configure` was changed to allow `--proxy`, which will set `proxy_server` to the correct proxy address. This also changed the previous use of `--auth-server` to set `auth_server`, which doesn't work with a proxy URL.

This changes the manual step's command for adding an application to use `--proxy`. Will also need a backport to v11.