### PR TITLE
Fix large file corruption

### DIFF
--- a/packages/teleport/src/lib/tdp/sharedDirectoryManager.ts
+++ b/packages/teleport/src/lib/tdp/sharedDirectoryManager.ts
@@ -143,7 +143,7 @@ export class SharedDirectoryManager {
   async writeFile(
     path: string,
     offset: bigint,
-    writeData: Uint8Array
+    data: Uint8Array
   ): Promise<number> {
     this.checkReady();
 
@@ -152,14 +152,11 @@ export class SharedDirectoryManager {
       throw new Error('cannot read the bytes of a directory');
     }
 
-    const file = await fileHandle.createWritable();
-    if (offset > 0) {
-      file.seek(Number(offset));
-    }
-    file.write(writeData);
+    const file = await fileHandle.createWritable({keepExistingData: true});
+    file.write({ type: "write", position: Number(offset), data })
     file.close(); // Needed to actually write data to disk.
 
-    return writeData.length;
+    return data.length;
   }
 
   /**

--- a/packages/teleport/src/lib/tdp/sharedDirectoryManager.ts
+++ b/packages/teleport/src/lib/tdp/sharedDirectoryManager.ts
@@ -152,8 +152,8 @@ export class SharedDirectoryManager {
       throw new Error('cannot read the bytes of a directory');
     }
 
-    const file = await fileHandle.createWritable({keepExistingData: true});
-    file.write({ type: "write", position: Number(offset), data })
+    const file = await fileHandle.createWritable({ keepExistingData: true });
+    file.write({ type: 'write', position: Number(offset), data });
     file.close(); // Needed to actually write data to disk.
 
     return data.length;


### PR DESCRIPTION
Previously we were calling `fileHandle.createWritable()` without any options, meaning that every time we wrote to a file during directory sharing it was being overwritten:

> keepExistingData: If false or not specified, the temporary file starts out empty, otherwise the existing file is first copied to this temporary file.

(quote from [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createWritable))

I managed to overlook this during manual testing because I was primarily using smaller files which are written in a single message. However in the case of larger files, which are written over the course of several messages (with an incrementing `offset`), this was causing us to erase the file on each write message. In effect, we'd only save the the last write message of the sequence, and everything before that final message's `offset` would get zeroed out.

fixes https://github.com/gravitational/teleport/issues/18534
