### PR TITLE
[v9] Add support for leaf cluster that does not support new api `ListResources`

### DIFF
--- a/packages/design/src/DataTable/Cells.tsx
+++ b/packages/design/src/DataTable/Cells.tsx
@@ -108,6 +108,24 @@ export const ClickableLabelCell = ({
   return <Cell>{$labels}</Cell>;
 };
 
+export const UnclickableLabelCell = ({ labels }: { labels: AgentLabel[] }) => {
+  const $labels = labels.map(label => (
+    <Label
+      key={`${label.name}:${label.value}`}
+      mr="1"
+      mb="1"
+      kind="secondary"
+      css={`
+        cursor: pointer;
+      `}
+    >
+      {`${label.name}: ${label.value}`}
+    </Label>
+  ));
+
+  return <Cell>{$labels}</Cell>;
+};
+
 type SortHeaderCellProps<T> = {
   column: TableColumn<T>;
   serversideProps: ServersideProps;

--- a/packages/design/src/DataTable/Cells.tsx
+++ b/packages/design/src/DataTable/Cells.tsx
@@ -110,15 +110,7 @@ export const ClickableLabelCell = ({
 
 export const UnclickableLabelCell = ({ labels }: { labels: AgentLabel[] }) => {
   const $labels = labels.map(label => (
-    <Label
-      key={`${label.name}:${label.value}`}
-      mr="1"
-      mb="1"
-      kind="secondary"
-      css={`
-        cursor: pointer;
-      `}
-    >
+    <Label key={`${label.name}:${label.value}`} mr="1" mb="1" kind="secondary">
       {`${label.name}: ${label.value}`}
     </Label>
   ));

--- a/packages/design/src/DataTable/index.ts
+++ b/packages/design/src/DataTable/index.ts
@@ -5,8 +5,17 @@ import {
   DateCell,
   LabelCell,
   ClickableLabelCell,
+  UnclickableLabelCell,
 } from './Cells';
 import { StyledPanel } from './StyledTable';
 
-export { Cell, TextCell, DateCell, LabelCell, ClickableLabelCell, StyledPanel };
+export {
+  Cell,
+  TextCell,
+  DateCell,
+  LabelCell,
+  ClickableLabelCell,
+  StyledPanel,
+  UnclickableLabelCell,
+};
 export default Table;

--- a/packages/teleport/src/Apps/AppList/AppList.test.tsx
+++ b/packages/teleport/src/Apps/AppList/AppList.test.tsx
@@ -26,6 +26,7 @@ test('correct launch url is generated for a selected role', () => {
   render(
     <AppList
       {...props}
+      paginationUnsupported={false}
       totalCount={1}
       apps={[
         {

--- a/packages/teleport/src/Apps/AppList/AppList.tsx
+++ b/packages/teleport/src/Apps/AppList/AppList.tsx
@@ -17,7 +17,11 @@ limitations under the License.
 import React from 'react';
 import styled from 'styled-components';
 import { Flex, Text, ButtonBorder } from 'design';
-import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
+import Table, {
+  Cell,
+  ClickableLabelCell,
+  UnclickableLabelCell,
+} from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import {
   pink,
@@ -55,7 +59,50 @@ export default function AppList(props: Props) {
     pathname,
     replaceHistory,
     onLabelClick,
+    paginationUnsupported,
   } = props;
+
+  if (paginationUnsupported) {
+    // Return a client paging/searching table.
+    return (
+      <Table
+        data={apps}
+        emptyText="No Applications Found"
+        isSearchable
+        pagination={{ pageSize }}
+        columns={[
+          {
+            altKey: 'app-icon',
+            render: renderAppIcon,
+          },
+          {
+            key: 'name',
+            headerText: 'Name',
+            isSortable: true,
+          },
+          {
+            key: 'description',
+            headerText: 'Description',
+            isSortable: true,
+          },
+          {
+            key: 'publicAddr',
+            headerText: 'Address',
+            render: renderAddressCell,
+          },
+          {
+            key: 'labels',
+            headerText: 'Labels',
+            render: ({ labels }) => <UnclickableLabelCell labels={labels} />,
+          },
+          {
+            altKey: 'launch-btn',
+            render: renderLaunchButtonCell,
+          },
+        ]}
+      />
+    );
+  }
 
   return (
     <StyledTable
@@ -218,6 +265,7 @@ type Props = {
   pathname: string;
   replaceHistory: (path: string) => void;
   onLabelClick: (label: AgentLabel) => void;
+  paginationUnsupported: boolean;
 };
 
 const StyledTable = styled(Table)`

--- a/packages/teleport/src/Apps/Apps.story.test.tsx
+++ b/packages/teleport/src/Apps/Apps.story.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { render } from 'design/utils/testing';
-import { Loaded, Failed, Empty, EmptyReadOnly } from './Apps.story';
+import {
+  Loaded,
+  Failed,
+  Empty,
+  EmptyReadOnly,
+  PaginationUnsupported,
+} from './Apps.story';
 
 jest.mock('teleport/useStickyClusterId', () =>
   jest.fn(() => ({ clusterId: 'im-a-cluster', isLeafCluster: false }))
@@ -8,6 +14,13 @@ jest.mock('teleport/useStickyClusterId', () =>
 
 test('loaded state', async () => {
   const { container, findAllByText } = render(<Loaded />);
+  await findAllByText(/Applications/i);
+
+  expect(container).toMatchSnapshot();
+});
+
+test('pagination unsupported state', async () => {
+  const { container, findAllByText } = render(<PaginationUnsupported />);
   await findAllByText(/Applications/i);
 
   expect(container).toMatchSnapshot();

--- a/packages/teleport/src/Apps/Apps.story.tsx
+++ b/packages/teleport/src/Apps/Apps.story.tsx
@@ -26,6 +26,13 @@ export default {
 
 export const Loaded = () => <Apps {...props} />;
 
+export const PaginationUnsupported = () => (
+  <Apps
+    {...props}
+    results={{ ...props.results, paginationUnsupported: true }}
+  />
+);
+
 export const Empty = () => (
   <Apps {...props} results={{ apps: [] }} isSearchEmpty={true} />
 );

--- a/packages/teleport/src/Apps/Apps.tsx
+++ b/packages/teleport/src/Apps/Apps.tsx
@@ -103,6 +103,7 @@ export function Apps(props: State) {
           pathname={pathname}
           replaceHistory={replaceHistory}
           onLabelClick={onLabelClick}
+          paginationUnsupported={results.paginationUnsupported}
         />
       )}
       {hasNoApps && (

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -2326,6 +2326,23 @@ exports[`pagination unsupported state 1`] = `
   font-size: 14px;
 }
 
+.c19 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
 .c10 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2538,24 +2555,6 @@ exports[`pagination unsupported state 1`] = `
   background: #222C59;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-}
-
-.c19 {
-  box-sizing: border-box;
-  border-radius: 100px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 16px;
-  line-height: 1.4;
-  font-size: 10px;
-  font-weight: 500;
-  padding: 0 8px;
-  background-color: #111B48;
-  color: rgba(255,255,255,0.87);
-  margin-bottom: 4px;
-  margin-right: 4px;
-  cursor: pointer;
 }
 
 .c12 {

--- a/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -2203,6 +2203,805 @@ exports[`loaded state 1`] = `
 </div>
 `;
 
+exports[`pagination unsupported state 1`] = `
+.c3 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c20 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #2C3A73;
+  border: 1px solid #1C254D;
+  opacity: .87;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  width: 88px;
+}
+
+.c20:active {
+  opacity: 0.56;
+}
+
+.c20:hover,
+.c20:focus {
+  background: #2C3A73;
+  border: 1px solid rgba(255,255,255,0.1);
+  opacity: 1;
+}
+
+.c20:active {
+  opacity: 0.24;
+}
+
+.c20:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c14 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c16 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c18 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 22px;
+}
+
+.c21 {
+  display: inline-block;
+  transition: color .3s;
+  margin-left: 4px;
+  color: rgba(255,255,255,0.56);
+  font-size: 14px;
+}
+
+.c10 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  margin-right: 4px;
+  color: #FFFFFF;
+}
+
+.c23 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 16px;
+  margin: 0px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-right: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.c11 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c24 {
+  box-sizing: border-box;
+  height: 32px;
+  width: 32px;
+  background-color: #0097a7;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.c25 {
+  box-sizing: border-box;
+  height: 32px;
+  width: 32px;
+  background-color: #00796b;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.c22 {
+  box-sizing: border-box;
+  height: 32px;
+  width: 32px;
+  background-color: #e64a19;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.c17 {
+  box-sizing: border-box;
+  height: 32px;
+  width: 32px;
+  background-color: #f57c00;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+.c15 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 12px;
+  width: 100%;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.c15 > thead > tr > th,
+.c15 > tbody > tr > th,
+.c15 > tfoot > tr > th,
+.c15 > thead > tr > td,
+.c15 > tbody > tr > td,
+.c15 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c15 > thead > tr > th:first-child,
+.c15 > tbody > tr > th:first-child,
+.c15 > tfoot > tr > th:first-child,
+.c15 > thead > tr > td:first-child,
+.c15 > tbody > tr > td:first-child,
+.c15 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c15 > thead > tr > th:last-child,
+.c15 > tbody > tr > th:last-child,
+.c15 > tfoot > tr > th:last-child,
+.c15 > thead > tr > td:last-child,
+.c15 > tbody > tr > td:last-child,
+.c15 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c15 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+.c15 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c15 > thead > tr > th .c13 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c15 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c15 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c15 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c4 {
+  padding: 16px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c19 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
+.c12 {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.c12 .c13 {
+  font-size: 20px;
+  transition: all 0.3s;
+  opacity: 0.5;
+}
+
+.c12:hover .c13,
+.c12:focus .c13 {
+  opacity: 1;
+}
+
+.c12:disabled {
+  cursor: default;
+}
+
+.c12:disabled .c13 {
+  opacity: 0.1;
+}
+
+.c7 {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2C3A73;
+  border-radius: 200px;
+}
+
+.c5 {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 200px;
+  height: 32px;
+  background: #111B48;
+}
+
+.c6 {
+  border: none;
+  outline: none;
+  box-sizing: border-box;
+  height: 100%;
+  font-size: 12px;
+  width: 100%;
+  transition: all 0.2s;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+  background: #111B48;
+  padding-right: 184px;
+}
+
+.c6:hover,
+.c6:focus,
+.c6:active {
+  background: #1C254D;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c6::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        Applications
+      </div>
+      <button
+        class="c3"
+        kind="primary"
+        title=""
+        width="240px"
+      >
+        Add 
+        application
+      </button>
+    </div>
+    <nav
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        <input
+          class="c6"
+          placeholder="SEARCH..."
+          value=""
+        />
+        <div
+          class="c7"
+        />
+      </div>
+      <div
+        class="c8"
+        width="100%"
+      >
+        <div
+          class="c9"
+        >
+          <div
+            class="c10"
+            color="primary.contrastText"
+          >
+            SHOWING 
+            <strong>
+              1
+            </strong>
+             - 
+            <strong>
+              4
+            </strong>
+             of
+             
+            <strong>
+              4
+            </strong>
+          </div>
+        </div>
+        <div
+          class="c11"
+        >
+          <button
+            class="c12"
+            disabled=""
+            title="Previous page"
+          >
+            <span
+              class="c13 c14 icon icon-arrow-left-circle "
+              color="light"
+              font-size="3"
+            />
+          </button>
+          <button
+            class="c12"
+            disabled=""
+            title="Next page"
+          >
+            <span
+              class="c13 c14 icon icon-arrow-right-circle "
+              color="light"
+              font-size="3"
+            />
+          </button>
+        </div>
+      </div>
+    </nav>
+    <table
+      class="c15"
+    >
+      <thead>
+        <tr>
+          <th
+            style="cursor: default;"
+          />
+          <th>
+            <a>
+              Name
+              <span
+                class="c13 c16 icon icon-chevron-up "
+                color="light"
+              />
+            </a>
+          </th>
+          <th>
+            <a>
+              Description
+              <span
+                class="c13 c16 icon icon-chevrons-expand-vertical "
+                color="light"
+              />
+            </a>
+          </th>
+          <th
+            style="cursor: default;"
+          >
+            Address
+          </th>
+          <th
+            style="cursor: default;"
+          >
+            Labels
+          </th>
+          <th
+            style="cursor: default;"
+          />
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td
+            style="user-select: none;"
+          >
+            <div
+              class="c17"
+              height="32px"
+              width="32px"
+            >
+              <span
+                class="c13 c18 icon icon-amazonaws "
+                color="light"
+                font-size="6"
+              />
+            </div>
+          </td>
+          <td>
+            aws-console-1
+          </td>
+          <td>
+            This is an AWS Console app
+          </td>
+          <td>
+            https://
+            awsconsole-1.teleport-proxy.com
+          </td>
+          <td>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              aws_account_id: A1234
+            </div>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              env: dev
+            </div>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              cluster: two
+            </div>
+          </td>
+          <td
+            align="right"
+          >
+            <button
+              class="c20"
+              kind="border"
+              width="88px"
+            >
+              LAUNCH
+              <span
+                class="c13 c21 icon icon-caret-down "
+                color="text.secondary"
+                font-size="2"
+              />
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td
+            style="user-select: none;"
+          >
+            <div
+              class="c22"
+              height="32px"
+              width="32px"
+            >
+              <div
+                class="c23"
+                font-size="3"
+              >
+                G
+              </div>
+            </div>
+          </td>
+          <td>
+            Grafana
+          </td>
+          <td>
+            This is a Grafana app
+          </td>
+          <td>
+            https://
+            grafana.teleport-proxy.com
+          </td>
+          <td>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              env: dev
+            </div>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              cluster: one
+            </div>
+          </td>
+          <td
+            align="right"
+          >
+            <a
+              class="c20"
+              href="/web/launch/grafana.one/one/grafana.teleport-proxy.com"
+              kind="border"
+              rel="noreferrer"
+              target="_blank"
+              width="88px"
+            >
+              LAUNCH
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td
+            style="user-select: none;"
+          >
+            <div
+              class="c24"
+              height="32px"
+              width="32px"
+            >
+              <div
+                class="c23"
+                font-size="3"
+              >
+                J
+              </div>
+            </div>
+          </td>
+          <td>
+            Jenkins
+          </td>
+          <td>
+            This is a Jenkins app
+          </td>
+          <td>
+            https://
+            jenkins.teleport-proxy.com
+          </td>
+          <td>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              env: prod
+            </div>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              cluster: one
+            </div>
+          </td>
+          <td
+            align="right"
+          >
+            <a
+              class="c20"
+              href="/web/launch/jenkins.one/one/jenkins.teleport-proxy.com"
+              kind="border"
+              rel="noreferrer"
+              target="_blank"
+              width="88px"
+            >
+              LAUNCH
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td
+            style="user-select: none;"
+          >
+            <div
+              class="c25"
+              height="32px"
+              width="32px"
+            >
+              <div
+                class="c23"
+                font-size="3"
+              >
+                M
+              </div>
+            </div>
+          </td>
+          <td>
+            Mattermost1
+          </td>
+          <td>
+            This is a Mattermost app
+          </td>
+          <td>
+            https://
+            mattermost.teleport-proxy.com
+          </td>
+          <td>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              env: dev
+            </div>
+            <div
+              class="c19"
+              kind="secondary"
+            >
+              cluster: two
+            </div>
+          </td>
+          <td
+            align="right"
+          >
+            <a
+              class="c20"
+              href="/web/launch/mattermost.one/one/mattermost.teleport-proxy.com"
+              kind="border"
+              rel="noreferrer"
+              target="_blank"
+              width="88px"
+            >
+              LAUNCH
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
 exports[`readonly empty state 1`] = `
 .c3 {
   box-sizing: border-box;

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
@@ -15,7 +15,11 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Document, createContext } from './DocumentNodes.story';
+import {
+  Document,
+  PaginationUnsupported,
+  createContext,
+} from './DocumentNodes.story';
 import { waitFor, render } from 'design/utils/testing';
 
 test('render DocumentNodes', async () => {
@@ -24,6 +28,17 @@ test('render DocumentNodes', async () => {
   jest.spyOn(ctx, 'fetchNodes');
 
   const { container } = render(<Document value={ctx} />);
+  await waitFor(() => expect(ctx.fetchClusters).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(ctx.fetchNodes).toHaveBeenCalledTimes(1));
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render DocumentNodes pagination unsupported', async () => {
+  const ctx = createContext(true /* paginationUnsupported */);
+  jest.spyOn(ctx, 'fetchClusters');
+  jest.spyOn(ctx, 'fetchNodes');
+
+  const { container } = render(<PaginationUnsupported value={ctx} />);
   await waitFor(() => expect(ctx.fetchClusters).toHaveBeenCalledTimes(1));
   await waitFor(() => expect(ctx.fetchNodes).toHaveBeenCalledTimes(1));
   expect(container.firstChild).toMatchSnapshot();

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.test.tsx
@@ -34,7 +34,7 @@ test('render DocumentNodes', async () => {
 });
 
 test('render DocumentNodes pagination unsupported', async () => {
-  const ctx = createContext(true /* paginationUnsupported */);
+  const ctx = createContext({ paginationUnsupported: true });
   jest.spyOn(ctx, 'fetchClusters');
   jest.spyOn(ctx, 'fetchNodes');
 

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -35,7 +35,7 @@ export const Document = ({ value }: { value: ConsoleCtx }) => {
 };
 
 export const PaginationUnsupported = ({ value }: { value: ConsoleCtx }) => {
-  const ctx = value || createContext(true /* paginationUnsupported */);
+  const ctx = value || createContext({ paginationUnsupported: true });
   return (
     <TestLayout ctx={ctx}>
       <DocumentNodes doc={doc} visible={true} />
@@ -63,14 +63,14 @@ export const Failed = () => {
   );
 };
 
-export function createContext(paginationUnsupported = false) {
+export function createContext(opts?: { paginationUnsupported: boolean }) {
   const ctx = new ConsoleCtx();
 
   ctx.fetchClusters = () => {
     return Promise.resolve<any>(clusters);
   };
   ctx.fetchNodes = () => {
-    if (paginationUnsupported) {
+    if (opts?.paginationUnsupported) {
       return Promise.resolve({
         nodesRes: { nodes, paginationUnsupported: true },
       });

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -34,6 +34,15 @@ export const Document = ({ value }: { value: ConsoleCtx }) => {
   );
 };
 
+export const PaginationUnsupported = ({ value }: { value: ConsoleCtx }) => {
+  const ctx = value || createContext(true /* paginationUnsupported */);
+  return (
+    <TestLayout ctx={ctx}>
+      <DocumentNodes doc={doc} visible={true} />
+    </TestLayout>
+  );
+};
+
 export const Loading = () => {
   const ctx = createContext();
   ctx.fetchNodes = () => new Promise(() => null);
@@ -54,15 +63,19 @@ export const Failed = () => {
   );
 };
 
-export function createContext() {
+export function createContext(paginationUnsupported = false) {
   const ctx = new ConsoleCtx();
 
   ctx.fetchClusters = () => {
     return Promise.resolve<any>(clusters);
   };
   ctx.fetchNodes = () => {
+    if (paginationUnsupported) {
+      return Promise.resolve({
+        nodesRes: { nodes, paginationUnsupported: true },
+      });
+    }
     return Promise.resolve({
-      logins: ['root'],
       nodesRes: { nodes, totalCount: nodes.length },
     });
   };

--- a/packages/teleport/src/Console/DocumentNodes/DocumentNodes.tsx
+++ b/packages/teleport/src/Console/DocumentNodes/DocumentNodes.tsx
@@ -103,6 +103,7 @@ export default function DocumentNodes(props: Props) {
           )}
           {attempt.status !== 'processing' && (
             <NodeList
+              paginationUnsupported={results.paginationUnsupported}
               nodes={results.nodes}
               totalCount={results.totalCount}
               onLoginMenuOpen={onLoginMenuOpen}

--- a/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -1312,6 +1312,23 @@ exports[`render DocumentNodes pagination unsupported 1`] = `
   font-size: 14px;
 }
 
+.c24 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #01172C;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
 .c5 {
   color: #FFFFFF;
   display: block;
@@ -1463,24 +1480,6 @@ exports[`render DocumentNodes pagination unsupported 1`] = `
   background: #03203C;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-}
-
-.c24 {
-  box-sizing: border-box;
-  border-radius: 100px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 16px;
-  line-height: 1.4;
-  font-size: 10px;
-  font-weight: 500;
-  padding: 0 8px;
-  background-color: #01172C;
-  color: rgba(255,255,255,0.87);
-  margin-bottom: 4px;
-  margin-right: 4px;
-  cursor: pointer;
 }
 
 .c19 {

--- a/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -1233,3 +1233,1100 @@ exports[`render DocumentNodes 1`] = `
   </div>
 </div>
 `;
+
+exports[`render DocumentNodes pagination unsupported 1`] = `
+.c4 {
+  box-sizing: border-box;
+  margin-right: 20px;
+  width: 336px;
+}
+
+.c25 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #092F52;
+  border: 1px solid #010B1C;
+  opacity: .87;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  height: 24px;
+}
+
+.c25:active {
+  opacity: 0.56;
+}
+
+.c25:hover,
+.c25:focus {
+  background: #092F52;
+  border: 1px solid rgba(255,255,255,0.1);
+  opacity: 1;
+}
+
+.c25:active {
+  opacity: 0.24;
+}
+
+.c25:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c21 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c23 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c26 {
+  display: inline-block;
+  transition: color .3s;
+  margin-left: 8px;
+  margin-right: -8px;
+  color: rgba(255,255,255,0.56);
+  font-size: 14px;
+}
+
+.c5 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.c17 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  margin-right: 4px;
+  color: #FFFFFF;
+}
+
+.c0 {
+  box-sizing: border-box;
+  margin: -16px;
+  height: 100%;
+  width: 100%;
+  background-color: #010B1C;
+  display: flex;
+}
+
+.c1 {
+  box-sizing: border-box;
+  flex: 1;
+  display: flex;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+}
+
+.c15 {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.c16 {
+  box-sizing: border-box;
+  margin-right: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.c18 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c22 {
+  background: #03203C;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 12px;
+  width: 100%;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.c22 > thead > tr > th,
+.c22 > tbody > tr > th,
+.c22 > tfoot > tr > th,
+.c22 > thead > tr > td,
+.c22 > tbody > tr > td,
+.c22 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c22 > thead > tr > th:first-child,
+.c22 > tbody > tr > th:first-child,
+.c22 > tfoot > tr > th:first-child,
+.c22 > thead > tr > td:first-child,
+.c22 > tbody > tr > td:first-child,
+.c22 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c22 > thead > tr > th:last-child,
+.c22 > tbody > tr > th:last-child,
+.c22 > tfoot > tr > th:last-child,
+.c22 > thead > tr > td:last-child,
+.c22 > tbody > tr > td:last-child,
+.c22 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c22 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+.c22 > thead > tr > th {
+  background: #01172C;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c22 > thead > tr > th .c20 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c22 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c22 tbody tr {
+  border-bottom: 1px solid #010B1C;
+}
+
+.c22 tbody tr:hover {
+  background-color: rgb(7,40,70);
+}
+
+.c11 {
+  padding: 16px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #03203C;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c24 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #01172C;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
+.c19 {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.c19 .c20 {
+  font-size: 20px;
+  transition: all 0.3s;
+  opacity: 0.5;
+}
+
+.c19:hover .c20,
+.c19:focus .c20 {
+  opacity: 1;
+}
+
+.c19:disabled {
+  cursor: default;
+}
+
+.c19:disabled .c20 {
+  opacity: 0.1;
+}
+
+.c14 {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #092F52;
+  border-radius: 200px;
+}
+
+.c12 {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 200px;
+  height: 32px;
+  background: #01172C;
+}
+
+.c13 {
+  border: none;
+  outline: none;
+  box-sizing: border-box;
+  height: 100%;
+  font-size: 12px;
+  width: 100%;
+  transition: all 0.2s;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+  background: #01172C;
+  padding-right: 184px;
+}
+
+.c13:hover,
+.c13:focus,
+.c13:active {
+  background: #010B1C;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c13::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  width: 240px;
+  display: flex;
+  align-items: center;
+  height: 32px;
+  border: 1px solid;
+  border-radius: 4px;
+  border-color: rgba(255,255,255,0.24);
+}
+
+.c9 {
+  opacity: 0.75;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 0 8px;
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+}
+
+.c10 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-sizing: border-box;
+  border-bottom-left-radius: unset;
+  border-top-left-radius: unset;
+  display: block;
+  outline: none;
+  width: 100%;
+  height: 100%;
+  box-shadow: none;
+  padding-left: 8px;
+  font-size: 12px;
+  color: rgba(255,255,255,0.87);
+  background-color: #03203C;
+}
+
+.c10::-ms-clear {
+  display: none;
+}
+
+.c10:read-only {
+  cursor: not-allowed;
+}
+
+.c10::placeholder {
+  opacity: 1;
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+.c10:hover,
+.c10:focus {
+  background: #092F52;
+}
+
+.c7 .react-select-container {
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
+  box-sizing: border-box;
+  border: none;
+  display: block;
+  font-size: 14px;
+  outline: none;
+  width: 100%;
+  color: rgba(0,0,0,0.87);
+  background-color: #ffffff;
+  margin-bottom: 0px;
+  border-radius: 4px;
+}
+
+.c7 .react-select__control,
+.c7 .react-select__control--is-focused {
+  min-height: 40px;
+  height: 40px;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+}
+
+.c7 .react-select__control:hover,
+.c7 .react-select__control--is-focused:hover {
+  border-color: transparent;
+  cursor: pointer;
+}
+
+.c7 .react-select__option:hover {
+  cursor: pointer;
+  background-color: #eceff1;
+}
+
+.c7 .react-select__option--is-focused {
+  background-color: #eceff1;
+}
+
+.c7 .react-select__option--is-selected {
+  background-color: #cfd8dc;
+  color: inherit;
+}
+
+.c7 .react-select__option--is-selected:hover {
+  background-color: #cfd8dc;
+}
+
+.c7 .react-select__menu {
+  margin-top: 0px;
+}
+
+.c7 .react-select__indicator-separator {
+  display: none;
+}
+
+.c7 .react-select__loading-indicator {
+  display: none;
+}
+
+.c7 .react-select--is-disabled .react-select__single-value,
+.c7 .react-select--is-disabled .react-select__placeholder {
+  color: rgba(0,0,0,0.24);
+}
+
+.c7 .react-select--is-disabled .react-select__indicator {
+  color: rgba(0,0,0,0.14);
+}
+
+.c6 .react-select-container {
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.24);
+  box-sizing: border-box;
+  border: none;
+  display: block;
+  font-size: 14px;
+  outline: none;
+  width: 100%;
+  color: rgba(0,0,0,0.87);
+  background-color: #ffffff;
+  margin-bottom: 0px;
+  border-radius: 4px;
+}
+
+.c6 .react-select__control,
+.c6 .react-select__control--is-focused {
+  min-height: 40px;
+  height: 40px;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+}
+
+.c6 .react-select__control:hover,
+.c6 .react-select__control--is-focused:hover {
+  border-color: transparent;
+  cursor: pointer;
+}
+
+.c6 .react-select__option:hover {
+  cursor: pointer;
+  background-color: #eceff1;
+}
+
+.c6 .react-select__option--is-focused {
+  background-color: #eceff1;
+}
+
+.c6 .react-select__option--is-selected {
+  background-color: #cfd8dc;
+  color: inherit;
+}
+
+.c6 .react-select__option--is-selected:hover {
+  background-color: #cfd8dc;
+}
+
+.c6 .react-select__menu {
+  margin-top: 0px;
+}
+
+.c6 .react-select__indicator-separator {
+  display: none;
+}
+
+.c6 .react-select__loading-indicator {
+  display: none;
+}
+
+.c6 .react-select--is-disabled .react-select__single-value,
+.c6 .react-select--is-disabled .react-select__placeholder {
+  color: rgba(0,0,0,0.24);
+}
+
+.c6 .react-select--is-disabled .react-select__indicator {
+  color: rgba(0,0,0,0.14);
+}
+
+.c6 .react-select-container {
+  background: transparent;
+}
+
+.c6 .react-select__option--is-focused:active {
+  background-color: #eceff1;
+}
+
+.c6 .react-select__value-container {
+  padding: 0 8px;
+}
+
+.c6 .react-select__single-value {
+  color: rgba(255,255,255,0.87);
+}
+
+.c6 .react-select__control {
+  min-height: 34px;
+  height: 34px;
+  border-color: rgba(255,255,255,0.24);
+  color: rgba(255,255,255,0.56);
+}
+
+.c6 .react-select__control:focus,
+.c6 .react-select__control:active {
+  background-color: #092F52;
+}
+
+.c6 .react-select__control:hover {
+  border-color: rgba(255,255,255,0.24);
+  background-color: #092F52;
+}
+
+.c6 .react-select__control:hover .react-select__dropdown-indicator {
+  color: #666;
+}
+
+.c6 .react-select__control .react-select__indicator,
+.c6 .react-select__control .react-select__dropdown-indicator {
+  padding: 4px 8px;
+  color: #666;
+}
+
+.c6 .react-select__control .react-select__indicator:hover,
+.c6 .react-select__control .react-select__dropdown-indicator:hover {
+  color: #999;
+}
+
+.c6 .react-select__control--menu-is-open {
+  background-color: #092F52;
+  border-color: transparent;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+  border-color: rgba(255,255,255,0.24);
+}
+
+.c6 .react-select__control--menu-is-open .react-select__indicator,
+.c6 .react-select__control--menu-is-open .react-select__dropdown-indicator {
+  color: #999 !important;
+}
+
+.c6 .react-select__control--menu-is-open .react-select__indicator:hover,
+.c6 .react-select__control--menu-is-open .react-select__dropdown-indicator:hover {
+  color: #ccc !important;
+}
+
+.c6 .react-select__input {
+  color: rgba(255,255,255,0.87);
+}
+
+.c6 .react-select__placeholder {
+  color: rgba(255,255,255,0.56);
+}
+
+.c6 .react-select__option {
+  padding: 4px 12px;
+}
+
+.c6 .react-select__menu {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.c6 .react-select__multi-value {
+  background-color: #01172C;
+  border: 1px solid rgba(255,255,255,0.24);
+}
+
+.c6 .react-select__multi-value__label {
+  color: rgba(255,255,255,0.87);
+  padding: 0 6px;
+}
+
+.c6 .react-select--is-disabled .react-select__single-value,
+.c6 .react-select--is-disabled .react-select__placeholder,
+.c6 .react-select--is-disabled .react-select__indicator {
+  color: rgba(255,255,255,0.24);
+}
+
+.c6 .react-select-container {
+  background: #03203C;
+}
+
+.c6 .react-select__single-value {
+  color: white;
+  padding: 0 4px;
+  margin: 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  margin-top: 24px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 32px;
+  padding-right: 32px;
+  flex-direction: column;
+  display: flex;
+  flex: 1;
+  max-width: 1024px;
+}
+
+.c2::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+<div
+  class="c0"
+  height="100%"
+  style="position: absolute;"
+  width="100%"
+>
+  <div
+    class="c1"
+    style="overflow: auto; background: rgb(1, 11, 28); display: flex; position: relative;"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+          width="336px"
+        >
+          <label
+            class="c5"
+            font-size="0"
+          >
+             Clusters 
+          </label>
+          <div
+            class="c6"
+          >
+            <div
+              class="c7"
+            >
+              <div
+                class="react-select-container css-2b097c-container"
+              >
+                <div
+                  class="react-select__control css-yk16xz-control"
+                >
+                  <div
+                    class="react-select__value-container react-select__value-container--has-value css-g1d714-ValueContainer"
+                  >
+                    <div
+                      class="react-select__single-value css-1uccc91-singleValue"
+                    >
+                      cluseter-1
+                    </div>
+                    <div
+                      class="css-b8ldur-Input"
+                    >
+                      <div
+                        class="react-select__input"
+                        style="display: inline-block;"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          autocorrect="off"
+                          id="react-select-3-input"
+                          spellcheck="false"
+                          style="box-sizing: content-box; width: 2px; border: 0px; opacity: 1; outline: 0; padding: 0px;"
+                          tabindex="0"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: Ubuntu2,-apple-system,BlinkMacSystemFont,\\"Segoe UI\\",Helvetica,Arial,sans-serif,\\"Apple Color Emoji\\",\\"Segoe UI Emoji\\",\\"Segoe UI Symbol\\"; letter-spacing: normal; text-transform: none;"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+                  >
+                    <span
+                      class="react-select__indicator-separator css-1okebmr-indicatorSeparator"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="css-6q0nyr-Svg"
+                        focusable="false"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                      >
+                        <path
+                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c8"
+          width="240px"
+        >
+          <div
+            class="c9"
+          >
+            SSH:
+          </div>
+          <input
+            class="c10"
+            color="text.primary"
+            placeholder="login@host:port"
+          />
+        </div>
+      </div>
+      <nav
+        class="c11"
+      >
+        <div
+          class="c12"
+        >
+          <input
+            class="c13"
+            placeholder="SEARCH..."
+            value=""
+          />
+          <div
+            class="c14"
+          />
+        </div>
+        <div
+          class="c15"
+          width="100%"
+        >
+          <div
+            class="c16"
+          >
+            <div
+              class="c17"
+              color="primary.contrastText"
+            >
+              SHOWING 
+              <strong>
+                1
+              </strong>
+               - 
+              <strong>
+                5
+              </strong>
+               of
+               
+              <strong>
+                5
+              </strong>
+            </div>
+          </div>
+          <div
+            class="c18"
+          >
+            <button
+              class="c19"
+              disabled=""
+              title="Previous page"
+            >
+              <span
+                class="c20 c21 icon icon-arrow-left-circle "
+                color="light"
+                font-size="3"
+              />
+            </button>
+            <button
+              class="c19"
+              disabled=""
+              title="Next page"
+            >
+              <span
+                class="c20 c21 icon icon-arrow-right-circle "
+                color="light"
+                font-size="3"
+              />
+            </button>
+          </div>
+        </div>
+      </nav>
+      <table
+        class="c22"
+      >
+        <thead>
+          <tr>
+            <th>
+              <a>
+                Hostname
+                <span
+                  class="c20 c23 icon icon-chevron-up "
+                  color="light"
+                />
+              </a>
+            </th>
+            <th
+              style="cursor: default;"
+            >
+              Address
+            </th>
+            <th
+              style="cursor: default;"
+            >
+              Labels
+            </th>
+            <th
+              style="cursor: default;"
+            />
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              duzsevkig
+            </td>
+            <td>
+              <span
+                style="cursor: default;"
+                title="This node is connected to cluster through reverse tunnel"
+              >
+                ⟵ tunnel
+              </span>
+            </td>
+            <td>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                cluster: one
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                kernel: 4.15.0-51-generic
+              </div>
+            </td>
+            <td
+              align="right"
+            >
+              <button
+                class="c25"
+                height="24px"
+                kind="border"
+              >
+                CONNECT
+                <span
+                  class="c20 c26 icon icon-caret-down "
+                  color="text.secondary"
+                  font-size="2"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              facuzguv
+            </td>
+            <td>
+              172.10.1.42:3022
+            </td>
+            <td>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                cluster: one
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                kernel: 4.15.0-51-generic
+              </div>
+            </td>
+            <td
+              align="right"
+            >
+              <button
+                class="c25"
+                height="24px"
+                kind="border"
+              >
+                CONNECT
+                <span
+                  class="c20 c26 icon icon-caret-down "
+                  color="text.secondary"
+                  font-size="2"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              fujedu
+            </td>
+            <td>
+              172.10.1.20:3022
+            </td>
+            <td>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                cluster: one
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                kernel: 4.15.0-51-generic
+              </div>
+            </td>
+            <td
+              align="right"
+            >
+              <button
+                class="c25"
+                height="24px"
+                kind="border"
+              >
+                CONNECT
+                <span
+                  class="c20 c26 icon icon-caret-down "
+                  color="text.secondary"
+                  font-size="2"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              kuhinur
+            </td>
+            <td>
+              <span
+                style="cursor: default;"
+                title="This node is connected to cluster through reverse tunnel"
+              >
+                ⟵ tunnel
+              </span>
+            </td>
+            <td>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                cluster: one
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                kernel: 4.15.0-51-generic
+              </div>
+            </td>
+            <td
+              align="right"
+            >
+              <button
+                class="c25"
+                height="24px"
+                kind="border"
+              >
+                CONNECT
+                <span
+                  class="c20 c26 icon icon-caret-down "
+                  color="text.secondary"
+                  font-size="2"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              zebpecda
+            </td>
+            <td>
+              172.10.1.24:3022
+            </td>
+            <td>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                cluster: one
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                kernel: 4.15.0-51-generic
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                lortavma: one
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                lenisret: 4.15.0-51-generic
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                lofdevod: one
+              </div>
+              <div
+                class="c24"
+                kind="secondary"
+              >
+                llhurlaz: 4.15.0-51-generic
+              </div>
+            </td>
+            <td
+              align="right"
+            >
+              <button
+                class="c25"
+                height="24px"
+                kind="border"
+              >
+                CONNECT
+                <span
+                  class="c20 c26 icon icon-caret-down "
+                  color="text.secondary"
+                  font-size="2"
+                />
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/teleport/src/Databases/DatabaseList/DatabaseList.test.tsx
+++ b/packages/teleport/src/Databases/DatabaseList/DatabaseList.test.tsx
@@ -32,6 +32,7 @@ test('search generates correct url params', () => {
       totalCount={50}
       pathname="test.com/cluster/one/databases"
       replaceHistory={replaceHistory}
+      paginationUnsupported={false}
     />
   );
 

--- a/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
+++ b/packages/teleport/src/Databases/DatabaseList/DatabaseList.tsx
@@ -16,7 +16,11 @@ limitations under the License.
 
 import React, { useState } from 'react';
 import { ButtonBorder } from 'design';
-import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
+import Table, {
+  Cell,
+  ClickableLabelCell,
+  UnclickableLabelCell,
+} from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import { AuthType } from 'teleport/services/user';
 import { Database, DbProtocol } from 'teleport/services/databases';
@@ -46,12 +50,65 @@ function DatabaseList(props: Props) {
     replaceHistory,
     onLabelClick,
     accessRequestId,
+    paginationUnsupported,
   } = props;
 
   const [dbConnectInfo, setDbConnectInfo] = useState<{
     name: string;
     protocol: DbProtocol;
   }>(null);
+
+  if (paginationUnsupported) {
+    // Return a client paging/searching table.
+    return (
+      <>
+        <Table
+          data={databases}
+          emptyText="No Databases Found"
+          isSearchable
+          pagination={{ pageSize }}
+          columns={[
+            {
+              key: 'name',
+              headerText: 'Name',
+              isSortable: true,
+            },
+            {
+              key: 'description',
+              headerText: 'Description',
+              isSortable: true,
+            },
+            {
+              key: 'type',
+              headerText: 'Type',
+              isSortable: true,
+            },
+            {
+              key: 'labels',
+              headerText: 'Labels',
+              render: ({ labels }) => <UnclickableLabelCell labels={labels} />,
+            },
+            {
+              altKey: 'connect-btn',
+              render: database =>
+                renderConnectButton(database, setDbConnectInfo),
+            },
+          ]}
+        />
+        {dbConnectInfo && (
+          <ConnectDialog
+            username={username}
+            clusterId={clusterId}
+            dbName={dbConnectInfo.name}
+            dbProtocol={dbConnectInfo.protocol}
+            onClose={() => setDbConnectInfo(null)}
+            authType={authType}
+            accessRequestId={accessRequestId}
+          />
+        )}
+      </>
+    );
+  }
 
   return (
     <>
@@ -168,6 +225,7 @@ type Props = {
   replaceHistory: (path: string) => void;
   onLabelClick: (label: AgentLabel) => void;
   accessRequestId?: string;
+  paginationUnsupported: boolean;
 };
 
 export default DatabaseList;

--- a/packages/teleport/src/Databases/Databases.story.test.tsx
+++ b/packages/teleport/src/Databases/Databases.story.test.tsx
@@ -16,10 +16,21 @@ limitations under the License.
 
 import React from 'react';
 import { render } from 'design/utils/testing';
-import { Loaded, Failed, Empty, EmptyReadOnly } from './Databases.story';
+import {
+  Loaded,
+  Failed,
+  Empty,
+  EmptyReadOnly,
+  PaginationUnsupported,
+} from './Databases.story';
 
 test('open source loaded', () => {
   const { container } = render(<Loaded />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('pagination unsupported', () => {
+  const { container } = render(<PaginationUnsupported />);
   expect(container.firstChild).toMatchSnapshot();
 });
 

--- a/packages/teleport/src/Databases/Databases.story.tsx
+++ b/packages/teleport/src/Databases/Databases.story.tsx
@@ -26,6 +26,13 @@ export default {
 
 export const Loaded = () => <Databases {...props} />;
 
+export const PaginationUnsupported = () => (
+  <Databases
+    {...props}
+    results={{ ...props.results, paginationUnsupported: true }}
+  />
+);
+
 export const Empty = () => (
   <Databases {...props} results={{ databases: [] }} isSearchEmpty={true} />
 );

--- a/packages/teleport/src/Databases/Databases.tsx
+++ b/packages/teleport/src/Databases/Databases.tsx
@@ -113,6 +113,7 @@ export function Databases(props: State) {
             replaceHistory={replaceHistory}
             onLabelClick={onLabelClick}
             accessRequestId={accessRequestId}
+            paginationUnsupported={results.paginationUnsupported}
           />
         </>
       )}

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -1908,6 +1908,23 @@ exports[`pagination unsupported 1`] = `
   color: #FFFFFF;
 }
 
+.c17 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
 .c10 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2067,24 +2084,6 @@ exports[`pagination unsupported 1`] = `
   background: #222C59;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-}
-
-.c17 {
-  box-sizing: border-box;
-  border-radius: 100px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 16px;
-  line-height: 1.4;
-  font-size: 10px;
-  font-weight: 500;
-  padding: 0 8px;
-  background-color: #111B48;
-  color: rgba(255,255,255,0.87);
-  margin-bottom: 4px;
-  margin-right: 4px;
-  cursor: pointer;
 }
 
 .c12 {

--- a/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -1801,6 +1801,608 @@ exports[`open source loaded 1`] = `
 </div>
 `;
 
+exports[`pagination unsupported 1`] = `
+.c3 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c18 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #2C3A73;
+  border: 1px solid #1C254D;
+  opacity: .87;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+}
+
+.c18:active {
+  opacity: 0.56;
+}
+
+.c18:hover,
+.c18:focus {
+  background: #2C3A73;
+  border: 1px solid rgba(255,255,255,0.1);
+  opacity: 1;
+}
+
+.c18:active {
+  opacity: 0.24;
+}
+
+.c18:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c14 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c16 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c10 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  margin-right: 4px;
+  color: #FFFFFF;
+}
+
+.c8 {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-right: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.c11 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+.c15 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 12px;
+  width: 100%;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.c15 > thead > tr > th,
+.c15 > tbody > tr > th,
+.c15 > tfoot > tr > th,
+.c15 > thead > tr > td,
+.c15 > tbody > tr > td,
+.c15 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c15 > thead > tr > th:first-child,
+.c15 > tbody > tr > th:first-child,
+.c15 > tfoot > tr > th:first-child,
+.c15 > thead > tr > td:first-child,
+.c15 > tbody > tr > td:first-child,
+.c15 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c15 > thead > tr > th:last-child,
+.c15 > tbody > tr > th:last-child,
+.c15 > tfoot > tr > th:last-child,
+.c15 > thead > tr > td:last-child,
+.c15 > tbody > tr > td:last-child,
+.c15 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c15 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+.c15 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c15 > thead > tr > th .c13 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c15 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c15 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c15 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c4 {
+  padding: 16px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c17 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
+.c12 {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.c12 .c13 {
+  font-size: 20px;
+  transition: all 0.3s;
+  opacity: 0.5;
+}
+
+.c12:hover .c13,
+.c12:focus .c13 {
+  opacity: 1;
+}
+
+.c12:disabled {
+  cursor: default;
+}
+
+.c12:disabled .c13 {
+  opacity: 0.1;
+}
+
+.c7 {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2C3A73;
+  border-radius: 200px;
+}
+
+.c5 {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 200px;
+  height: 32px;
+  background: #111B48;
+}
+
+.c6 {
+  border: none;
+  outline: none;
+  box-sizing: border-box;
+  height: 100%;
+  font-size: 12px;
+  width: 100%;
+  transition: all 0.2s;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+  background: #111B48;
+  padding-right: 184px;
+}
+
+.c6:hover,
+.c6:focus,
+.c6:active {
+  background: #1C254D;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c6::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      Databases
+    </div>
+    <button
+      class="c3"
+      kind="primary"
+      title=""
+      width="240px"
+    >
+      Add Database
+    </button>
+  </div>
+  <nav
+    class="c4"
+  >
+    <div
+      class="c5"
+    >
+      <input
+        class="c6"
+        placeholder="SEARCH..."
+        value=""
+      />
+      <div
+        class="c7"
+      />
+    </div>
+    <div
+      class="c8"
+      width="100%"
+    >
+      <div
+        class="c9"
+      >
+        <div
+          class="c10"
+          color="primary.contrastText"
+        >
+          SHOWING 
+          <strong>
+            1
+          </strong>
+           - 
+          <strong>
+            3
+          </strong>
+           of
+           
+          <strong>
+            3
+          </strong>
+        </div>
+      </div>
+      <div
+        class="c11"
+      >
+        <button
+          class="c12"
+          disabled=""
+          title="Previous page"
+        >
+          <span
+            class="c13 c14 icon icon-arrow-left-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+        <button
+          class="c12"
+          disabled=""
+          title="Next page"
+        >
+          <span
+            class="c13 c14 icon icon-arrow-right-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+      </div>
+    </div>
+  </nav>
+  <table
+    class="c15"
+  >
+    <thead>
+      <tr>
+        <th>
+          <a>
+            Name
+            <span
+              class="c13 c16 icon icon-chevron-up "
+              color="light"
+            />
+          </a>
+        </th>
+        <th>
+          <a>
+            Description
+            <span
+              class="c13 c16 icon icon-chevrons-expand-vertical "
+              color="light"
+            />
+          </a>
+        </th>
+        <th>
+          <a>
+            Type
+            <span
+              class="c13 c16 icon icon-chevrons-expand-vertical "
+              color="light"
+            />
+          </a>
+        </th>
+        <th
+          style="cursor: default;"
+        >
+          Labels
+        </th>
+        <th
+          style="cursor: default;"
+        />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          aurora
+        </td>
+        <td>
+          PostgreSQL 11.6: AWS Aurora 
+        </td>
+        <td>
+          RDS PostgreSQL
+        </td>
+        <td>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            cluster: root
+          </div>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            env: aws
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            kind="border"
+          >
+            Connect
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          mysql-aurora-56
+        </td>
+        <td>
+          MySQL 5.6: AWS Aurora Longname For SQL
+        </td>
+        <td>
+          Self-hosted MySQL
+        </td>
+        <td>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            cluster: root
+          </div>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            env: aws
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            kind="border"
+          >
+            Connect
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          postgres-gcp
+        </td>
+        <td>
+          PostgreSQL 9.6: Google Cloud SQL
+        </td>
+        <td>
+          Cloud SQL PostgreSQL
+        </td>
+        <td>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            cluster: root
+          </div>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            env: gcp
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            kind="border"
+          >
+            Connect
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`readonly empty state 1`] = `
 .c3 {
   box-sizing: border-box;

--- a/packages/teleport/src/Desktops/DesktopList/DesktopList.test.tsx
+++ b/packages/teleport/src/Desktops/DesktopList/DesktopList.test.tsx
@@ -25,6 +25,7 @@ test('search generates correct url params', () => {
   render(
     <DesktopList
       {...props}
+      paginationUnsupported={false}
       totalCount={50}
       username="joe"
       desktops={desktops}

--- a/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
+++ b/packages/teleport/src/Desktops/DesktopList/DesktopList.tsx
@@ -15,7 +15,11 @@ limitations under the License.
 */
 
 import React from 'react';
-import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
+import Table, {
+  Cell,
+  ClickableLabelCell,
+  UnclickableLabelCell,
+} from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import { Desktop } from 'teleport/services/desktops';
 import { AgentLabel } from 'teleport/services/resources';
@@ -42,6 +46,7 @@ function DesktopList(props: Props) {
     pathname,
     replaceHistory,
     onLabelClick,
+    paginationUnsupported,
   } = props;
 
   function onDesktopSelect(
@@ -51,6 +56,39 @@ function DesktopList(props: Props) {
   ) {
     e.preventDefault();
     onLoginSelect(username, desktopName);
+  }
+
+  if (paginationUnsupported) {
+    // Return a client paging/searching table.
+    return (
+      <Table
+        data={desktops}
+        emptyText="No Desktops Found"
+        isSearchable
+        pagination={{ pageSize }}
+        columns={[
+          {
+            key: 'addr',
+            headerText: 'Address',
+          },
+          {
+            key: 'name',
+            headerText: 'Name',
+            isSortable: true,
+          },
+          {
+            key: 'labels',
+            headerText: 'Labels',
+            render: ({ labels }) => <UnclickableLabelCell labels={labels} />,
+          },
+          {
+            altKey: 'login-cell',
+            render: desktop =>
+              renderLoginCell(desktop, onLoginMenuOpen, onDesktopSelect),
+          },
+        ]}
+      />
+    );
   }
 
   return (
@@ -168,6 +206,7 @@ type Props = {
   pathname: string;
   replaceHistory: (path: string) => void;
   onLabelClick: (label: AgentLabel) => void;
+  paginationUnsupported: boolean;
 };
 
 export default DesktopList;

--- a/packages/teleport/src/Desktops/Desktops.story.test.tsx
+++ b/packages/teleport/src/Desktops/Desktops.story.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from 'design/utils/testing';
+import { Loaded, PaginationUnsupported } from './Desktops.story';
+
+test('loaded', () => {
+  const { container } = render(<Loaded />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('pagination unsupported', () => {
+  const { container } = render(<PaginationUnsupported />);
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/packages/teleport/src/Desktops/Desktops.story.tsx
+++ b/packages/teleport/src/Desktops/Desktops.story.tsx
@@ -28,6 +28,13 @@ export const Loading = () => (
   <Desktops {...props} attempt={{ status: 'processing' }} />
 );
 
+export const PaginationUnsupported = () => (
+  <Desktops
+    {...props}
+    results={{ ...props.results, paginationUnsupported: true }}
+  />
+);
+
 export const Loaded = () => <Desktops {...props} />;
 
 export const Empty = () => (

--- a/packages/teleport/src/Desktops/Desktops.tsx
+++ b/packages/teleport/src/Desktops/Desktops.tsx
@@ -111,6 +111,7 @@ export function Desktops(props: State) {
           pathname={pathname}
           replaceHistory={replaceHistory}
           onLabelClick={onLabelClick}
+          paginationUnsupported={results.paginationUnsupported}
         />
       )}
       {hasNoDesktops && (

--- a/packages/teleport/src/Desktops/__snapshots__/Desktops.story.test.tsx.snap
+++ b/packages/teleport/src/Desktops/__snapshots__/Desktops.story.test.tsx.snap
@@ -1,0 +1,1321 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loaded 1`] = `
+.c7 {
+  box-sizing: border-box;
+  margin-right: 16px;
+  width: 100%;
+}
+
+.c3 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c23 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #2C3A73;
+  border: 1px solid #1C254D;
+  opacity: .87;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  height: 24px;
+}
+
+.c23:active {
+  opacity: 0.56;
+}
+
+.c23:hover,
+.c23:focus {
+  background: #2C3A73;
+  border: 1px solid rgba(255,255,255,0.1);
+  opacity: 1;
+}
+
+.c23:active {
+  opacity: 0.24;
+}
+
+.c23:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c18 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c24 {
+  display: inline-block;
+  transition: color .3s;
+  margin-left: 8px;
+  margin-right: -8px;
+  color: rgba(255,255,255,0.56);
+  font-size: 14px;
+}
+
+.c29 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c16 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 12px;
+  line-height: 24px;
+  margin: 0px;
+}
+
+.c20 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  margin-right: 4px;
+  color: #FFFFFF;
+}
+
+.c5 {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.c6 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+}
+
+.c19 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c26 {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.c27 {
+  box-sizing: border-box;
+  margin-right: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+.c21 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 12px;
+  width: 100%;
+}
+
+.c21 > thead > tr > th,
+.c21 > tbody > tr > th,
+.c21 > tfoot > tr > th,
+.c21 > thead > tr > td,
+.c21 > tbody > tr > td,
+.c21 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c21 > thead > tr > th:first-child,
+.c21 > tbody > tr > th:first-child,
+.c21 > tfoot > tr > th:first-child,
+.c21 > thead > tr > td:first-child,
+.c21 > tbody > tr > td:first-child,
+.c21 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c21 > thead > tr > th:last-child,
+.c21 > tbody > tr > th:last-child,
+.c21 > tfoot > tr > th:last-child,
+.c21 > thead > tr > td:last-child,
+.c21 > tbody > tr > td:last-child,
+.c21 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c21 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+.c21 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c21 > thead > tr > th .c17 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c21 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c21 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c21 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c4 {
+  padding: 16px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c25 {
+  padding: 16px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.c22 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
+.c28 {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.c28 .c17 {
+  font-size: 20px;
+  transition: all 0.3s;
+  opacity: 0.5;
+}
+
+.c28:hover .c17,
+.c28:focus .c17 {
+  opacity: 1;
+}
+
+.c28:disabled {
+  cursor: default;
+}
+
+.c28:disabled .c17 {
+  opacity: 0.1;
+}
+
+.c10 {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2C3A73;
+  border-radius: 200px;
+}
+
+.c8 {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 200px;
+  height: 32px;
+  background: #111B48;
+}
+
+.c9 {
+  border: none;
+  outline: none;
+  box-sizing: border-box;
+  height: 100%;
+  font-size: 12px;
+  width: 100%;
+  transition: all 0.2s;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+  background: #111B48;
+  padding-right: 184px;
+}
+
+.c9:hover,
+.c9:focus,
+.c9:active {
+  background: #1C254D;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c9::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+.c12 {
+  position: relative;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.c15 {
+  width: 32px;
+  height: 12px;
+  border-radius: 12px;
+  background: #222C59;
+  cursor: pointer;
+}
+
+.c15:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  transform: translate(0,-50%);
+  width: 16px;
+  height: 16px;
+  border-radius: 16px;
+  background: #651FFF;
+}
+
+.c13 {
+  opacity: 0;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c13:checked + .c14 {
+  background: #512FC9;
+}
+
+.c13:checked + .c14:before {
+  transform: translate(16px,-50%);
+}
+
+.c11 {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding-right: 16px;
+  padding-left: 16px;
+  width: 120px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      Desktops
+    </div>
+    <a
+      class="c3"
+      href="https://goteleport.com/docs/desktop-access/getting-started/"
+      kind="primary"
+      rel="noreferrer"
+      target="_blank"
+      width="240px"
+    >
+      View documentation
+    </a>
+  </div>
+  <form
+    class="c4"
+  >
+    <div
+      class="c5"
+      width="100%"
+    >
+      <div
+        class="c6"
+        style="width: 70%;"
+      >
+        <div
+          class="c7"
+          width="100%"
+        >
+          <div
+            class="c8"
+          >
+            <input
+              class="c9"
+              placeholder="SEARCH..."
+              value=""
+            />
+            <div
+              class="c10"
+            >
+              <div
+                class="c11"
+              >
+                <label
+                  class="c12"
+                >
+                  <input
+                    class="c13"
+                    type="checkbox"
+                  />
+                  <div
+                    class="c14 c15"
+                  />
+                </label>
+                <div
+                  class="c16"
+                >
+                  Advanced
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style="line-height: 0px;"
+        >
+          <span
+            class="c17 c18 icon icon-info_outline "
+            color="light"
+            style="cursor: pointer; font-size: 20px;"
+          />
+        </div>
+      </div>
+      <div
+        class="c19"
+      >
+        <div
+          class="c20"
+          color="primary.contrastText"
+        >
+          SHOWING 
+          <strong>
+            1
+          </strong>
+           - 
+          <strong>
+            3
+          </strong>
+           of
+           
+          <strong>
+            3
+          </strong>
+        </div>
+      </div>
+    </div>
+  </form>
+  <table
+    class="c21"
+  >
+    <thead>
+      <tr>
+        <th
+          style="cursor: default;"
+        >
+          Address
+        </th>
+        <th>
+          <a>
+            Name
+            <span
+              class="c17 c18 icon icon-chevron-up "
+              color="light"
+            />
+          </a>
+        </th>
+        <th
+          style="cursor: default;"
+        >
+          Labels
+        </th>
+        <th
+          style="cursor: default;"
+        />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          host.com
+        </td>
+        <td>
+          bb8411a4-ba50-537c-89b3-226a00447bc6
+        </td>
+        <td>
+          <div
+            class="c22"
+            kind="secondary"
+          >
+            foo: bar
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c23"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c24 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          another.com
+        </td>
+        <td>
+          d96e7dd6-26b6-56d5-8259-778f943f90f2
+        </td>
+        <td />
+        <td
+          align="right"
+        >
+          <button
+            class="c23"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c24 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          yetanother.com
+        </td>
+        <td>
+          18cd6652-2f9a-5475-8138-2a56d44e1645
+        </td>
+        <td>
+          <div
+            class="c22"
+            kind="secondary"
+          >
+            bar: foo
+          </div>
+          <div
+            class="c22"
+            kind="secondary"
+          >
+            foo: bar
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c23"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c24 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <nav
+    class="c25"
+  >
+    <div
+      class="c26"
+      width="100%"
+    >
+      <div
+        class="c27"
+      />
+      <div
+        class="c19"
+      >
+        <button
+          class="c28"
+          disabled=""
+          title="Previous page"
+        >
+          <span
+            class="c17 c29 icon icon-arrow-left-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+        <button
+          class="c28"
+          disabled=""
+          title="Next page"
+        >
+          <span
+            class="c17 c29 icon icon-arrow-right-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+      </div>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`pagination unsupported 1`] = `
+.c3 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c18 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #2C3A73;
+  border: 1px solid #1C254D;
+  opacity: .87;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  height: 24px;
+}
+
+.c18:active {
+  opacity: 0.56;
+}
+
+.c18:hover,
+.c18:focus {
+  background: #2C3A73;
+  border: 1px solid rgba(255,255,255,0.1);
+  opacity: 1;
+}
+
+.c18:active {
+  opacity: 0.24;
+}
+
+.c18:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c14 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c16 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c19 {
+  display: inline-block;
+  transition: color .3s;
+  margin-left: 8px;
+  margin-right: -8px;
+  color: rgba(255,255,255,0.56);
+  font-size: 14px;
+}
+
+.c10 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  margin-right: 4px;
+  color: #FFFFFF;
+}
+
+.c8 {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-right: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.c11 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+.c15 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 12px;
+  width: 100%;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.c15 > thead > tr > th,
+.c15 > tbody > tr > th,
+.c15 > tfoot > tr > th,
+.c15 > thead > tr > td,
+.c15 > tbody > tr > td,
+.c15 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c15 > thead > tr > th:first-child,
+.c15 > tbody > tr > th:first-child,
+.c15 > tfoot > tr > th:first-child,
+.c15 > thead > tr > td:first-child,
+.c15 > tbody > tr > td:first-child,
+.c15 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c15 > thead > tr > th:last-child,
+.c15 > tbody > tr > th:last-child,
+.c15 > tfoot > tr > th:last-child,
+.c15 > thead > tr > td:last-child,
+.c15 > tbody > tr > td:last-child,
+.c15 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c15 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+.c15 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c15 > thead > tr > th .c13 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c15 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c15 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c15 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c4 {
+  padding: 16px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c17 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
+.c12 {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.c12 .c13 {
+  font-size: 20px;
+  transition: all 0.3s;
+  opacity: 0.5;
+}
+
+.c12:hover .c13,
+.c12:focus .c13 {
+  opacity: 1;
+}
+
+.c12:disabled {
+  cursor: default;
+}
+
+.c12:disabled .c13 {
+  opacity: 0.1;
+}
+
+.c7 {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2C3A73;
+  border-radius: 200px;
+}
+
+.c5 {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 200px;
+  height: 32px;
+  background: #111B48;
+}
+
+.c6 {
+  border: none;
+  outline: none;
+  box-sizing: border-box;
+  height: 100%;
+  font-size: 12px;
+  width: 100%;
+  transition: all 0.2s;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+  background: #111B48;
+  padding-right: 184px;
+}
+
+.c6:hover,
+.c6:focus,
+.c6:active {
+  background: #1C254D;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c6::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      Desktops
+    </div>
+    <a
+      class="c3"
+      href="https://goteleport.com/docs/desktop-access/getting-started/"
+      kind="primary"
+      rel="noreferrer"
+      target="_blank"
+      width="240px"
+    >
+      View documentation
+    </a>
+  </div>
+  <nav
+    class="c4"
+  >
+    <div
+      class="c5"
+    >
+      <input
+        class="c6"
+        placeholder="SEARCH..."
+        value=""
+      />
+      <div
+        class="c7"
+      />
+    </div>
+    <div
+      class="c8"
+      width="100%"
+    >
+      <div
+        class="c9"
+      >
+        <div
+          class="c10"
+          color="primary.contrastText"
+        >
+          SHOWING 
+          <strong>
+            1
+          </strong>
+           - 
+          <strong>
+            3
+          </strong>
+           of
+           
+          <strong>
+            3
+          </strong>
+        </div>
+      </div>
+      <div
+        class="c11"
+      >
+        <button
+          class="c12"
+          disabled=""
+          title="Previous page"
+        >
+          <span
+            class="c13 c14 icon icon-arrow-left-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+        <button
+          class="c12"
+          disabled=""
+          title="Next page"
+        >
+          <span
+            class="c13 c14 icon icon-arrow-right-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+      </div>
+    </div>
+  </nav>
+  <table
+    class="c15"
+  >
+    <thead>
+      <tr>
+        <th
+          style="cursor: default;"
+        >
+          Address
+        </th>
+        <th>
+          <a>
+            Name
+            <span
+              class="c13 c16 icon icon-chevron-up "
+              color="light"
+            />
+          </a>
+        </th>
+        <th
+          style="cursor: default;"
+        >
+          Labels
+        </th>
+        <th
+          style="cursor: default;"
+        />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          yetanother.com
+        </td>
+        <td>
+          18cd6652-2f9a-5475-8138-2a56d44e1645
+        </td>
+        <td>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            bar: foo
+          </div>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            foo: bar
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c13 c19 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          host.com
+        </td>
+        <td>
+          bb8411a4-ba50-537c-89b3-226a00447bc6
+        </td>
+        <td>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            foo: bar
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c13 c19 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          another.com
+        </td>
+        <td>
+          d96e7dd6-26b6-56d5-8259-778f943f90f2
+        </td>
+        <td />
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c13 c19 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/packages/teleport/src/Desktops/__snapshots__/Desktops.story.test.tsx.snap
+++ b/packages/teleport/src/Desktops/__snapshots__/Desktops.story.test.tsx.snap
@@ -846,6 +846,23 @@ exports[`pagination unsupported 1`] = `
   font-size: 14px;
 }
 
+.c17 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
 .c10 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1005,24 +1022,6 @@ exports[`pagination unsupported 1`] = `
   background: #222C59;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-}
-
-.c17 {
-  box-sizing: border-box;
-  border-radius: 100px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 16px;
-  line-height: 1.4;
-  font-size: 10px;
-  font-weight: 500;
-  padding: 0 8px;
-  background-color: #111B48;
-  color: rgba(255,255,255,0.87);
-  margin-bottom: 4px;
-  margin-right: 4px;
-  cursor: pointer;
 }
 
 .c12 {

--- a/packages/teleport/src/Kubes/KubeList/KubeList.test.tsx
+++ b/packages/teleport/src/Kubes/KubeList/KubeList.test.tsx
@@ -32,6 +32,7 @@ test('search generates correct url params', () => {
       totalCount={10}
       pathname="test.com/cluster/one/kubes"
       replaceHistory={replaceHistory}
+      paginationUnsupported={false}
     />
   );
 

--- a/packages/teleport/src/Kubes/KubeList/KubeList.tsx
+++ b/packages/teleport/src/Kubes/KubeList/KubeList.tsx
@@ -16,7 +16,11 @@ limitations under the License.
 
 import React, { useState } from 'react';
 import { ButtonBorder } from 'design';
-import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
+import Table, {
+  Cell,
+  ClickableLabelCell,
+  UnclickableLabelCell,
+} from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import { Kube } from 'teleport/services/kube';
 import { AuthType } from 'teleport/services/user';
@@ -46,9 +50,50 @@ function KubeList(props: Props) {
     replaceHistory,
     onLabelClick,
     accessRequestId,
+    paginationUnsupported,
   } = props;
 
   const [kubeConnectName, setKubeConnectName] = useState('');
+
+  if (paginationUnsupported) {
+    // Return a client paging/searching table.
+    return (
+      <>
+        <Table
+          data={kubes}
+          emptyText="No Kubernetes Clusters Found"
+          isSearchable
+          pagination={{ pageSize }}
+          columns={[
+            {
+              key: 'name',
+              headerText: 'Name',
+              isSortable: true,
+            },
+            {
+              key: 'labels',
+              headerText: 'Labels',
+              render: ({ labels }) => <UnclickableLabelCell labels={labels} />,
+            },
+            {
+              altKey: 'connect-btn',
+              render: kube => renderConnectButtonCell(kube, setKubeConnectName),
+            },
+          ]}
+        />
+        {kubeConnectName && (
+          <ConnectDialog
+            onClose={() => setKubeConnectName('')}
+            username={username}
+            authType={authType}
+            kubeConnectName={kubeConnectName}
+            clusterId={clusterId}
+            accessRequestId={accessRequestId}
+          />
+        )}
+      </>
+    );
+  }
 
   return (
     <>
@@ -144,6 +189,7 @@ type Props = {
   replaceHistory: (path: string) => void;
   onLabelClick: (label: AgentLabel) => void;
   accessRequestId?: string;
+  paginationUnsupported: boolean;
 };
 
 export default KubeList;

--- a/packages/teleport/src/Kubes/Kubes.story.test.tsx
+++ b/packages/teleport/src/Kubes/Kubes.story.test.tsx
@@ -16,10 +16,21 @@ limitations under the License.
 
 import React from 'react';
 import { render } from 'design/utils/testing';
-import { Loaded, Failed, Empty, EmptyReadOnly } from './Kubes.story';
+import {
+  Loaded,
+  Failed,
+  Empty,
+  EmptyReadOnly,
+  PaginationUnsupported,
+} from './Kubes.story';
 
 test('loaded', () => {
   const { container } = render(<Loaded />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('pagination unsupported', () => {
+  const { container } = render(<PaginationUnsupported />);
   expect(container.firstChild).toMatchSnapshot();
 });
 

--- a/packages/teleport/src/Kubes/Kubes.story.tsx
+++ b/packages/teleport/src/Kubes/Kubes.story.tsx
@@ -27,6 +27,13 @@ export default {
 
 export const Loaded = () => <Kubes {...props} />;
 
+export const PaginationUnsupported = () => (
+  <Kubes
+    {...props}
+    results={{ ...props.results, paginationUnsupported: true }}
+  />
+);
+
 export const Empty = () => (
   <Kubes {...props} results={{ kubes: [] }} isSearchEmpty={true} />
 );

--- a/packages/teleport/src/Kubes/Kubes.tsx
+++ b/packages/teleport/src/Kubes/Kubes.tsx
@@ -112,6 +112,7 @@ export function Kubes(props: State) {
             replaceHistory={replaceHistory}
             onLabelClick={onLabelClick}
             accessRequestId={accessRequestId}
+            paginationUnsupported={results.paginationUnsupported}
           />
         </>
       )}

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -1828,6 +1828,23 @@ exports[`pagination unsupported 1`] = `
   color: #FFFFFF;
 }
 
+.c17 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
 .c10 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1946,24 +1963,6 @@ exports[`pagination unsupported 1`] = `
   background: #222C59;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-}
-
-.c17 {
-  box-sizing: border-box;
-  border-radius: 100px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 16px;
-  line-height: 1.4;
-  font-size: 10px;
-  font-weight: 500;
-  padding: 0 8px;
-  background-color: #111B48;
-  color: rgba(255,255,255,0.87);
-  margin-bottom: 4px;
-  margin-right: 4px;
-  cursor: pointer;
 }
 
 .c12 {

--- a/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -1721,6 +1721,568 @@ exports[`loaded 1`] = `
 </div>
 `;
 
+exports[`pagination unsupported 1`] = `
+.c3 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c3:active {
+  opacity: 0.56;
+}
+
+.c3:hover,
+.c3:focus {
+  background: #651FFF;
+}
+
+.c3:active {
+  background: #354AA4;
+}
+
+.c3:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c18 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #2C3A73;
+  border: 1px solid #1C254D;
+  opacity: .87;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+}
+
+.c18:active {
+  opacity: 0.56;
+}
+
+.c18:hover,
+.c18:focus {
+  background: #2C3A73;
+  border: 1px solid rgba(255,255,255,0.1);
+  opacity: 1;
+}
+
+.c18:active {
+  opacity: 0.24;
+}
+
+.c18:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c14 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c16 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c10 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  margin-right: 4px;
+  color: #FFFFFF;
+}
+
+.c8 {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-right: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.c11 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c15 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 12px;
+  width: 100%;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.c15 > thead > tr > th,
+.c15 > tbody > tr > th,
+.c15 > tfoot > tr > th,
+.c15 > thead > tr > td,
+.c15 > tbody > tr > td,
+.c15 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c15 > thead > tr > th:first-child,
+.c15 > tbody > tr > th:first-child,
+.c15 > tfoot > tr > th:first-child,
+.c15 > thead > tr > td:first-child,
+.c15 > tbody > tr > td:first-child,
+.c15 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c15 > thead > tr > th:last-child,
+.c15 > tbody > tr > th:last-child,
+.c15 > tfoot > tr > th:last-child,
+.c15 > thead > tr > td:last-child,
+.c15 > tbody > tr > td:last-child,
+.c15 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c15 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+.c15 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c15 > thead > tr > th .c13 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c15 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c15 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c15 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c4 {
+  padding: 16px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c17 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
+.c12 {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.c12 .c13 {
+  font-size: 20px;
+  transition: all 0.3s;
+  opacity: 0.5;
+}
+
+.c12:hover .c13,
+.c12:focus .c13 {
+  opacity: 1;
+}
+
+.c12:disabled {
+  cursor: default;
+}
+
+.c12:disabled .c13 {
+  opacity: 0.1;
+}
+
+.c7 {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2C3A73;
+  border-radius: 200px;
+}
+
+.c5 {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 200px;
+  height: 32px;
+  background: #111B48;
+}
+
+.c6 {
+  border: none;
+  outline: none;
+  box-sizing: border-box;
+  height: 100%;
+  font-size: 12px;
+  width: 100%;
+  transition: all 0.2s;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+  background: #111B48;
+  padding-right: 184px;
+}
+
+.c6:hover,
+.c6:focus,
+.c6:active {
+  background: #1C254D;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c6::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      Kubernetes
+    </div>
+    <button
+      class="c3"
+      kind="primary"
+      title=""
+      width="240px"
+    >
+      Add 
+      kubernetes
+    </button>
+  </div>
+  <nav
+    class="c4"
+  >
+    <div
+      class="c5"
+    >
+      <input
+        class="c6"
+        placeholder="SEARCH..."
+        value=""
+      />
+      <div
+        class="c7"
+      />
+    </div>
+    <div
+      class="c8"
+      width="100%"
+    >
+      <div
+        class="c9"
+      >
+        <div
+          class="c10"
+          color="primary.contrastText"
+        >
+          SHOWING 
+          <strong>
+            1
+          </strong>
+           - 
+          <strong>
+            3
+          </strong>
+           of
+           
+          <strong>
+            3
+          </strong>
+        </div>
+      </div>
+      <div
+        class="c11"
+      >
+        <button
+          class="c12"
+          disabled=""
+          title="Previous page"
+        >
+          <span
+            class="c13 c14 icon icon-arrow-left-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+        <button
+          class="c12"
+          disabled=""
+          title="Next page"
+        >
+          <span
+            class="c13 c14 icon icon-arrow-right-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+      </div>
+    </div>
+  </nav>
+  <table
+    class="c15"
+  >
+    <thead>
+      <tr>
+        <th>
+          <a>
+            Name
+            <span
+              class="c13 c16 icon icon-chevron-up "
+              color="light"
+            />
+          </a>
+        </th>
+        <th
+          style="cursor: default;"
+        >
+          Labels
+        </th>
+        <th
+          style="cursor: default;"
+        />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          cookie
+        </td>
+        <td>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            cluster-name: some-cluster-name
+          </div>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            env: idk
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            kind="border"
+          >
+            Connect
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          tele.logicoma.dev-prod
+        </td>
+        <td>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            kernel: 4.15.0-51-generic
+          </div>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            env: prod
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            kind="border"
+          >
+            Connect
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          tele.logicoma.dev-staging
+        </td>
+        <td>
+          <div
+            class="c17"
+            kind="secondary"
+          >
+            env: staging
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c18"
+            kind="border"
+          >
+            Connect
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  
+</div>
+`;
+
 exports[`readonly empty state 1`] = `
 .c3 {
   box-sizing: border-box;

--- a/packages/teleport/src/Nodes/Nodes.story.test.tsx
+++ b/packages/teleport/src/Nodes/Nodes.story.test.tsx
@@ -1,9 +1,20 @@
 import React from 'react';
 import { render } from 'design/utils/testing';
-import { Loaded, Failed, Empty, EmptyReadOnly } from './Nodes.story';
+import {
+  Loaded,
+  Failed,
+  Empty,
+  EmptyReadOnly,
+  PaginationUnsupported,
+} from './Nodes.story';
 
 test('loaded', () => {
   const { container } = render(<Loaded />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('pagination unsupported', () => {
+  const { container } = render(<PaginationUnsupported />);
   expect(container.firstChild).toMatchSnapshot();
 });
 

--- a/packages/teleport/src/Nodes/Nodes.story.tsx
+++ b/packages/teleport/src/Nodes/Nodes.story.tsx
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { Nodes } from './Nodes';
 import { State } from './useNodes';
 import { nodes } from './fixtures';
@@ -24,34 +25,55 @@ export default {
   excludeStories: ['props'],
 };
 
-export const Loaded = () => <Nodes {...props} />;
+export const Loaded = () => (
+  <MemoryRouter>
+    <Nodes {...props} />
+  </MemoryRouter>
+);
+
+export const PaginationUnsupported = () => (
+  <MemoryRouter>
+    <Nodes
+      {...props}
+      results={{ ...props.results, paginationUnsupported: true }}
+    />
+  </MemoryRouter>
+);
 
 export const Empty = () => (
-  <Nodes
-    {...props}
-    results={{ nodes: [], totalCount: 0 }}
-    isSearchEmpty={true}
-  />
+  <MemoryRouter>
+    <Nodes
+      {...props}
+      results={{ nodes: [], totalCount: 0 }}
+      isSearchEmpty={true}
+    />
+  </MemoryRouter>
 );
 
 export const EmptyReadOnly = () => (
-  <Nodes
-    {...props}
-    results={{ nodes: [], totalCount: 0 }}
-    isSearchEmpty={true}
-    canCreate={false}
-  />
+  <MemoryRouter>
+    <Nodes
+      {...props}
+      results={{ nodes: [], totalCount: 0 }}
+      isSearchEmpty={true}
+      canCreate={false}
+    />
+  </MemoryRouter>
 );
 
 export const Loading = () => (
-  <Nodes {...props} attempt={{ status: 'processing' }} />
+  <MemoryRouter>
+    <Nodes {...props} attempt={{ status: 'processing' }} />
+  </MemoryRouter>
 );
 
 export const Failed = () => (
-  <Nodes
-    {...props}
-    attempt={{ status: 'failed', statusText: 'some error message' }}
-  />
+  <MemoryRouter>
+    <Nodes
+      {...props}
+      attempt={{ status: 'failed', statusText: 'some error message' }}
+    />
+  </MemoryRouter>
 );
 
 const props: State = {

--- a/packages/teleport/src/Nodes/Nodes.tsx
+++ b/packages/teleport/src/Nodes/Nodes.tsx
@@ -123,6 +123,7 @@ export function Nodes(props: State) {
             pathname={pathname}
             replaceHistory={replaceHistory}
             onLabelClick={onLabelClick}
+            paginationUnsupported={results.paginationUnsupported}
           />
         </>
       )}

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -2410,6 +2410,23 @@ exports[`pagination unsupported 1`] = `
   font-size: 14px;
 }
 
+.c21 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+
 .c14 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2633,24 +2650,6 @@ exports[`pagination unsupported 1`] = `
   background: #222C59;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-}
-
-.c21 {
-  box-sizing: border-box;
-  border-radius: 100px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 16px;
-  line-height: 1.4;
-  font-size: 10px;
-  font-weight: 500;
-  padding: 0 8px;
-  background-color: #111B48;
-  color: rgba(255,255,255,0.87);
-  margin-bottom: 4px;
-  margin-right: 4px;
-  cursor: pointer;
 }
 
 .c16 {

--- a/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -2293,6 +2293,860 @@ exports[`loaded 1`] = `
 </div>
 `;
 
+exports[`pagination unsupported 1`] = `
+.c7 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #512FC9;
+  color: rgba(255,255,255,0.87);
+  min-height: 32px;
+  font-size: 12px;
+  padding: 0px 24px;
+  width: 240px;
+}
+
+.c7:active {
+  opacity: 0.56;
+}
+
+.c7:hover,
+.c7:focus {
+  background: #651FFF;
+}
+
+.c7:active {
+  background: #354AA4;
+}
+
+.c7:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c22 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  background: #2C3A73;
+  border: 1px solid #1C254D;
+  opacity: .87;
+  color: rgba(255,255,255,0.87);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  height: 24px;
+}
+
+.c22:active {
+  opacity: 0.56;
+}
+
+.c22:hover,
+.c22:focus {
+  background: #2C3A73;
+  border: 1px solid rgba(255,255,255,0.1);
+  opacity: 1;
+}
+
+.c22:active {
+  opacity: 0.24;
+}
+
+.c22:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+}
+
+.c18 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.c20 {
+  display: inline-block;
+  transition: color .3s;
+  color: #FFFFFF;
+}
+
+.c23 {
+  display: inline-block;
+  transition: color .3s;
+  margin-left: 8px;
+  margin-right: -8px;
+  color: rgba(255,255,255,0.56);
+  font-size: 14px;
+}
+
+.c14 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px;
+  margin-right: 4px;
+  color: #FFFFFF;
+}
+
+.c3 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+}
+
+.c12 {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.c13 {
+  box-sizing: border-box;
+  margin-right: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.c15 {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  border-bottom: 1px solid #1C254D;
+  height: 56px;
+  margin-left: -40px;
+  margin-right: -40px;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 32px;
+  margin: 0px;
+  white-space: nowrap;
+}
+
+.c0 {
+  box-sizing: border-box;
+  padding-left: 40px;
+  padding-right: 40px;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+}
+
+.c0::after {
+  content: ' ';
+  padding-bottom: 24px;
+}
+
+.c4 {
+  box-sizing: border-box;
+  margin-right: 16px;
+  width: 280px;
+  display: flex;
+  align-items: center;
+  height: 32px;
+  border: 1px solid;
+  border-radius: 4px;
+  border-color: rgba(255,255,255,0.24);
+}
+
+.c5 {
+  opacity: 0.75;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 0 8px;
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+}
+
+.c6 {
+  appearance: none;
+  border: none;
+  border-radius: 4px;
+  box-sizing: border-box;
+  border-bottom-left-radius: unset;
+  border-top-left-radius: unset;
+  display: block;
+  outline: none;
+  width: 100%;
+  height: 100%;
+  box-shadow: none;
+  padding-left: 8px;
+  font-size: 12px;
+  color: rgba(255,255,255,0.87);
+  background-color: #222C59;
+}
+
+.c6::-ms-clear {
+  display: none;
+}
+
+.c6:read-only {
+  cursor: not-allowed;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+.c6:hover,
+.c6:focus {
+  background: #2C3A73;
+}
+
+.c19 {
+  background: #222C59;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 12px;
+  width: 100%;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.c19 > thead > tr > th,
+.c19 > tbody > tr > th,
+.c19 > tfoot > tr > th,
+.c19 > thead > tr > td,
+.c19 > tbody > tr > td,
+.c19 > tfoot > tr > td {
+  padding: 8px 8px;
+  vertical-align: middle;
+}
+
+.c19 > thead > tr > th:first-child,
+.c19 > tbody > tr > th:first-child,
+.c19 > tfoot > tr > th:first-child,
+.c19 > thead > tr > td:first-child,
+.c19 > tbody > tr > td:first-child,
+.c19 > tfoot > tr > td:first-child {
+  padding-left: 24px;
+}
+
+.c19 > thead > tr > th:last-child,
+.c19 > tbody > tr > th:last-child,
+.c19 > tfoot > tr > th:last-child,
+.c19 > thead > tr > td:last-child,
+.c19 > tbody > tr > td:last-child,
+.c19 > tfoot > tr > td:last-child {
+  padding-right: 24px;
+}
+
+.c19 > tbody > tr > td {
+  vertical-align: baseline;
+}
+
+.c19 > thead > tr > th {
+  background: #111B48;
+  color: #FFFFFF;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  padding-bottom: 0;
+  padding-top: 0;
+  text-align: left;
+  opacity: 0.75;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c19 > thead > tr > th .c17 {
+  font-weight: bold;
+  font-size: 8px;
+  margin-left: 8px;
+}
+
+.c19 > tbody > tr > td {
+  color: rgba(255,255,255,0.87);
+  line-height: 16px;
+}
+
+.c19 tbody tr {
+  border-bottom: 1px solid #1C254D;
+}
+
+.c19 tbody tr:hover {
+  background-color: rgb(37,49,98);
+}
+
+.c8 {
+  padding: 16px 24px;
+  display: flex;
+  height: 24px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  background: #222C59;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.c21 {
+  box-sizing: border-box;
+  border-radius: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16px;
+  line-height: 1.4;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 0 8px;
+  background-color: #111B48;
+  color: rgba(255,255,255,0.87);
+  margin-bottom: 4px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
+.c16 {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.c16 .c17 {
+  font-size: 20px;
+  transition: all 0.3s;
+  opacity: 0.5;
+}
+
+.c16:hover .c17,
+.c16:focus .c17 {
+  opacity: 1;
+}
+
+.c16:disabled {
+  cursor: default;
+}
+
+.c16:disabled .c17 {
+  opacity: 0.1;
+}
+
+.c11 {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2C3A73;
+  border-radius: 200px;
+}
+
+.c9 {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 200px;
+  height: 32px;
+  background: #111B48;
+}
+
+.c10 {
+  border: none;
+  outline: none;
+  box-sizing: border-box;
+  height: 100%;
+  font-size: 12px;
+  width: 100%;
+  transition: all 0.2s;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: rgba(255,255,255,0.87);
+  background: #111B48;
+  padding-right: 184px;
+}
+
+.c10:hover,
+.c10:focus,
+.c10:active {
+  background: #1C254D;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.24);
+  color: rgba(255,255,255,0.87);
+}
+
+.c10::placeholder {
+  color: rgba(255,255,255,0.24);
+  font-size: 12px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      Servers
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
+        width="280px"
+      >
+        <div
+          class="c5"
+        >
+          SSH:
+        </div>
+        <input
+          class="c6"
+          color="text.primary"
+          placeholder="login@host:port"
+        />
+      </div>
+      <button
+        class="c7"
+        kind="primary"
+        title=""
+        width="240px"
+      >
+        Add 
+        server
+      </button>
+    </div>
+  </div>
+  <nav
+    class="c8"
+  >
+    <div
+      class="c9"
+    >
+      <input
+        class="c10"
+        placeholder="SEARCH..."
+        value=""
+      />
+      <div
+        class="c11"
+      />
+    </div>
+    <div
+      class="c12"
+      width="100%"
+    >
+      <div
+        class="c13"
+      >
+        <div
+          class="c14"
+          color="primary.contrastText"
+        >
+          SHOWING 
+          <strong>
+            1
+          </strong>
+           - 
+          <strong>
+            7
+          </strong>
+           of
+           
+          <strong>
+            7
+          </strong>
+        </div>
+      </div>
+      <div
+        class="c15"
+      >
+        <button
+          class="c16"
+          disabled=""
+          title="Previous page"
+        >
+          <span
+            class="c17 c18 icon icon-arrow-left-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+        <button
+          class="c16"
+          disabled=""
+          title="Next page"
+        >
+          <span
+            class="c17 c18 icon icon-arrow-right-circle "
+            color="light"
+            font-size="3"
+          />
+        </button>
+      </div>
+    </div>
+  </nav>
+  <table
+    class="c19"
+  >
+    <thead>
+      <tr>
+        <th>
+          <a>
+            Hostname
+            <span
+              class="c17 c20 icon icon-chevron-up "
+              color="light"
+            />
+          </a>
+        </th>
+        <th
+          style="cursor: default;"
+        >
+          Address
+        </th>
+        <th
+          style="cursor: default;"
+        >
+          Labels
+        </th>
+        <th
+          style="cursor: default;"
+        />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          duzsevkig
+        </td>
+        <td>
+          172.10.1.1:3022
+        </td>
+        <td>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            cluster: one
+          </div>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            kernel: 4.15.0-51-generic
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c22"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c23 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          facuzguv
+        </td>
+        <td>
+          172.10.1.1:3022
+        </td>
+        <td>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            cluster: one
+          </div>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            kernel: 4.15.0-51-generic
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c22"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c23 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          fujedu
+        </td>
+        <td>
+          172.10.1.20:3022
+        </td>
+        <td>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            cluster: one
+          </div>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            kernel: 4.15.0-51-generic
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c22"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c23 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          kuhinur
+        </td>
+        <td>
+          172.10.1.1:3022
+        </td>
+        <td>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            cluster: one
+          </div>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            kernel: 4.15.0-51-generic
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c22"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c23 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          zebpecda
+        </td>
+        <td>
+          172.10.1.1:3022
+        </td>
+        <td>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            cluster: one
+          </div>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            kernel: 4.15.0-51-generic
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c22"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c23 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          zebpecda
+        </td>
+        <td>
+          <span
+            style="cursor: default;"
+            title="This node is connected to cluster through reverse tunnel"
+          >
+            ⟵ tunnel
+          </span>
+        </td>
+        <td>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            cluster: one
+          </div>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            kernel: 4.15.0-51-generic
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c22"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c23 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          zebpecda
+        </td>
+        <td>
+          <span
+            style="cursor: default;"
+            title="This node is connected to cluster through reverse tunnel"
+          >
+            ⟵ tunnel
+          </span>
+        </td>
+        <td>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            cluster: one
+          </div>
+          <div
+            class="c21"
+            kind="secondary"
+          >
+            kernel: 4.15.0-51-generic
+          </div>
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c22"
+            height="24px"
+            kind="border"
+          >
+            CONNECT
+            <span
+              class="c17 c23 icon icon-caret-down "
+              color="text.secondary"
+              font-size="2"
+            />
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`readonly empty state 1`] = `
 .c3 {
   box-sizing: border-box;

--- a/packages/teleport/src/components/NodeList/NodeList.tsx
+++ b/packages/teleport/src/components/NodeList/NodeList.tsx
@@ -15,7 +15,11 @@ limitations under the License.
 */
 
 import React from 'react';
-import Table, { Cell, ClickableLabelCell } from 'design/DataTable';
+import Table, {
+  Cell,
+  ClickableLabelCell,
+  UnclickableLabelCell,
+} from 'design/DataTable';
 import { SortType } from 'design/DataTable/types';
 import { LoginItem, MenuLogin } from 'shared/components/MenuLogin';
 import { Node } from 'teleport/services/nodes';
@@ -26,6 +30,7 @@ import { ResourceUrlQueryParams } from 'teleport/getUrlQueryParams';
 function NodeList(props: Props) {
   const {
     nodes = [],
+    paginationUnsupported,
     onLoginMenuOpen,
     onLoginSelect,
     pageSize,
@@ -43,6 +48,40 @@ function NodeList(props: Props) {
     replaceHistory,
     onLabelClick,
   } = props;
+
+  if (paginationUnsupported) {
+    // Return a client paging/searching table.
+    return (
+      <Table
+        data={nodes}
+        emptyText="No Nodes Found"
+        isSearchable
+        pagination={{ pageSize }}
+        columns={[
+          {
+            key: 'hostname',
+            headerText: 'Hostname',
+            isSortable: true,
+          },
+          {
+            key: 'addr',
+            headerText: 'Address',
+            render: renderAddressCell,
+          },
+          {
+            key: 'labels',
+            headerText: 'Labels',
+            render: ({ labels }) => <UnclickableLabelCell labels={labels} />,
+          },
+          {
+            altKey: 'connect-btn',
+            render: ({ id }) =>
+              renderLoginCell(id, onLoginSelect, onLoginMenuOpen),
+          },
+        ]}
+      />
+    );
+  }
 
   return (
     <>
@@ -168,6 +207,7 @@ type Props = {
   pathname: string;
   replaceHistory: (path: string) => void;
   onLabelClick: (label: AgentLabel) => void;
+  paginationUnsupported: boolean;
 };
 
 export default NodeList;

--- a/packages/teleport/src/services/apps/apps.test.ts
+++ b/packages/teleport/src/services/apps/apps.test.ts
@@ -42,10 +42,11 @@ test('correct formatting of apps fetch response', async () => {
     ],
     startKey: mockResponse.startKey,
     totalCount: mockResponse.totalCount,
+    paginationUnsupported: false,
   });
 });
 
-test('null response from apps fetch', async () => {
+test('null (empty) response from apps fetch', async () => {
   jest.spyOn(api, 'get').mockResolvedValue(null);
 
   const response = await apps.fetchApps('does-not-matter', {
@@ -56,6 +57,24 @@ test('null response from apps fetch', async () => {
     apps: [],
     startKey: undefined,
     totalCount: undefined,
+    paginationUnsupported: false,
+  });
+});
+
+test('null fields from apps fetch', async () => {
+  jest
+    .spyOn(api, 'get')
+    .mockResolvedValue({ startKey: null, totalCount: null });
+
+  const response = await apps.fetchApps('does-not-matter', {
+    search: 'does-not-matter',
+  });
+
+  expect(response).toEqual({
+    apps: [],
+    startKey: null,
+    totalCount: null,
+    paginationUnsupported: true,
   });
 });
 

--- a/packages/teleport/src/services/apps/apps.ts
+++ b/packages/teleport/src/services/apps/apps.ts
@@ -31,6 +31,8 @@ const service = {
         apps: items.map(makeApp),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
+        paginationUnsupported:
+          json?.startKey === null && json?.totalCount === null,
       };
     });
   },

--- a/packages/teleport/src/services/apps/types.ts
+++ b/packages/teleport/src/services/apps/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel, AgentQueryMeta } from 'teleport/services/resources';
 
 export interface App {
   id: string;
@@ -30,10 +30,8 @@ export interface App {
   awsConsole: boolean;
 }
 
-export type AppsResponse = {
+export type AppsResponse = AgentQueryMeta & {
   apps: App[];
-  startKey?: string;
-  totalCount?: number;
 };
 
 export type AwsRole = {

--- a/packages/teleport/src/services/databases/databases.test.ts
+++ b/packages/teleport/src/services/databases/databases.test.ts
@@ -40,10 +40,11 @@ test('correct formatting of database fetch response', async () => {
     ],
     startKey: mockResponse.startKey,
     totalCount: mockResponse.totalCount,
+    paginationUnsupported: false,
   });
 });
 
-test('null response from database fetch', async () => {
+test('null (empty) response from database fetch', async () => {
   jest.spyOn(api, 'get').mockResolvedValue(null);
 
   const database = new DatabaseService();
@@ -55,6 +56,25 @@ test('null response from database fetch', async () => {
     databases: [],
     startKey: undefined,
     totalCount: undefined,
+    paginationUnsupported: false,
+  });
+});
+
+test('null fields from database fetch', async () => {
+  jest
+    .spyOn(api, 'get')
+    .mockResolvedValue({ startKey: null, totalCount: null });
+
+  const database = new DatabaseService();
+  const response = await database.fetchDatabases('im-a-cluster', {
+    search: 'does-not-matter',
+  });
+
+  expect(response).toEqual({
+    databases: [],
+    startKey: null,
+    totalCount: null,
+    paginationUnsupported: true,
   });
 });
 

--- a/packages/teleport/src/services/databases/databases.ts
+++ b/packages/teleport/src/services/databases/databases.ts
@@ -31,6 +31,8 @@ class DatabaseService {
         databases: items.map(makeDatabase),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
+        paginationUnsupported:
+          json?.startKey === null && json?.totalCount === null,
       };
     });
   }

--- a/packages/teleport/src/services/databases/types.ts
+++ b/packages/teleport/src/services/databases/types.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel, AgentQueryMeta } from 'teleport/services/resources';
 
 export interface Database {
   name: string;
@@ -32,8 +32,6 @@ export type DbProtocol =
   | 'sqlserver'
   | 'redis';
 
-export type DatabasesResponse = {
+export type DatabasesResponse = AgentQueryMeta & {
   databases: Database[];
-  startKey?: string;
-  totalCount?: number;
 };

--- a/packages/teleport/src/services/desktops/desktops.test.ts
+++ b/packages/teleport/src/services/desktops/desktops.test.ts
@@ -34,10 +34,11 @@ test('correct formatting of desktops fetch response', async () => {
     ],
     startKey: mockResponse.startKey,
     totalCount: mockResponse.totalCount,
+    paginationUnsupported: false,
   });
 });
 
-test('null response from desktops fetch', async () => {
+test('null (empty) response from desktops fetch', async () => {
   jest.spyOn(api, 'get').mockResolvedValue(null);
 
   const response = await desktops.fetchDesktops('does-not-matter', {
@@ -48,6 +49,24 @@ test('null response from desktops fetch', async () => {
     desktops: [],
     startKey: undefined,
     totalCount: undefined,
+    paginationUnsupported: false,
+  });
+});
+
+test('null fields from desktops fetch', async () => {
+  jest
+    .spyOn(api, 'get')
+    .mockResolvedValue({ startKey: null, totalCount: null });
+
+  const response = await desktops.fetchDesktops('does-not-matter', {
+    search: 'does-not-matter',
+  });
+
+  expect(response).toEqual({
+    desktops: [],
+    startKey: null,
+    totalCount: null,
+    paginationUnsupported: true,
   });
 });
 

--- a/packages/teleport/src/services/desktops/desktops.ts
+++ b/packages/teleport/src/services/desktops/desktops.ts
@@ -31,6 +31,8 @@ class DesktopService {
         desktops: items.map(makeDesktop),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
+        paginationUnsupported:
+          json?.startKey === null && json?.totalCount === null,
       };
     });
   }

--- a/packages/teleport/src/services/desktops/types.ts
+++ b/packages/teleport/src/services/desktops/types.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel, AgentQueryMeta } from 'teleport/services/resources';
 
 // Desktop is a remote desktop.
 export type Desktop = {
@@ -28,8 +28,6 @@ export type Desktop = {
   labels: AgentLabel[];
 };
 
-export type DesktopsResponse = {
+export type DesktopsResponse = AgentQueryMeta & {
   desktops: Desktop[];
-  startKey?: string;
-  totalCount?: number;
 };

--- a/packages/teleport/src/services/kube/kube.test.ts
+++ b/packages/teleport/src/services/kube/kube.test.ts
@@ -37,10 +37,11 @@ test('correct processed fetch response formatting', async () => {
     ],
     startKey: mockApiResponse.startKey,
     totalCount: mockApiResponse.totalCount,
+    paginationUnsupported: false,
   });
 });
 
-test('handling of null fetch response', async () => {
+test('handling of null (empty) fetch response', async () => {
   jest.spyOn(api, 'get').mockResolvedValue(null);
 
   const kubeService = new KubeService();
@@ -52,6 +53,25 @@ test('handling of null fetch response', async () => {
     kubes: [],
     startKey: undefined,
     totalCount: undefined,
+    paginationUnsupported: false,
+  });
+});
+
+test('handling of null fields response', async () => {
+  jest
+    .spyOn(api, 'get')
+    .mockResolvedValue({ startKey: null, totalCount: null });
+
+  const kubeService = new KubeService();
+  const response = await kubeService.fetchKubernetes('clusterId', {
+    search: 'does-not-matter',
+  });
+
+  expect(response).toEqual({
+    kubes: [],
+    startKey: null,
+    totalCount: null,
+    paginationUnsupported: true,
   });
 });
 

--- a/packages/teleport/src/services/kube/kube.ts
+++ b/packages/teleport/src/services/kube/kube.ts
@@ -31,6 +31,8 @@ class KubeService {
         kubes: items.map(makeKube),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
+        paginationUnsupported:
+          json?.startKey === null && json?.totalCount === null,
       };
     });
   }

--- a/packages/teleport/src/services/kube/types.ts
+++ b/packages/teleport/src/services/kube/types.ts
@@ -14,14 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel, AgentQueryMeta } from 'teleport/services/resources';
 export interface Kube {
   name: string;
   labels: AgentLabel[];
 }
 
-export type KubesResponse = {
+export type KubesResponse = AgentQueryMeta & {
   kubes: Kube[];
-  startKey?: string;
-  totalCount?: number;
 };

--- a/packages/teleport/src/services/nodes/nodes.test.ts
+++ b/packages/teleport/src/services/nodes/nodes.test.ts
@@ -36,6 +36,7 @@ test('correct formatting of nodes fetch response', async () => {
     ],
     startKey: mockResponse.startKey,
     totalCount: mockResponse.totalCount,
+    paginationUnsupported: false,
   });
 });
 
@@ -49,6 +50,23 @@ test('null response from nodes fetch', async () => {
     nodes: [],
     startKey: undefined,
     totalCount: undefined,
+    paginationUnsupported: false,
+  });
+});
+
+test('null fields from nodes fetch', async () => {
+  const nodesService = new NodesService();
+  jest
+    .spyOn(api, 'get')
+    .mockResolvedValue({ startKey: null, totalCount: null });
+
+  const response = await nodesService.fetchNodes('does-not-matter');
+
+  expect(response).toEqual({
+    nodes: [],
+    startKey: null,
+    totalCount: null,
+    paginationUnsupported: true,
   });
 });
 

--- a/packages/teleport/src/services/nodes/nodes.ts
+++ b/packages/teleport/src/services/nodes/nodes.ts
@@ -31,6 +31,8 @@ class NodeService {
         nodes: items.map(makeNode),
         startKey: json?.startKey,
         totalCount: json?.totalCount,
+        paginationUnsupported:
+          json?.startKey === null && json?.totalCount === null,
       };
     });
   }

--- a/packages/teleport/src/services/nodes/types.ts
+++ b/packages/teleport/src/services/nodes/types.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { AgentLabel } from 'teleport/services/resources';
+import { AgentLabel, AgentQueryMeta } from 'teleport/services/resources';
 
 export interface Node {
   id: string;
@@ -30,8 +30,6 @@ export interface BashCommand {
   expires: string;
 }
 
-export type NodesResponse = {
+export type NodesResponse = AgentQueryMeta & {
   nodes: Node[];
-  startKey?: string;
-  totalCount?: number;
 };

--- a/packages/teleport/src/services/resources/types.ts
+++ b/packages/teleport/src/services/resources/types.ts
@@ -27,6 +27,12 @@ export type AgentLabel = {
   value: string;
 };
 
+export type AgentQueryMeta = {
+  startKey?: string;
+  totalCount?: number;
+  paginationUnsupported?: boolean;
+};
+
 export type KindRole = 'role';
 export type KindTrustedCluster = 'trusted_cluster';
 export type KindAuthConnectors = 'github' | 'saml' | 'oidc';


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/18171

Note: easier to review by commit

#### Description
Starting v9.1, changes were made to support backend pagination/filtering. But fallbacks were not provided for the web UI, resulting in user's not being able to see a list of resources from v8 clusters. This PR adds fallback support by falling back to a client side filtering table when serverside pagination is not supported. 

The backend will return a `null` (to mean field not set, different from `undefined`) for both the `startKey` and `totalCount` and this will be the flag to determine if pagination is not supported.

#### TODO
- [ ] requires backend changes to merge first https://github.com/gravitational/teleport/pull/18262
- [ ] forward port to v10

#### Screenshot
the server side paginating table

<img width="755" alt="image" src="https://user-images.githubusercontent.com/43280172/200694205-6e5fbdd4-b677-480a-bca5-535d12cf603f.png">


the fallback table

<img width="758" alt="image" src="https://user-images.githubusercontent.com/43280172/200694237-08af13d2-d59c-4208-a1f8-107450994c7b.png">

