### PR TITLE
[Discover] Tentatively implement Create Database screen

### DIFF
--- a/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
+++ b/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { CreateDatabaseView } from './CreateDatabase';
+
+import type { State } from './useCreateDatabase';
+
+export default {
+  title: 'Teleport/Discover/Database/CreateDatabase',
+};
+
+export const Init = () => (
+  <MemoryRouter>
+    <CreateDatabaseView {...props} />
+  </MemoryRouter>
+);
+
+export const Processing = () => (
+  <MemoryRouter>
+    <CreateDatabaseView {...props} attempt={{ status: 'processing' }} />
+  </MemoryRouter>
+);
+
+export const Failed = () => (
+  <MemoryRouter>
+    <CreateDatabaseView
+      {...props}
+      attempt={{ status: 'failed', statusText: 'some error message' }}
+    />
+  </MemoryRouter>
+);
+
+const props: State = {
+  attempt: { status: '' },
+  createDbAndQueryDb: () => null,
+};

--- a/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
+++ b/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import { Text, Box } from 'design';
+import { Danger } from 'design/Alert';
+import Validation, { Validator } from 'shared/components/Validation';
+import FieldInput from 'shared/components/FieldInput';
+import { requiredField } from 'shared/components/Validation/rules';
+
+import {
+  ActionButtons,
+  HeaderSubtitle,
+  Header,
+  LabelsCreater,
+} from '../../Shared';
+
+import { useCreateDatabase, State } from './useCreateDatabase';
+
+import type { AgentStepProps } from '../../types';
+import type { AgentLabel } from 'teleport/services/agents';
+
+export function CreateDatabase(props: AgentStepProps) {
+  const state = useCreateDatabase(props);
+  return <CreateDatabaseView {...state} />;
+}
+
+export function CreateDatabaseView({ attempt, createDbAndQueryDb }: State) {
+  const [dbName, setDbName] = useState('');
+  const [dbUri, setDbUri] = useState('');
+  const [labels, setLabels] = useState<AgentLabel[]>([]);
+
+  // TODO (lisa or ryan): these depend on if user chose AWS options:
+  // const [awsAccountId, setAwsAccountId] = useState('')
+  // const [awsResourceId, setAwsResourceId] = useState('')
+
+  function handleOnProceed(validator: Validator) {
+    if (!validator.validate()) {
+      return;
+    }
+
+    // TODO (lisa or ryan): preserve "self hosted" or "aws"
+    // and protocol on first step, and use it here.
+    createDbAndQueryDb({
+      labels,
+      name: dbName,
+      uri: dbUri,
+      // TODO (lisa or ryan) hard coded for now as example.
+      protocol: 'postgres',
+      // TODO (lisa or ryan) add AWS fields
+    });
+  }
+
+  return (
+    <Validation>
+      {({ validator }) => (
+        <Box>
+          <Header>Register a Database</Header>
+          <HeaderSubtitle>Lorem ipsum dolores</HeaderSubtitle>
+          {attempt.status === 'failed' && (
+            <Danger children={attempt.statusText} />
+          )}
+          <Box width="500px" mb={2}>
+            <FieldInput
+              label="Database Name"
+              rule={requiredField('database name is required')}
+              autoFocus
+              value={dbName}
+              placeholder="Enter database name"
+              onChange={e => setDbName(e.target.value)}
+            />
+          </Box>
+          <Box width="500px" mb={6}>
+            <FieldInput
+              label="Database Connection Endpoint"
+              rule={requiredField('database connection endpoint is required')}
+              autoFocus
+              value={dbUri}
+              placeholder="Enter database connection endpoint"
+              onChange={e => setDbUri(e.target.value)}
+            />
+          </Box>
+          {/* TODO (lisa or ryan): add AWS input fields */}
+          <Box>
+            <Text bold>Labels (optional)</Text>
+            <LabelsCreater
+              labels={labels}
+              setLabels={setLabels}
+              isLabelOptional={true}
+              disableBtns={attempt.status === 'processing'}
+            />
+          </Box>
+          <ActionButtons
+            onProceed={() => handleOnProceed(validator)}
+            // On failure, allow user to attempt again.
+            disableProceed={attempt.status === 'processing'}
+          />
+        </Box>
+      )}
+    </Validation>
+  );
+}

--- a/packages/teleport/src/Discover/Database/CreateDatabase/index.ts
+++ b/packages/teleport/src/Discover/Database/CreateDatabase/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { CreateDatabase } from './CreateDatabase';

--- a/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
+++ b/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import useAttempt from 'shared/hooks/useAttemptNext';
+
+import useTeleport from 'teleport/useTeleport';
+
+import type { AgentStepProps } from '../../types';
+import type { CreateDatabaseRequest } from 'teleport/services/databases';
+
+export function useCreateDatabase(props: AgentStepProps) {
+  const ctx = useTeleport();
+  const { attempt, setAttempt } = useAttempt('processing');
+
+  async function createDbAndQueryDb(db: CreateDatabaseRequest) {
+    setAttempt({ status: 'processing' });
+    try {
+      const clusterId = ctx.storeUser.getClusterId();
+      // Create the Database.
+      await ctx.databaseService.createDatabase(clusterId, db);
+
+      // Query for the created database by searching through database services.
+      // As discussed, if a service was already available, the new db should be
+      // picked up immediately.
+      let numSteps;
+      const request = {
+        search: db.name,
+        limit: 1,
+      };
+      const queryResult = await ctx.databaseService.fetchDatabases(
+        clusterId,
+        request
+      );
+
+      // If an agent was found, skip the next step that requires you
+      // to set up the db service, and set the database we queried to
+      // refer to it in later steps (this queried db will include current
+      // db users and db names).
+      const queriedDb = queryResult.agents[0];
+      if (queriedDb) {
+        numSteps = 2;
+        props.updateAgentMeta({
+          ...props.agentMeta,
+          resourceName: queriedDb.name,
+          db: queriedDb,
+        });
+      }
+      props.nextStep(numSteps);
+    } catch (err) {
+      let message;
+      if (err instanceof Error) message = err.message;
+      else message = String(err);
+      setAttempt({ status: 'failed', statusText: message });
+    }
+  }
+
+  return {
+    attempt,
+    createDbAndQueryDb,
+  };
+}
+
+export type State = ReturnType<typeof useCreateDatabase>;

--- a/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
@@ -15,21 +15,9 @@
  */
 
 import React, { useState, Suspense } from 'react';
-import {
-  Text,
-  Box,
-  ButtonSecondary,
-  Flex,
-  ButtonIcon,
-  ButtonText,
-} from 'design';
+import { Text, Box, ButtonSecondary } from 'design';
 import * as Icons from 'design/Icon';
-import FieldInput from 'shared/components/FieldInput';
-import Validation, {
-  useValidation,
-  Validator,
-} from 'shared/components/Validation';
-import { requiredField } from 'shared/components/Validation/rules';
+import Validation, { Validator } from 'shared/components/Validation';
 
 import { CatchError } from 'teleport/components/CatchError';
 import {
@@ -48,6 +36,7 @@ import {
   HeaderSubtitle,
   ResourceKind,
   TextIcon,
+  LabelsCreater,
 } from '../../Shared';
 
 import type { AgentStepProps } from '../../types';
@@ -98,7 +87,7 @@ export default function Container(
                 <Labels
                   labels={labels}
                   setLabels={setLabels}
-                  disableAddBtn={true}
+                  disableBtns={true}
                 />
                 <ButtonSecondary width="200px" disabled={true}>
                   Generate Command
@@ -195,7 +184,7 @@ export function DownloadScript(
       <Labels
         labels={props.labels}
         setLabels={props.setLabels}
-        disableAddBtn={poll.state === 'polling'}
+        disableBtns={poll.state === 'polling'}
       />
       <ButtonSecondary
         width="200px"
@@ -230,55 +219,12 @@ const Heading = () => {
 export const Labels = ({
   labels,
   setLabels,
-  disableAddBtn = false,
+  disableBtns = false,
 }: {
   labels: AgentLabel[];
   setLabels(l: AgentLabel[]): void;
-  disableAddBtn?: boolean;
+  disableBtns?: boolean;
 }) => {
-  const validator = useValidation() as Validator;
-
-  function addLabel() {
-    // Prevent adding more rows if there are
-    // empty input fields. After checking,
-    // reset the validator so the newly
-    // added empty input boxes are not
-    // considered an error.
-    if (!validator.validate()) {
-      return;
-    }
-    validator.reset();
-    setLabels([...labels, { name: '', value: '' }]);
-  }
-
-  function removeLabel(index: number) {
-    if (labels.length === 1) {
-      // Since at least one label is required
-      // instead of removing the row, clear
-      // the input and turn on error.
-      const newList = [...labels];
-      newList[index] = { name: '', value: '' };
-      setLabels(newList);
-
-      validator.validate();
-      return;
-    }
-    const newList = [...labels];
-    newList.splice(index, 1);
-    setLabels(newList);
-  }
-
-  const handleChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
-    index: number,
-    labelField: keyof AgentLabel
-  ) => {
-    const { value } = event.target;
-    const newList = [...labels];
-    newList[index] = { ...newList[index], [labelField]: value };
-    setLabels(newList);
-  };
-
   return (
     <Box mb={2}>
       <Text bold>Labels</Text>
@@ -286,84 +232,11 @@ export const Labels = ({
         At least one label is required to help this service identify your
         database.
       </Text>
-      <Flex mt={2}>
-        <Box width="170px" mr="3">
-          Key{' '}
-          <span css={{ fontSize: '12px', fontWeight: 'lighter' }}>
-            (required field)
-          </span>
-        </Box>
-        <Box>
-          Value{' '}
-          <span css={{ fontSize: '12px', fontWeight: 'lighter' }}>
-            (required field)
-          </span>
-        </Box>
-      </Flex>
-      <Box>
-        {labels.map((label, index) => {
-          return (
-            <Box mb={2} key={index}>
-              <Flex alignItems="center">
-                <FieldInput
-                  Input
-                  rule={requiredField('required')}
-                  autoFocus
-                  value={label.name}
-                  placeholder="label key"
-                  width="170px"
-                  mr={3}
-                  mb={0}
-                  onChange={e => handleChange(e, index, 'name')}
-                />
-                <FieldInput
-                  rule={requiredField('required')}
-                  value={label.value}
-                  placeholder="label value"
-                  width="170px"
-                  mb={0}
-                  mr={2}
-                  onChange={e => handleChange(e, index, 'value')}
-                />
-                <ButtonIcon
-                  size={1}
-                  title="Remove Label"
-                  onClick={() => removeLabel(index)}
-                >
-                  <Icons.Trash />
-                </ButtonIcon>
-              </Flex>
-            </Box>
-          );
-        })}
-      </Box>
-      <ButtonText
-        onClick={addLabel}
-        css={`
-          padding-left: 0px;
-          &:disabled {
-            .icon-add {
-              opacity: 0.35;
-            }
-            pointer-events: none;
-          }
-        `}
-        disabled={disableAddBtn}
-      >
-        <Icons.Add
-          className="icon-add"
-          disabled={disableAddBtn}
-          css={`
-            font-weight: bold;
-            letter-spacing: 4px;
-            margin-top: -2px;
-            &:after {
-              content: ' ';
-            }
-          `}
-        />
-        Add New Label
-      </ButtonText>
+      <LabelsCreater
+        labels={labels}
+        setLabels={setLabels}
+        disableBtns={disableBtns}
+      />
     </Box>
   );
 };

--- a/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.story.tsx
+++ b/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.story.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+
+import Validation from 'shared/components/Validation';
+
+import { LabelsCreater } from './LabelsCreater';
+
+export default {
+  title: 'Teleport/Discover/Shared/LabelsCreator',
+};
+
+export const OptionalLabels = () => {
+  const [labels, setLabels] = useState([]);
+
+  return (
+    <Validation>
+      <LabelsCreater
+        labels={labels}
+        setLabels={setLabels}
+        isLabelOptional={true}
+      />
+    </Validation>
+  );
+};
+
+export const RequiredLabels = () => {
+  const [labels, setLabels] = useState([
+    { name: 'env', value: 'prod' },
+    { name: 'os', value: 'windows' },
+  ]);
+
+  return (
+    <Validation>
+      <LabelsCreater labels={labels} setLabels={setLabels} />
+    </Validation>
+  );
+};
+
+export const DisabledAddButton = () => {
+  const [labels, setLabels] = useState([{ name: '*', value: '*' }]);
+
+  return (
+    <Validation>
+      <LabelsCreater labels={labels} setLabels={setLabels} disableBtns={true} />
+    </Validation>
+  );
+};

--- a/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.tsx
+++ b/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.tsx
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Box, Flex, ButtonIcon, ButtonText } from 'design';
+import * as Icons from 'design/Icon';
+import FieldInput from 'shared/components/FieldInput';
+import { useValidation, Validator } from 'shared/components/Validation';
+import { requiredField } from 'shared/components/Validation/rules';
+
+import { AgentLabel } from 'teleport/services/agents';
+
+export function LabelsCreater({
+  labels,
+  setLabels,
+  disableBtns = false,
+  isLabelOptional = false,
+}: {
+  labels: AgentLabel[];
+  setLabels(l: AgentLabel[]): void;
+  disableBtns?: boolean;
+  isLabelOptional?: boolean;
+}) {
+  const validator = useValidation() as Validator;
+
+  function addLabel() {
+    // Prevent adding more rows if there are
+    // empty input fields. After checking,
+    // reset the validator so the newly
+    // added empty input boxes are not
+    // considered an error.
+    if (!validator.validate()) {
+      return;
+    }
+    validator.reset();
+    setLabels([...labels, { name: '', value: '' }]);
+  }
+
+  function removeLabel(index: number) {
+    if (!isLabelOptional && labels.length === 1) {
+      // Since at least one label is required
+      // instead of removing the last row, clear
+      // the input and turn on error.
+      const newList = [...labels];
+      newList[index] = { name: '', value: '' };
+      setLabels(newList);
+
+      validator.validate();
+      return;
+    }
+    const newList = [...labels];
+    newList.splice(index, 1);
+    setLabels(newList);
+  }
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    index: number,
+    labelField: keyof AgentLabel
+  ) => {
+    const { value } = event.target;
+    const newList = [...labels];
+    newList[index] = { ...newList[index], [labelField]: value };
+    setLabels(newList);
+  };
+
+  return (
+    <>
+      {labels.length > 0 && (
+        <Flex mt={2}>
+          <Box width="170px" mr="3">
+            Key{' '}
+            <span css={{ fontSize: '12px', fontWeight: 'lighter' }}>
+              (required field)
+            </span>
+          </Box>
+          <Box>
+            Value{' '}
+            <span css={{ fontSize: '12px', fontWeight: 'lighter' }}>
+              (required field)
+            </span>
+          </Box>
+        </Flex>
+      )}
+      <Box>
+        {labels.map((label, index) => {
+          return (
+            <Box mb={2} key={index}>
+              <Flex alignItems="center">
+                <FieldInput
+                  Input
+                  rule={requiredField('required')}
+                  autoFocus
+                  value={label.name}
+                  placeholder="label key"
+                  width="170px"
+                  mr={3}
+                  mb={0}
+                  onChange={e => handleChange(e, index, 'name')}
+                />
+                <FieldInput
+                  rule={requiredField('required')}
+                  value={label.value}
+                  placeholder="label value"
+                  width="170px"
+                  mb={0}
+                  mr={2}
+                  onChange={e => handleChange(e, index, 'value')}
+                />
+                <ButtonIcon
+                  size={1}
+                  title="Remove Label"
+                  onClick={() => removeLabel(index)}
+                  css={`
+                    &:disabled {
+                      opacity: 0.65;
+                      pointer-events: none;
+                    }
+                  `}
+                  disabled={disableBtns}
+                >
+                  <Icons.Trash />
+                </ButtonIcon>
+              </Flex>
+            </Box>
+          );
+        })}
+      </Box>
+      <ButtonText
+        onClick={addLabel}
+        css={`
+          padding-left: 0px;
+          &:disabled {
+            .icon-add {
+              opacity: 0.35;
+            }
+            pointer-events: none;
+          }
+        `}
+        disabled={disableBtns}
+      >
+        <Icons.Add
+          className="icon-add"
+          disabled={disableBtns}
+          css={`
+            font-weight: bold;
+            letter-spacing: 4px;
+            margin-top: -2px;
+            &:after {
+              content: ' ';
+            }
+          `}
+        />
+        Add New Label
+      </ButtonText>
+    </>
+  );
+}

--- a/packages/teleport/src/Discover/Shared/LabelsCreater/index.ts
+++ b/packages/teleport/src/Discover/Shared/LabelsCreater/index.ts
@@ -14,13 +14,4 @@
  * limitations under the License.
  */
 
-export { ActionButtons } from './ActionButtons';
-export { ButtonBlueText } from './ButtonBlueText';
-export { Header, HeaderSubtitle, HeaderWithBackBtn } from './Header';
-export { Finished } from './Finished';
-export { Mark } from './Mark';
-export { ReadOnlyYamlEditor } from './YAML';
-export { ResourceKind } from './ResourceKind';
-export { Step, StepContainer } from './Step';
-export { TextBox, TextIcon } from './Text';
 export { LabelsCreater } from './LabelsCreater';

--- a/packages/teleport/src/Discover/useDiscover.tsx
+++ b/packages/teleport/src/Discover/useDiscover.tsx
@@ -66,8 +66,14 @@ export function useDiscover(config: UseMainConfig) {
     setSelectedResourceKind(kind);
   }
 
-  function nextStep() {
-    const nextView = findViewAtIndex(views, currentStep + 1);
+  // nextStep takes the user to the next screen.
+  // The prop `numToIncrement` is used (>1) when we want to
+  // skip some number of steps.
+  // eg: particularly for Database flow, if there exists a
+  // database service, then we don't want to show the user
+  // the screen that lets them add a database server.
+  function nextStep(numToIncrement = 1) {
+    const nextView = findViewAtIndex(views, currentStep + numToIncrement);
 
     if (nextView) {
       setCurrentStep(currentStep + 1);
@@ -109,9 +115,10 @@ export function useDiscover(config: UseMainConfig) {
 }
 
 type BaseMeta = {
-  // resourceName is the resource name which for each resource
-  // can be determined from a different field. Atm only resource
-  // `node` is the only outlier.
+  // resourceName provides a consistent field to refer to for
+  // the resource name since resources can refer to its name
+  // by different field names.
+  // Eg. used in Finish (last step) component.
   resourceName: string;
 };
 

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -129,6 +129,7 @@ const cfg = {
     changeUserPasswordPath: '/v1/webapi/users/password',
     nodesPath:
       '/v1/webapi/sites/:clusterId/nodes?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?',
+    databasePath: `/v1/webapi/sites/:clusterId/databases/:database`,
     databasesPath: `/v1/webapi/sites/:clusterId/databases?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,
     desktopsPath: `/v1/webapi/sites/:clusterId/desktops?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,
     desktopServicesPath: `/v1/webapi/sites/:clusterId/desktopservices?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,
@@ -423,7 +424,14 @@ const cfg = {
     });
   },
 
-  getDatabasesUrl(clusterId: string, params: UrlResourcesParams) {
+  getDatabaseUrl(clusterId: string, dbName: string) {
+    return generateResourcePath(cfg.api.databasePath, {
+      clusterId,
+      database: dbName,
+    });
+  },
+
+  getDatabasesUrl(clusterId: string, params?: UrlResourcesParams) {
     return generateResourcePath(cfg.api.databasesPath, {
       clusterId,
       ...params,

--- a/packages/teleport/src/services/databases/databases.ts
+++ b/packages/teleport/src/services/databases/databases.ts
@@ -18,8 +18,13 @@ import api from 'teleport/services/api';
 import cfg, { UrlResourcesParams } from 'teleport/config';
 import { AgentResponse } from 'teleport/services/agents';
 
-import { Database } from './types';
 import makeDatabase from './makeDatabase';
+
+import type {
+  CreateDatabaseRequest,
+  Database,
+  UpdateDatabaseRequest,
+} from './types';
 
 class DatabaseService {
   fetchDatabases(
@@ -38,6 +43,26 @@ class DatabaseService {
           totalCount: json?.totalCount,
         };
       });
+  }
+
+  fetchDatabase(clusterId: string, dbName: string): Promise<Database> {
+    return api.get(cfg.getDatabaseUrl(clusterId, dbName)).then(makeDatabase);
+  }
+
+  updateDatabase(
+    clusterId: string,
+    req: UpdateDatabaseRequest
+  ): Promise<Database> {
+    return api
+      .put(cfg.getDatabaseUrl(clusterId, req.name), { ca_cert: req.caCert })
+      .then(makeDatabase);
+  }
+
+  createDatabase(
+    clusterId: string,
+    req: CreateDatabaseRequest
+  ): Promise<Database> {
+    return api.post(cfg.getDatabasesUrl(clusterId), req).then(makeDatabase);
   }
 }
 

--- a/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/packages/teleport/src/services/databases/makeDatabase.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { Database, DbType, DbProtocol } from './types';
 
-export default function makeDatabase(json): Database {
+export default function makeDatabase(json: any): Database {
   const { name, desc, protocol, type } = json;
 
   const labels = json.labels || [];

--- a/packages/teleport/src/services/databases/types.ts
+++ b/packages/teleport/src/services/databases/types.ts
@@ -39,3 +39,17 @@ export type DatabasesResponse = {
   startKey?: string;
   totalCount?: number;
 };
+
+export type UpdateDatabaseRequest = {
+  name: string;
+  caCert: string;
+};
+
+export type CreateDatabaseRequest = {
+  name: string;
+  protocol: DbProtocol;
+  uri: string;
+  labels?: AgentLabel[];
+  // TODO (lisa or ryan): marco will work on including aws object fields
+  // eg: aws account id and resource id
+};


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/16858

#### Description
There's a lot of TODO, but wanted to ship it out because it will be used for both `self-hosted` and `aws` flows

- added new endpoints from https://github.com/gravitational/teleport/pull/17783
- extracted label creating logic from `Database/DownloadScript` to re-use elsewhere
- Tentatively created a `CreateDatabase` component for `self-hosted`. The AWS portion for the backend was not included so left it out until it is done (pinged @marcoandredinis and he will focus on it next week)

#### Figma Design
Self-hosted: https://www.figma.com/file/8DQZl1mYUPLgvKgmA6zPOM/In-Progress-Work?node-id=1299%3A69070&t=U9L15xmjMaN6JJAq-0
AWS (very sim to self-hosted): https://www.figma.com/file/8DQZl1mYUPLgvKgmA6zPOM/In-Progress-Work?node-id=1296%3A67025&t=U9L15xmjMaN6JJAq-0

#### Screenshot

initial load

<img width="526" alt="image" src="https://user-images.githubusercontent.com/43280172/202792170-4b99f0df-f20f-45a1-b703-dd411a7b2afd.png">


with labels

<img width="535" alt="image" src="https://user-images.githubusercontent.com/43280172/202792227-e8a03ffe-7290-4949-a7a5-9f25133d4eb5.png">


