### PR TITLE
Update ensureBaseUrl to use URL constructors only

### DIFF
--- a/packages/teleport/src/services/history/history.test.ts
+++ b/packages/teleport/src/services/history/history.test.ts
@@ -42,8 +42,21 @@ describe('services/history', () => {
       expect(history.ensureBaseUrl('somepath')).toBe(
         'http://localhost/somepath'
       );
-      expect(history.ensureBaseUrl('http://badurl')).toBe(
-        'http://localhost/http://badurl'
+      expect(history.ensureBaseUrl('http://badurl')).toBe('http://localhost/');
+      // app access path redirects
+      expect(
+        history.ensureBaseUrl(
+          '/web/launch%3Fpath%3D%252Fteleport%252Fconfig%252F'
+        )
+      ).toBe(
+        'http://localhost/web/launch%3Fpath%3D%252Fteleport%252Fconfig%252F'
+      );
+      expect(
+        history.ensureBaseUrl(
+          'http://badurl/web/launch%3Fpath%3D%252Fteleport%252Fconfig%252F'
+        )
+      ).toBe(
+        'http://localhost/web/launch%3Fpath%3D%252Fteleport%252Fconfig%252F'
       );
     });
   });

--- a/packages/teleport/src/services/history/history.ts
+++ b/packages/teleport/src/services/history/history.ts
@@ -74,20 +74,18 @@ const history = {
   },
 
   ensureBaseUrl(url: string) {
-    url = url || '';
     // create a URL object with url arg and optional `base` second arg set to cfg.baseUrl
+    let urlWithBase = new URL(url || '', cfg.baseUrl);
+
     // if an attacker tries to pass a url such as teleport.example.com.bad.io
-    // the cfg.baseUrl will be overridden. If it hasn't been overridden we can
-    // assume that the passed url is either relative, or match our cfg.baseUrl
-    if (new URL(url, cfg.baseUrl).hostname !== cfg.baseUrl) {
-      if (url.startsWith('/')) {
-        url = `${cfg.baseUrl}${url}`;
-      } else {
-        url = `${cfg.baseUrl}/${url}`;
-      }
+    // the cfg.baseUrl argument will be overridden. If it hasn't been overridden we can
+    // assume that the passed url is either relative, or matches our cfg.baseUrl
+    if (urlWithBase.origin !== cfg.baseUrl) {
+      // create a new url with our base if the base doesn't match
+      urlWithBase = new URL(urlWithBase.pathname, cfg.baseUrl);
     }
 
-    return url;
+    return urlWithBase.toString();
   },
 
   getRoutes() {


### PR DESCRIPTION
An update to https://github.com/gravitational/webapps/pull/1320

We were checking `hostname` which would be something like `localhost` when the `cfg.baseUrl` would be `http://localhost`, so... no open redirect could ever succeed since we were 100% of the time always updating the base. The desired outcome of preventing an open redirect was fixed in the PR above but in the wrong way. 

This PR checks the origin now instead of hostname, and if not matching, will just create a new URL with `cfg.baseUrl`