### PR TITLE
Fix null array

### DIFF
--- a/packages/teleport/src/lib/util.test.ts
+++ b/packages/teleport/src/lib/util.test.ts
@@ -63,6 +63,8 @@ test('no port and access request id', () => {
 });
 
 test('arrayStrDiff returns the correct diff', () => {
+  expect(arrayStrDiff(null, null)).toStrictEqual([]);
+
   const arrayA = ['a', 'b', 'c', 'd', 'e'];
   const arrayB = ['b', 'e', 'f', 'g'];
 

--- a/packages/teleport/src/lib/util.ts
+++ b/packages/teleport/src/lib/util.ts
@@ -73,5 +73,9 @@ export function generateTshLoginCommand({
 // arrayStrDiff returns an array of strings that
 // belong in stringsA but not in stringsB.
 export function arrayStrDiff(stringsA: string[], stringsB: string[]) {
+  if (!stringsA || !stringsB) {
+    return [];
+  }
+
   return stringsA.filter(l => !stringsB.includes(l));
 }

--- a/packages/teleport/src/services/nodes/makeNode.ts
+++ b/packages/teleport/src/services/nodes/makeNode.ts
@@ -16,24 +16,17 @@ limitations under the License.
 
 import { Node } from './types';
 
-export default function makeNode(json): Node {
-  const {
-    id,
-    siteId,
-    hostname,
-    addr,
-    tunnel,
-    tags = [],
-    sshLogins = [],
-  } = json;
+export default function makeNode(json: any): Node {
+  json = json ?? {};
+  const { id, siteId, hostname, addr, tunnel, tags, sshLogins } = json;
 
   return {
     id,
     clusterId: siteId,
     hostname,
-    labels: tags,
+    labels: tags ?? [],
     addr,
     tunnel,
-    sshLogins,
+    sshLogins: sshLogins ?? [],
   };
 }

--- a/packages/teleport/src/services/nodes/nodes.test.ts
+++ b/packages/teleport/src/services/nodes/nodes.test.ts
@@ -31,7 +31,7 @@ test('correct formatting of nodes fetch response', async () => {
         labels: [{ name: 'env', value: 'dev' }],
         addr: '192.168.86.132:3022',
         tunnel: false,
-        sshLogins: [],
+        sshLogins: ['root'],
       },
     ],
     startKey: mockResponse.startKey,
@@ -52,12 +52,15 @@ test('null response from nodes fetch', async () => {
   });
 });
 
-test('null labels field in nodes fetch response', async () => {
+test('null fields in nodes fetch response', async () => {
   const nodesService = new NodesService();
-  jest.spyOn(api, 'get').mockResolvedValue({ items: [{ labels: null }] });
+  jest.spyOn(api, 'get').mockResolvedValue({
+    items: [{ tags: null, sshLogins: null }],
+  });
   const response = await nodesService.fetchNodes('does-not-matter');
 
   expect(response.agents[0].labels).toEqual([]);
+  expect(response.agents[0].sshLogins).toEqual([]);
 });
 
 const mockResponse = {
@@ -69,6 +72,7 @@ const mockResponse = {
       siteId: 'im-a-cluster-name',
       tags: [{ name: 'env', value: 'dev' }],
       tunnel: false,
+      sshLogins: ['root'],
     },
   ],
   startKey: 'mockKey',


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/18369

#### Description
fixes bug where we try to iterate over a `null` array. the source was from `services/nodes/makeNodes`. I also placed checks for `arrayStrDiff` thinking this was the source of bug initially but it wasn't but why not.

#### TODO
- [ ] backport to v11
- [ ] backport to v10