### PR TITLE
Correct "sign into" to "sign in"

### DIFF
--- a/packages/teleport/src/Login/Login.test.tsx
+++ b/packages/teleport/src/Login/Login.test.tsx
@@ -35,7 +35,7 @@ test('basic rendering', () => {
 
   // test rendering of logo and title
   expect(screen.getByRole('img')).toBeInTheDocument();
-  expect(screen.getByText(/sign into teleport/i)).toBeInTheDocument();
+  expect(screen.getByText(/sign in to teleport/i)).toBeInTheDocument();
 });
 
 test('login with redirect', async () => {

--- a/packages/teleport/src/Login/Login.tsx
+++ b/packages/teleport/src/Login/Login.tsx
@@ -46,7 +46,7 @@ export function Login({
     <>
       <Logo src={logoSrc} />
       <FormLogin
-        title={'Sign into Teleport'}
+        title={'Sign in to Teleport'}
         authProviders={authProviders}
         auth2faType={auth2faType}
         preferredMfaType={preferredMfaType}


### PR DESCRIPTION
Correct "Sign into Teleport" to "Sign in to Teleport"

Needs a backport to.. well, probably every version