### PR TITLE
Display `verb`, `request_path` & `response_code` in `kube.request` events

### DIFF
--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -3495,7 +3495,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [alex] made a request to kubernetes cluster [gke_teleport-a]
+          User [alex] received a [200] from a [GET /api/v1/namespaces/teletest/pods/test-pod] request to kubernetes cluster [gke_teleport-a]
         </td>
         <td
           style="min-width: 120px;"

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -685,8 +685,8 @@ export const formatters: Formatters = {
   [eventCodes.KUBE_REQUEST]: {
     type: 'kube.request',
     desc: 'Kubernetes Request',
-    format: ({ user, kubernetes_cluster }) =>
-      `User [${user}] made a request to kubernetes cluster [${kubernetes_cluster}]`,
+    format: ({ user, kubernetes_cluster, verb, request_path, response_code }) =>
+      `User [${user}] received a [${response_code}] from a [${verb} ${request_path}] request to kubernetes cluster [${kubernetes_cluster}]`,
   },
   [eventCodes.KUBE_CREATED]: {
     type: 'kube.create',

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -566,6 +566,9 @@ export type RawEvents = {
     typeof eventCodes.KUBE_REQUEST,
     {
       kubernetes_cluster: string;
+      verb: string,
+      request_path: string,
+      response_code: string,
     }
   >;
   [eventCodes.KUBE_CREATED]: RawEvent<

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -566,9 +566,9 @@ export type RawEvents = {
     typeof eventCodes.KUBE_REQUEST,
     {
       kubernetes_cluster: string;
-      verb: string,
-      request_path: string,
-      response_code: string,
+      verb: string;
+      request_path: string;
+      response_code: string;
     }
   >;
   [eventCodes.KUBE_CREATED]: RawEvent<


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/16973.

This commit eases the navigation through the audit log by not requiring a click on the `kube.request` event to see all details about it.

<img width="1435" alt="Screenshot 2022-11-28 at 14 23 40" src="https://user-images.githubusercontent.com/4520516/204301448-9166a978-965e-435a-84ab-62ddebb11d49.png">
<img width="901" alt="Screenshot 2022-11-28 at 14 23 29" src="https://user-images.githubusercontent.com/4520516/204301509-3121ff8b-b975-47e6-a7d0-b31ffef61e83.png">
