### PR TITLE
[Discover] Refactor TestConnection Screens

### DIFF
--- a/packages/teleport/src/Discover/Database/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/Database/TestConnection/TestConnection.story.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { TestConnectionView } from './TestConnection';
+
+import type { State } from './useTestConnection';
+
+export default {
+  title: 'Teleport/Discover/Shared/ConnectionDiagnostic/Database',
+};
+
+export const Init = () => (
+  <MemoryRouter>
+    <TestConnectionView {...props} />
+  </MemoryRouter>
+);
+
+export const InitWithOnlyDbUsers = () => (
+  <MemoryRouter>
+    <TestConnectionView {...props} db={{ ...props.db, names: [] }} />
+  </MemoryRouter>
+);
+
+export const InitWithOnlyDbNames = () => (
+  <MemoryRouter>
+    <TestConnectionView {...props} db={{ ...props.db, users: [] }} />
+  </MemoryRouter>
+);
+
+const props: State = {
+  attempt: {
+    status: 'success',
+    statusText: '',
+  },
+  testConnection: () => null,
+  nextStep: () => null,
+  prevStep: () => null,
+  diagnosis: null,
+  canTestConnection: true,
+  username: 'teleport-username',
+  authType: 'local',
+  clusterId: 'some-cluster-id',
+  db: {
+    name: 'dbname',
+    description: 'some desc',
+    type: 'self-hosted',
+    protocol: 'postgres',
+    labels: [],
+    names: ['name1', 'name2'],
+    users: ['user1', 'user2'],
+  },
+};

--- a/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Text, Box, LabelInput } from 'design';
+
+import Select, { Option } from 'shared/components/Select';
+
+import TextSelectCopy from 'teleport/components/TextSelectCopy';
+import { generateTshLoginCommand } from 'teleport/lib/util';
+
+import {
+  ActionButtons,
+  HeaderSubtitle,
+  HeaderWithBackBtn,
+  ConnectionDiagnosticResult,
+} from '../../Shared';
+
+import { useTestConnection, State } from './useTestConnection';
+
+import type { AgentStepProps } from '../../types';
+
+export function TestConnection(props: AgentStepProps) {
+  const state = useTestConnection(props);
+
+  return <TestConnectionView {...state} />;
+}
+
+export function TestConnectionView({
+  attempt,
+  testConnection,
+  diagnosis,
+  nextStep,
+  prevStep,
+  canTestConnection,
+  db,
+  authType,
+  username,
+  clusterId,
+}: State) {
+  const userOpts = db.users.map(l => ({ value: l, label: l }));
+  const nameOpts = db.names.map(l => ({ value: l, label: l }));
+
+  const [selectedUser, setSelectedUser] = useState(userOpts[0]);
+
+  // Database User might be the more popular option so it takes
+  // precedence.
+  const [selectedName, setSelectedName] = useState(
+    userOpts[0] ? null : nameOpts[0]
+  );
+
+  return (
+    <Box>
+      <HeaderWithBackBtn onPrev={prevStep}>Test Connection</HeaderWithBackBtn>
+      <HeaderSubtitle>
+        Optionally verify that you can successfully connect to the Database you
+        just added.
+      </HeaderSubtitle>
+      <StyledBox mb={5}>
+        <Text bold>Step 1</Text>
+        <Text typography="subtitle1" mb={3}>
+          Select a user and or a database name to test. At least one must be
+          selected.
+        </Text>
+        <Box width="500px" mb={4}>
+          <LabelInput htmlFor={'select'}>Database User</LabelInput>
+          <Select
+            placeholder={
+              userOpts.length === 0
+                ? 'No database users defined'
+                : 'Click to select a database user'
+            }
+            isSearchable
+            isClearable={true}
+            value={selectedUser}
+            onChange={(o: Option) => setSelectedUser(o)}
+            options={userOpts}
+            isDisabled={
+              attempt.status === 'processing' || userOpts.length === 0
+            }
+          />
+        </Box>
+        <Box width="500px" mb={3}>
+          <LabelInput htmlFor={'select'}>Database Name</LabelInput>
+          <Select
+            label="Database name"
+            placeholder={
+              nameOpts.length === 0
+                ? 'No database names defined'
+                : 'Click to select a database name'
+            }
+            isSearchable
+            isClearable={true}
+            value={selectedName}
+            onChange={(o: Option) => setSelectedName(o)}
+            options={nameOpts}
+            isDisabled={
+              attempt.status === 'processing' || nameOpts.length === 0
+            }
+          />
+        </Box>
+      </StyledBox>
+      <ConnectionDiagnosticResult
+        attempt={attempt}
+        diagnosis={diagnosis}
+        canTestConnection={canTestConnection}
+        testConnection={testConnection}
+        stepNumber={2}
+        stepDescription="Verify that your database is accessible"
+      />
+      <StyledBox>
+        <Text bold mb={3}>
+          To Access your Database
+        </Text>
+        <Box mb={2}>
+          Log into your Teleport cluster
+          <TextSelectCopy
+            mt="1"
+            text={generateTshLoginCommand({
+              authType,
+              username,
+              clusterId,
+            })}
+          />
+        </Box>
+        <Box mb={2}>
+          Connect to your database
+          <TextSelectCopy mt="1" text={`tsh db connect ${db.name}`} />
+        </Box>
+      </StyledBox>
+      <ActionButtons onProceed={nextStep} lastStep={true} />
+    </Box>
+  );
+}
+
+const StyledBox = styled(Box)`
+  max-width: 800px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 20px;
+`;

--- a/packages/teleport/src/Discover/Database/TestConnection/index.ts
+++ b/packages/teleport/src/Discover/Database/TestConnection/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { TestConnection } from './TestConnection';

--- a/packages/teleport/src/Discover/Database/TestConnection/useTestConnection.ts
+++ b/packages/teleport/src/Discover/Database/TestConnection/useTestConnection.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useConnectionDiagnostic } from 'teleport/Discover/Shared';
+
+import { DbMeta } from '../../useDiscover';
+
+import type { AgentStepProps } from '../../types';
+
+export function useTestConnection(props: AgentStepProps) {
+  const { runConnectionDiagnostic, ...connectionDiagnostic } =
+    useConnectionDiagnostic(props);
+
+  function testConnection() {
+    runConnectionDiagnostic({
+      resourceKind: 'db',
+      resourceName: props.agentMeta.resourceName,
+      // TODO (lisa or ryan): possible more fields specific to database
+      // once backend finalizes.
+    });
+  }
+
+  return {
+    ...connectionDiagnostic,
+    testConnection,
+    db: (props.agentMeta as DbMeta).db,
+  };
+}
+
+export type State = ReturnType<typeof useTestConnection>;

--- a/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.story.tsx
@@ -19,20 +19,19 @@ import { MemoryRouter } from 'react-router';
 
 import { TestConnection } from './TestConnection';
 
-import type { ConnectionDiagnosticTrace } from 'teleport/services/agents';
 import type { State } from './useTestConnection';
 
 export default {
-  title: 'Teleport/Discover/Kube/TestConnection',
+  title: 'Teleport/Discover/Shared/ConnectionDiagnostic/Kube',
 };
 
-export const LoadedInitWithLocal = () => (
+export const InitWithLocal = () => (
   <MemoryRouter>
     <TestConnection {...props} />
   </MemoryRouter>
 );
 
-export const LoadedInitWithSso = () => (
+export const InitWithSso = () => (
   <MemoryRouter>
     <TestConnection {...props} authType="sso" />
   </MemoryRouter>
@@ -80,109 +79,12 @@ export const WithKubeUsersAndGroups = () => (
   </MemoryRouter>
 );
 
-export const Processing = () => (
-  <MemoryRouter>
-    <TestConnection {...props} attempt={{ status: 'processing' }} />
-  </MemoryRouter>
-);
-
-export const LoadedWithDiagnosisSuccess = () => (
-  <MemoryRouter>
-    <TestConnection {...props} diagnosis={mockDiagnosis} />
-  </MemoryRouter>
-);
-
-export const LoadedWithDiagnosisFailure = () => {
-  const diagnosisWithErr = {
-    ...mockDiagnosis,
-    success: false,
-    traces: [
-      ...mockDiagnosis.traces,
-      {
-        id: '',
-        traceType: 'some trace type',
-        status: 'failed',
-        details:
-          'Invalid user. Please ensure the principal "debian" is a valid Linux login in the target node. Output from Node: Failed to launch: user: unknown user debian.',
-        error: 'ssh: handshake failed: EOF',
-      } as ConnectionDiagnosticTrace,
-      {
-        id: '',
-        traceType: 'some trace type',
-        status: 'failed',
-        details: 'Another error',
-        error: 'some other error',
-      } as ConnectionDiagnosticTrace,
-    ],
-  };
-  return (
-    <MemoryRouter>
-      <TestConnection {...props} diagnosis={diagnosisWithErr} />
-    </MemoryRouter>
-  );
-};
-
-export const LoadedNoPerm = () => (
-  <MemoryRouter>
-    <TestConnection {...props} canTestConnection={false} />
-  </MemoryRouter>
-);
-
-export const Failed = () => (
-  <MemoryRouter>
-    <TestConnection
-      {...props}
-      attempt={{ status: 'failed', statusText: 'some error message' }}
-    />
-  </MemoryRouter>
-);
-
-// TODO update to kube, does not matter really.
-const mockDiagnosis = {
-  id: 'id',
-  labels: [],
-  success: true,
-  message: 'some diagnosis message',
-  traces: [
-    {
-      traceType: 'rbac node',
-      status: 'success',
-      details: 'Resource exists.',
-    },
-    {
-      traceType: 'network connectivity',
-      status: 'success',
-      details: 'Host is alive and reachable.',
-    },
-    {
-      traceType: 'rbac principal',
-      status: 'success',
-      details: 'Successfully authenticated.',
-    },
-    {
-      traceType: 'node ssh server',
-      status: 'success',
-      details: 'Established an SSH connection.',
-    },
-    {
-      traceType: 'node ssh session',
-      status: 'success',
-      details: 'Created an SSH session.',
-    },
-    {
-      traceType: 'node principal',
-      status: 'success',
-      details: 'User exists message.',
-    },
-  ] as ConnectionDiagnosticTrace[],
-};
-
 const props: State = {
   attempt: {
     status: 'success',
     statusText: '',
   },
-  runConnectionDiagnostic: () => null,
+  testConnection: () => null,
   nextStep: () => null,
   prevStep: () => null,
   diagnosis: null,

--- a/packages/teleport/src/Discover/Server/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/Server/TestConnection/TestConnection.story.tsx
@@ -19,114 +19,17 @@ import { MemoryRouter } from 'react-router';
 
 import { TestConnection } from './TestConnection';
 
-import type { ConnectionDiagnosticTrace } from 'teleport/services/agents';
 import type { State } from './useTestConnection';
 
 export default {
-  title: 'Teleport/Discover/Server/TestConnection',
+  title: 'Teleport/Discover/Shared/ConnectionDiagnostic/Server',
 };
 
-export const LoadedInit = () => (
+export const Init = () => (
   <MemoryRouter>
     <TestConnection {...props} />
   </MemoryRouter>
 );
-
-export const Processing = () => (
-  <MemoryRouter>
-    <TestConnection {...props} attempt={{ status: 'processing' }} />
-  </MemoryRouter>
-);
-
-export const LoadedWithDiagnosisSuccess = () => (
-  <MemoryRouter>
-    <TestConnection {...props} diagnosis={mockDiagnosis} />
-  </MemoryRouter>
-);
-
-export const LoadedWithDiagnosisFailure = () => {
-  const diagnosisWithErr = {
-    ...mockDiagnosis,
-    success: false,
-    traces: [
-      ...mockDiagnosis.traces,
-      {
-        id: '',
-        traceType: 'some trace type',
-        status: 'failed',
-        details:
-          'Invalid user. Please ensure the principal "debian" is a valid Linux login in the target node. Output from Node: Failed to launch: user: unknown user debian.',
-        error: 'ssh: handshake failed: EOF',
-      } as ConnectionDiagnosticTrace,
-      {
-        id: '',
-        traceType: 'some trace type',
-        status: 'failed',
-        details: 'Another error',
-        error: 'some other error',
-      } as ConnectionDiagnosticTrace,
-    ],
-  };
-  return (
-    <MemoryRouter>
-      <TestConnection {...props} diagnosis={diagnosisWithErr} />
-    </MemoryRouter>
-  );
-};
-
-export const LoadedNoPerm = () => (
-  <MemoryRouter>
-    <TestConnection {...props} canTestConnection={false} />
-  </MemoryRouter>
-);
-
-export const Failed = () => (
-  <MemoryRouter>
-    <TestConnection
-      {...props}
-      attempt={{ status: 'failed', statusText: 'some error message' }}
-    />
-  </MemoryRouter>
-);
-
-const mockDiagnosis = {
-  id: 'id',
-  labels: [],
-  success: true,
-  message: 'some diagnosis message',
-  traces: [
-    {
-      traceType: 'rbac node',
-      status: 'success',
-      details: 'Resource exists.',
-    },
-    {
-      traceType: 'network connectivity',
-      status: 'success',
-      details: 'Host is alive and reachable.',
-    },
-    {
-      traceType: 'rbac principal',
-      status: 'success',
-      details: 'Successfully authenticated.',
-    },
-    {
-      traceType: 'node ssh server',
-      status: 'success',
-      details: 'Established an SSH connection.',
-    },
-    {
-      traceType: 'node ssh session',
-      status: 'success',
-      details: 'Created an SSH session.',
-    },
-    {
-      traceType: 'node principal',
-      status: 'success',
-      details: 'User exists message.',
-    },
-  ] as ConnectionDiagnosticTrace[],
-};
 
 const props: State = {
   attempt: {
@@ -135,9 +38,12 @@ const props: State = {
   },
   logins: ['root', 'llama', 'george_washington_really_long_name_testing'],
   startSshSession: () => null,
-  runConnectionDiagnostic: () => null,
+  testConnection: () => null,
   nextStep: () => null,
   prevStep: () => null,
   diagnosis: null,
   canTestConnection: true,
+  username: 'teleport-username',
+  authType: 'local',
+  clusterId: 'some-cluster-id',
 };

--- a/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
@@ -16,19 +16,14 @@
 
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { ButtonSecondary, Text, Box, LabelInput, Flex } from 'design';
-import * as Icons from 'design/Icon';
+import { ButtonSecondary, Text, Box, LabelInput } from 'design';
 import Select from 'shared/components/Select';
-
-import useTeleport from 'teleport/useTeleport';
-import { YamlReader } from 'teleport/Discover/Shared/SetupAccess/AccessInfo';
 
 import {
   HeaderWithBackBtn,
   ActionButtons,
-  TextIcon,
   HeaderSubtitle,
-  Mark,
+  ConnectionDiagnosticResult,
 } from '../../Shared';
 
 import { useTestConnection, State } from './useTestConnection';
@@ -37,8 +32,7 @@ import type { Option } from 'shared/components/Select';
 import type { AgentStepProps } from '../../types';
 
 export default function Container(props: AgentStepProps) {
-  const ctx = useTeleport();
-  const state = useTestConnection({ ctx, props });
+  const state = useTestConnection(props);
 
   return <TestConnection {...state} />;
 }
@@ -47,7 +41,7 @@ export function TestConnection({
   attempt,
   startSshSession,
   logins,
-  runConnectionDiagnostic,
+  testConnection,
   diagnosis,
   nextStep,
   prevStep,
@@ -59,32 +53,6 @@ export function TestConnection({
   // There will always be one login, as the user cannot proceed
   // the step that requires users to have at least one login.
   const [selectedOpt, setSelectedOpt] = useState(usernameOpts[0]);
-
-  let $diagnosisStateComponent;
-  if (attempt.status === 'processing') {
-    $diagnosisStateComponent = (
-      <TextIcon>
-        <Icons.Restore fontSize={4} />
-        Testing in-progress
-      </TextIcon>
-    );
-  } else if (attempt.status === 'failed' || (diagnosis && !diagnosis.success)) {
-    $diagnosisStateComponent = (
-      <TextIcon>
-        <Icons.Warning ml={1} color="danger" />
-        Testing failed
-      </TextIcon>
-    );
-  } else if (attempt.status === 'success' && diagnosis?.success) {
-    $diagnosisStateComponent = (
-      <TextIcon>
-        <Icons.CircleCheck ml={1} color="success" />
-        Testing complete
-      </TextIcon>
-    );
-  }
-
-  const showDiagnosisOutput = !!diagnosis || attempt.status === 'failed';
 
   return (
     <Box>
@@ -108,75 +76,14 @@ export function TestConnection({
           />
         </Box>
       </StyledBox>
-      <StyledBox mb={5}>
-        <Text bold>Step 2</Text>
-        <Text typography="subtitle1" mb={3}>
-          Verify that the server is accessible
-        </Text>
-        <Flex alignItems="center" mt={3}>
-          {canTestConnection ? (
-            <>
-              <ButtonSecondary
-                width="200px"
-                onClick={() => runConnectionDiagnostic(selectedOpt.value)}
-                disabled={attempt.status === 'processing'}
-              >
-                {diagnosis ? 'Restart Test' : 'Test Connection'}
-              </ButtonSecondary>
-              <Box ml={4}>{$diagnosisStateComponent}</Box>
-            </>
-          ) : (
-            <Box>
-              <Text>
-                You don't have permission to test connection.
-                <br />
-                Please ask your Teleport administrator to update your role and
-                add the <Mark>connection_diagnostic</Mark> rule:
-              </Text>
-              <YamlReader traitKind="ConnDiag" />
-            </Box>
-          )}
-        </Flex>
-        {showDiagnosisOutput && (
-          <Box mt={3}>
-            {attempt.status === 'failed' &&
-              `Encountered Error: ${attempt.statusText}`}
-            {attempt.status === 'success' && (
-              <Box>
-                {diagnosis.traces.map((trace, index) => {
-                  if (trace.status === 'failed') {
-                    return (
-                      <TextIcon alignItems="baseline">
-                        <Icons.CircleCross mr={1} color="danger" />
-                        {trace.details}
-                        <br />
-                        {trace.error}
-                      </TextIcon>
-                    );
-                  }
-                  if (trace.status === 'success') {
-                    return (
-                      <TextIcon key={index}>
-                        <Icons.CircleCheck mr={1} color="success" />
-                        {trace.details}
-                      </TextIcon>
-                    );
-                  }
-
-                  // For whatever reason the status is not the value
-                  // of failed or success.
-                  return (
-                    <TextIcon key={index}>
-                      <Icons.Question mr={1} />
-                      {trace.details}
-                    </TextIcon>
-                  );
-                })}
-              </Box>
-            )}
-          </Box>
-        )}
-      </StyledBox>
+      <ConnectionDiagnosticResult
+        attempt={attempt}
+        diagnosis={diagnosis}
+        canTestConnection={canTestConnection}
+        testConnection={() => testConnection(selectedOpt.value)}
+        stepNumber={2}
+        stepDescription="Verify that the server is accessible"
+      />
       <StyledBox>
         <Text bold>Step 3</Text>
         <Text typography="subtitle1" mb={3}>

--- a/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.story.tsx
+++ b/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.story.tsx
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { ConnectionDiagnosticResult } from './ConnectionDiagnosticResult';
+
+import type { Props } from './ConnectionDiagnosticResult';
+import type { ConnectionDiagnosticTrace } from 'teleport/services/agents';
+
+export default {
+  title: 'Teleport/Discover/Shared/ConnectionDiagnostic',
+};
+
+export const Init = () => (
+  <ConnectionDiagnosticResult {...props} diagnosis={null} />
+);
+
+export const DiagnosisSuccess = () => (
+  <ConnectionDiagnosticResult
+    {...props}
+    attempt={{ status: 'success' }}
+    diagnosis={diagnosisSuccess}
+  />
+);
+
+export const DiagnosisFailed = () => (
+  <ConnectionDiagnosticResult
+    {...props}
+    attempt={{ status: 'success' }}
+    diagnosis={diagnosisFailed}
+  />
+);
+
+export const DiagnosisLoading = () => (
+  <ConnectionDiagnosticResult {...props} attempt={{ status: 'processing' }} />
+);
+
+export const NoAccess = () => (
+  <ConnectionDiagnosticResult {...props} canTestConnection={false} />
+);
+
+export const Error = () => (
+  <ConnectionDiagnosticResult
+    {...props}
+    attempt={{ status: 'failed', statusText: 'some error message' }}
+  />
+);
+
+const diagnosisSuccess = {
+  id: 'id',
+  labels: [],
+  success: true,
+  message: 'some diagnosis message',
+  traces: [
+    {
+      traceType: 'rbac node',
+      status: 'success',
+      details: 'Resource exists.',
+    },
+    {
+      traceType: 'network connectivity',
+      status: 'success',
+      details: 'Host is alive and reachable.',
+    },
+    {
+      traceType: 'rbac principal',
+      status: 'success',
+      details: 'Successfully authenticated.',
+    },
+    {
+      traceType: 'node ssh server',
+      status: 'success',
+      details: 'Established an SSH connection.',
+    },
+    {
+      traceType: 'node ssh session',
+      status: 'success',
+      details: 'Created an SSH session.',
+    },
+    {
+      traceType: 'node principal',
+      status: 'success',
+      details: 'User exists message.',
+    },
+  ] as ConnectionDiagnosticTrace[],
+};
+
+const diagnosisFailed = {
+  id: 'id',
+  labels: [],
+  success: false,
+  message: 'some diagnosis message',
+  traces: [
+    {
+      traceType: 'rbac node',
+      status: 'success',
+      details: 'Resource exists.',
+    },
+    {
+      traceType: 'network connectivity',
+      status: 'success',
+      details: 'Host is alive and reachable.',
+    },
+    {
+      traceType: 'rbac principal',
+      status: 'failed',
+      details: 'Why rbac principal check failed',
+      error: 'Some extra error log',
+    },
+    {
+      traceType: 'node ssh session',
+      status: 'failed',
+      details: 'Why node ssh session might have failed',
+      error: 'Some extra error log 2',
+    },
+  ] as ConnectionDiagnosticTrace[],
+};
+
+const props: Props = {
+  attempt: { status: '' },
+  diagnosis: null,
+  canTestConnection: true,
+  testConnection: () => null,
+  stepNumber: 2,
+  stepDescription: 'Verify that your example database is accessible',
+};

--- a/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
+++ b/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { ButtonSecondary, Text, Box, Flex, ButtonText } from 'design';
+import * as Icons from 'design/Icon';
+
+import { YamlReader } from 'teleport/Discover/Shared/SetupAccess/AccessInfo';
+
+import { TextIcon, Mark } from '..';
+
+import type { Attempt } from 'shared/hooks/useAttemptNext';
+import type { ConnectionDiagnostic } from 'teleport/services/agents';
+
+export function ConnectionDiagnosticResult({
+  attempt,
+  diagnosis,
+  canTestConnection,
+  testConnection,
+  stepNumber,
+  stepDescription,
+}: Props) {
+  const showDiagnosisOutput = !!diagnosis || attempt.status === 'failed';
+
+  let $diagnosisStateComponent;
+  if (attempt.status === 'processing') {
+    $diagnosisStateComponent = (
+      <TextIcon>
+        <Icons.Restore fontSize={4} />
+        Testing in-progress
+      </TextIcon>
+    );
+  } else if (attempt.status === 'failed' || (diagnosis && !diagnosis.success)) {
+    $diagnosisStateComponent = (
+      <TextIcon>
+        <Icons.Warning ml={1} color="danger" />
+        Testing failed
+      </TextIcon>
+    );
+  } else if (attempt.status === 'success' && diagnosis?.success) {
+    $diagnosisStateComponent = (
+      <TextIcon>
+        <Icons.CircleCheck ml={1} color="success" />
+        Testing complete
+      </TextIcon>
+    );
+  }
+
+  return (
+    <StyledBox mb={5}>
+      <Text bold>Step {stepNumber}</Text>
+      <Text typography="subtitle1" mb={3}>
+        {stepDescription}
+      </Text>
+      <Flex alignItems="center" mt={3}>
+        {canTestConnection ? (
+          <>
+            <ButtonSecondary
+              width="200px"
+              onClick={testConnection}
+              disabled={attempt.status === 'processing'}
+            >
+              {diagnosis ? 'Restart Test' : 'Test Connection'}
+            </ButtonSecondary>
+            <Box ml={4}>{$diagnosisStateComponent}</Box>
+          </>
+        ) : (
+          <Box>
+            <Text>
+              You don't have permission to test connection.
+              <br />
+              Please ask your Teleport administrator to update your role and add
+              the <Mark>connection_diagnostic</Mark> rule:
+            </Text>
+            <YamlReader traitKind="ConnDiag" />
+          </Box>
+        )}
+      </Flex>
+      {showDiagnosisOutput && (
+        <Box mt={3}>
+          {attempt.status === 'failed' &&
+            `Encountered Error: ${attempt.statusText}`}
+          {attempt.status === 'success' && (
+            <Box>
+              {diagnosis.traces.map((trace, index) => {
+                if (trace.status === 'failed') {
+                  return (
+                    <ErrorWithDetails
+                      error={trace.error}
+                      details={trace.details}
+                      key={index}
+                    />
+                  );
+                }
+                if (trace.status === 'success') {
+                  return (
+                    <TextIcon key={index} css={{ alignItems: 'baseline' }}>
+                      <Icons.CircleCheck mr={1} color="success" />
+                      {trace.details}
+                    </TextIcon>
+                  );
+                }
+
+                // For whatever reason the status is not the value
+                // of failed or success.
+                return (
+                  <TextIcon key={index}>
+                    <Icons.Question mr={1} />
+                    {trace.details}
+                  </TextIcon>
+                );
+              })}
+            </Box>
+          )}
+        </Box>
+      )}
+    </StyledBox>
+  );
+}
+
+const ErrorWithDetails = ({
+  details,
+  error,
+}: {
+  details: string;
+  error: string;
+}) => {
+  const [showMore, setShowMore] = useState(false);
+  return (
+    <TextIcon css={{ alignItems: 'baseline' }}>
+      <Icons.CircleCross mr={1} color="danger" />
+      <div>
+        <div>{details}</div>
+        <div>
+          <ButtonShowMore onClick={() => setShowMore(p => !p)}>
+            {showMore ? 'Hide' : 'Click for extra'} details
+          </ButtonShowMore>
+          {showMore && <div>{error}</div>}
+        </div>
+      </div>
+    </TextIcon>
+  );
+};
+
+const StyledBox = styled(Box)`
+  max-width: 800px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 20px;
+`;
+
+const ButtonShowMore = styled(ButtonText)`
+  min-height: auto;
+  padding: 0;
+  font-weight: inherit;
+  text-decoration: underline;
+`;
+
+export type Props = {
+  attempt: Attempt;
+  diagnosis: ConnectionDiagnostic;
+  canTestConnection: boolean;
+  testConnection(): void;
+  stepNumber: number;
+  stepDescription: string;
+};

--- a/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/index.ts
+++ b/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/index.ts
@@ -14,17 +14,5 @@
  * limitations under the License.
  */
 
-export { ActionButtons } from './ActionButtons';
-export { ButtonBlueText } from './ButtonBlueText';
-export { Header, HeaderSubtitle, HeaderWithBackBtn } from './Header';
-export { Finished } from './Finished';
-export { Mark } from './Mark';
-export { ReadOnlyYamlEditor } from './YAML';
-export { ResourceKind } from './ResourceKind';
-export { Step, StepContainer } from './Step';
-export { TextBox, TextIcon } from './Text';
-export { LabelsCreater } from './LabelsCreater';
-export {
-  ConnectionDiagnosticResult,
-  useConnectionDiagnostic,
-} from './ConnectionDiagnostic';
+export { ConnectionDiagnosticResult } from './ConnectionDiagnosticResult';
+export { useConnectionDiagnostic } from './useConnectionDiagnostic';

--- a/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/useConnectionDiagnostic.ts
+++ b/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/useConnectionDiagnostic.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2022 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+import useAttempt from 'shared/hooks/useAttemptNext';
+
+import useTeleport from 'teleport/useTeleport';
+
+import type {
+  ConnectionDiagnostic,
+  ConnectionDiagnosticRequest,
+} from 'teleport/services/agents';
+
+import type { AgentStepProps } from '../../types';
+
+export function useConnectionDiagnostic(props: AgentStepProps) {
+  const ctx = useTeleport();
+
+  const { attempt, run } = useAttempt('');
+  const [diagnosis, setDiagnosis] = useState<ConnectionDiagnostic>();
+
+  const access = ctx.storeUser.getConnectionDiagnosticAccess();
+  const canTestConnection = access.create && access.edit && access.read;
+
+  function runConnectionDiagnostic(req: ConnectionDiagnosticRequest) {
+    setDiagnosis(null); // reset since user's can re-test connection.
+    run(() =>
+      ctx.agentService.createConnectionDiagnostic(req).then(setDiagnosis)
+    );
+  }
+
+  const { username, authType } = ctx.storeUser.state;
+
+  return {
+    attempt,
+    runConnectionDiagnostic,
+    diagnosis,
+    nextStep: props.nextStep,
+    prevStep: props.prevStep,
+    canTestConnection,
+    username,
+    authType,
+    clusterId: ctx.storeUser.getClusterId(),
+  };
+}
+
+export type State = ReturnType<typeof useConnectionDiagnostic>;


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/16858

#### Description
- extract common logic used throughout all resource test connection screens 
- reorganized story
- refactored existing screens
- tentatively implement the database test connection screen (backend is still unfinished)

#### Figma Design
https://www.figma.com/file/8DQZl1mYUPLgvKgmA6zPOM/In-Progress-Work?node-id=1315%3A70746&t=MKwOH53cFBLIV3FK-0

#### Screenshot
<img width="826" alt="image" src="https://user-images.githubusercontent.com/43280172/202973359-8b92d8f0-15b7-4008-9fd3-0e332b907b79.png">
