### PR TITLE
Update ensureBaseUrl conditional

### DIFF
--- a/packages/teleport/src/services/history/history.test.ts
+++ b/packages/teleport/src/services/history/history.test.ts
@@ -34,6 +34,20 @@ describe('services/history', () => {
     jest.clearAllMocks();
   });
 
+  describe('ensureBaseUrl', () => {
+    it('should always ensure the base url matched cfg.baseUrl', () => {
+      expect(history.ensureBaseUrl('')).toBe('http://localhost/');
+      expect(history.ensureBaseUrl('/')).toBe('http://localhost/');
+      expect(history.ensureBaseUrl('/web')).toBe('http://localhost/web');
+      expect(history.ensureBaseUrl('somepath')).toBe(
+        'http://localhost/somepath'
+      );
+      expect(history.ensureBaseUrl('http://badurl')).toBe(
+        'http://localhost/http://badurl'
+      );
+    });
+  });
+
   describe('canPush', () => {
     const push = actual => ({
       andExpect(expected) {

--- a/packages/teleport/src/services/history/history.ts
+++ b/packages/teleport/src/services/history/history.ts
@@ -75,7 +75,11 @@ const history = {
 
   ensureBaseUrl(url: string) {
     url = url || '';
-    if (url.indexOf(cfg.baseUrl) !== 0) {
+    // create a URL object with url and option base set to cfg.baseUrl
+    // if an attacker tries to pass a url such as teleport.example.com.bad.io
+    // the cfg.baseUrl will be overridden. If it hasn't been overridden we can
+    // assume that the passed url is either relative, or match our cfg.baseUrl
+    if (new URL(url, cfg.baseUrl).hostname !== cfg.baseUrl) {
       if (url.startsWith('/')) {
         url = `${cfg.baseUrl}${url}`;
       } else {

--- a/packages/teleport/src/services/history/history.ts
+++ b/packages/teleport/src/services/history/history.ts
@@ -75,7 +75,7 @@ const history = {
 
   ensureBaseUrl(url: string) {
     url = url || '';
-    // create a URL object with url and option base set to cfg.baseUrl
+    // create a URL object with url arg and optional `base` second arg set to cfg.baseUrl
     // if an attacker tries to pass a url such as teleport.example.com.bad.io
     // the cfg.baseUrl will be overridden. If it hasn't been overridden we can
     // assume that the passed url is either relative, or match our cfg.baseUrl


### PR DESCRIPTION
Fixes https://github.com/gravitational/security-findings/issues/5

Previously we would only check if the `cfg.baseUrl` was the 0th index of the url being passed in during redirects. This would catch most 'bad' redirects except for ones that would use the entire baseUrl as subdomains. For example,
if `cfg.baseUrl` was `https://teleport.avat.us`, I could perform an open redirect by passing a redirect_uri of `https://teleport.avat.us.bad.io` because the baseUrl was still the 0th index of the passed url. This fix takes advantage of the URL api by passing in `cfg.baseUrl` as the optional base param in URL.

If a full, valid url is passed as the first param into `new URL`, any base param passed as the second will be overridden. If thats the case, we can check if it is still equal to our `cfg.baseUrl` (a normal redirect will be), and prevent any sneaky redirects from bad actors.

Adding @mdwn because, even tho I checked this with app access and it worked as expected, I wanted you to double check I wasn't missing something. Thank you!!

Note about `URL`:
If we weren't passing in a `base` param, then `new URL` would break if the first value was relative like `/web`. However, because we are passing in `cfg.baseUrl` as the second, optional param, this `new URL` will never fail, unless `cfg.baseUrl` could be undefined or not a full url but I'm not sure thats possible? If it is, we can just expand this into a try/catch and then its gucci. [examples](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#examples)