### PR TITLE
[Discover] Add back button for `TestConnection` screens

### DIFF
--- a/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.story.tsx
@@ -184,6 +184,7 @@ const props: State = {
   },
   runConnectionDiagnostic: () => null,
   nextStep: () => null,
+  prevStep: () => null,
   diagnosis: null,
   canTestConnection: true,
   kube: {

--- a/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
@@ -29,12 +29,12 @@ import useTeleport from 'teleport/useTeleport';
 import { generateTshLoginCommand } from 'teleport/lib/util';
 
 import {
-  Header,
   ActionButtons,
   TextIcon,
   HeaderSubtitle,
   Mark,
   ReadOnlyYamlEditor,
+  HeaderWithBackBtn,
 } from '../../Shared';
 import { ruleConnectionDiagnostic } from '../../templates';
 
@@ -54,6 +54,7 @@ export function TestConnection({
   runConnectionDiagnostic,
   diagnosis,
   nextStep,
+  prevStep,
   canTestConnection,
   kube,
   authType,
@@ -114,7 +115,9 @@ export function TestConnection({
     <Validation>
       {({ validator }) => (
         <Box>
-          <Header>Test Connection</Header>
+          <HeaderWithBackBtn onPrev={prevStep}>
+            Test Connection
+          </HeaderWithBackBtn>
           <HeaderSubtitle>
             Optionally verify that you can successfully connect to the
             Kubernetes cluster you just added.

--- a/packages/teleport/src/Discover/Kubernetes/TestConnection/useTestConnection.ts
+++ b/packages/teleport/src/Discover/Kubernetes/TestConnection/useTestConnection.ts
@@ -55,6 +55,7 @@ export function useTestConnection({ ctx, props }: Props) {
     runConnectionDiagnostic,
     diagnosis,
     nextStep: props.nextStep,
+    prevStep: props.prevStep,
     canTestConnection,
     kube: (props.agentMeta as KubeMeta).kube,
     username,

--- a/packages/teleport/src/Discover/Server/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/Server/TestConnection/TestConnection.story.tsx
@@ -137,6 +137,7 @@ const props: State = {
   startSshSession: () => null,
   runConnectionDiagnostic: () => null,
   nextStep: () => null,
+  prevStep: () => null,
   diagnosis: null,
   canTestConnection: true,
 };

--- a/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
@@ -23,7 +23,7 @@ import Select from 'shared/components/Select';
 import useTeleport from 'teleport/useTeleport';
 
 import {
-  Header,
+  HeaderWithBackBtn,
   ActionButtons,
   TextIcon,
   HeaderSubtitle,
@@ -51,6 +51,7 @@ export function TestConnection({
   runConnectionDiagnostic,
   diagnosis,
   nextStep,
+  prevStep,
   canTestConnection,
 }: State) {
   const [usernameOpts] = useState(() =>
@@ -88,7 +89,7 @@ export function TestConnection({
 
   return (
     <Box>
-      <Header>Test Connection</Header>
+      <HeaderWithBackBtn onPrev={prevStep}>Test Connection</HeaderWithBackBtn>
       <HeaderSubtitle>
         Optionally verify that you can successfully connect to the server you
         just added.

--- a/packages/teleport/src/Discover/Server/TestConnection/useTestConnection.ts
+++ b/packages/teleport/src/Discover/Server/TestConnection/useTestConnection.ts
@@ -65,6 +65,7 @@ export function useTestConnection({ ctx, props }: Props) {
     runConnectionDiagnostic,
     diagnosis,
     nextStep: props.nextStep,
+    prevStep: props.prevStep,
     canTestConnection,
   };
 }

--- a/packages/teleport/src/Discover/Shared/Header.tsx
+++ b/packages/teleport/src/Discover/Shared/Header.tsx
@@ -16,7 +16,8 @@
 
 import React from 'react';
 
-import { Text } from 'design';
+import { ArrowBack } from 'design/Icon';
+import { Text, ButtonIcon, Flex } from 'design';
 
 export const Header: React.FC = ({ children }) => (
   <Text my={1} fontSize="18px" bold>
@@ -26,4 +27,18 @@ export const Header: React.FC = ({ children }) => (
 
 export const HeaderSubtitle: React.FC = ({ children }) => (
   <Text mb={5}>{children}</Text>
+);
+
+export const HeaderWithBackBtn: React.FC<{ onPrev(): void }> = ({
+  children,
+  onPrev,
+}) => (
+  <Flex alignItems="center">
+    <ButtonIcon size={1} title="Go Back" onClick={onPrev} ml={-2}>
+      <ArrowBack fontSize="24px" />
+    </ButtonIcon>
+    <Text my={1} fontSize="18px" bold>
+      {children}
+    </Text>
+  </Flex>
 );

--- a/packages/teleport/src/Discover/Shared/index.ts
+++ b/packages/teleport/src/Discover/Shared/index.ts
@@ -16,7 +16,7 @@
 
 export { ActionButtons } from './ActionButtons';
 export { ButtonBlueText } from './ButtonBlueText';
-export { Header, HeaderSubtitle } from './Header';
+export { Header, HeaderSubtitle, HeaderWithBackBtn } from './Header';
 export { Finished } from './Finished';
 export { Mark } from './Mark';
 export { ReadOnlyYamlEditor } from './YAML';

--- a/packages/teleport/src/Discover/types.ts
+++ b/packages/teleport/src/Discover/types.ts
@@ -26,6 +26,8 @@ export type AgentStepProps = {
   updateAgentMeta?: State['updateAgentMeta'];
   // nextStep increments the `currentStep` to go to the next step.
   nextStep?: State['nextStep'];
+  // prevStep decrements the `currentStep` to go to the prev step.
+  prevStep?: State['prevStep'];
   selectedResource?: State['selectedResource'];
   selectedResourceKind?: ResourceKind;
   onSelectResource?: State['onSelectResource'];

--- a/packages/teleport/src/Discover/useDiscover.tsx
+++ b/packages/teleport/src/Discover/useDiscover.tsx
@@ -73,6 +73,14 @@ export function useDiscover(config: UseMainConfig) {
     }
   }
 
+  function prevStep() {
+    const nextView = findViewAtIndex(views, currentStep - 1);
+
+    if (nextView) {
+      setCurrentStep(currentStep - 1);
+    }
+  }
+
   function updateAgentMeta(meta: AgentMeta) {
     setAgentMeta(meta);
   }
@@ -90,6 +98,7 @@ export function useDiscover(config: UseMainConfig) {
     initAttempt: { status: initState.status, statusText: initState.statusText },
     logout,
     nextStep,
+    prevStep,
     onSelectResource,
     selectedResource,
     updateAgentMeta,

--- a/packages/teleport/src/services/agents/agents.test.ts
+++ b/packages/teleport/src/services/agents/agents.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import api from 'teleport/services/api';
+import cfg from 'teleport/config';
+
+import { agentService } from './agents';
+
+import type { ConnectionDiagnosticRequest } from './types';
+
+test('createConnectionDiagnostic request', () => {
+  jest.spyOn(api, 'post').mockResolvedValue(null);
+
+  // Test with all empty fields.
+  agentService.createConnectionDiagnostic({} as any);
+  expect(api.post).toHaveBeenCalledWith(cfg.getConnectionDiagnosticUrl(), {
+    resource_kind: undefined,
+    resource_name: undefined,
+    ssh_principal: undefined,
+    kubernetes_namespace: undefined,
+    kubernetes_impersonation: {
+      kubernetes_user: undefined,
+      kubernetes_groups: undefined,
+    },
+  });
+
+  // Test all fields gets set as requested.
+  const mock: ConnectionDiagnosticRequest = {
+    resourceKind: 'node',
+    resourceName: 'resource_name',
+    sshPrincipal: 'ssh_principal',
+    kubeImpersonation: {
+      namespace: 'kubernetes_namespace',
+      user: 'kubernetes_user',
+      groups: ['group1', 'group2'],
+    },
+  };
+  agentService.createConnectionDiagnostic(mock);
+  expect(api.post).toHaveBeenCalledWith(cfg.getConnectionDiagnosticUrl(), {
+    resource_kind: 'node',
+    resource_name: 'resource_name',
+    ssh_principal: 'ssh_principal',
+    kubernetes_namespace: 'kubernetes_namespace',
+    kubernetes_impersonation: {
+      kubernetes_user: 'kubernetes_user',
+      kubernetes_groups: ['group1', 'group2'],
+    },
+  });
+});

--- a/packages/teleport/src/services/agents/agents.ts
+++ b/packages/teleport/src/services/agents/agents.ts
@@ -33,10 +33,10 @@ export const agentService = {
         resource_kind: req.resourceKind,
         resource_name: req.resourceName,
         ssh_principal: req.sshPrincipal,
-        kubernetes_namespace: req.kubeImpersonation.namespace,
+        kubernetes_namespace: req.kubeImpersonation?.namespace,
         kubernetes_impersonation: {
-          kubernetes_user: req.kubeImpersonation.user,
-          kubernetes_groups: req.kubeImpersonation.groups,
+          kubernetes_user: req.kubeImpersonation?.user,
+          kubernetes_groups: req.kubeImpersonation?.groups,
         },
       })
       .then(makeConnectionDiagnostic);


### PR DESCRIPTION
#### Description
- As discussed in discover meeting, allow user to go back to the `Setup Access` screen from `TestConnection` screen to fix incorrect access when testing connection (otherwise they are stuck and have to restart the flow).
- Fix a bug where we try to access a possible undefined field

#### TODO
-  [ ] backport to v11
-  [ ] backport to v10

#### Screenshot
<img width="542" alt="image" src="https://user-images.githubusercontent.com/43280172/199343464-0b7e7328-cb7d-416d-b0f1-b9daa27611c7.png">

on hover

<img width="548" alt="image" src="https://user-images.githubusercontent.com/43280172/199343504-935163a4-cb8e-455c-a611-8573c0446609.png">
