### PR TITLE
Prevent non-https protocol from opening external windows

### DIFF
--- a/packages/teleterm/src/main.ts
+++ b/packages/teleterm/src/main.ts
@@ -118,6 +118,9 @@ function initializeApp(): void {
       const url = new URL(details.url);
 
       function isUrlSafe(): boolean {
+        if (url.protocol !== 'https:') {
+          return false;
+        }
         if (url.host === 'goteleport.com') {
           return true;
         }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport-private/issues/173

As far as I'm aware, we only open two external links and both of them are `https` protocol. This only allows that protocol and prevents any links such as `window.open("ftp://badurl.here")` from being opened.