### PR TITLE
[v9] Display `verb`, `request_path` & `response_code` in `kube.request` events

### DIFF
--- a/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -2494,7 +2494,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [alex] made a request to kubernetes cluster [gke_teleport-a]
+          User [alex] received a [200] from a [GET /api/v1/namespaces/teletest/pods/test-pod] request to kubernetes cluster [gke_teleport-a]
         </td>
         <td
           style="min-width: 120px;"

--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -640,8 +640,8 @@ export const formatters: Formatters = {
   [eventCodes.KUBE_REQUEST]: {
     type: 'kube.request',
     desc: 'Kubernetes Request',
-    format: ({ user, kubernetes_cluster }) =>
-      `User [${user}] made a request to kubernetes cluster [${kubernetes_cluster}]`,
+    format: ({ user, kubernetes_cluster, verb, request_path, response_code }) =>
+      `User [${user}] received a [${response_code}] from a [${verb} ${request_path}] request to kubernetes cluster [${kubernetes_cluster}]`,
   },
   [eventCodes.DATABASE_SESSION_STARTED]: {
     type: 'db.session.start',

--- a/packages/teleport/src/services/audit/types.ts
+++ b/packages/teleport/src/services/audit/types.ts
@@ -507,6 +507,9 @@ export type RawEvents = {
     typeof eventCodes.KUBE_REQUEST,
     {
       kubernetes_cluster: string;
+      verb: string;
+      request_path: string;
+      response_code: string;
     }
   >;
   [eventCodes.DATABASE_SESSION_STARTED]: RawEvent<


### PR DESCRIPTION
Backport #1384 to teleport-v9