### PR TITLE
Fix alerts from not disappearing on route changes

### DIFF
--- a/packages/teleport/src/components/BannerList/useAlerts.tsx
+++ b/packages/teleport/src/components/BannerList/useAlerts.tsx
@@ -24,7 +24,7 @@ import type { ClusterAlert } from 'teleport/services/alerts';
 
 const logger = Logger.create('ClusterAlerts');
 
-const DISABLED_BANNERS = 'disabledAlerts';
+const DISABLED_ALERTS = 'disabledAlerts';
 const MS_HOUR = 60 * 60 * 1000;
 
 export function addHours(date: number, hours: number) {
@@ -40,16 +40,16 @@ function setItem(key: string, data: string) {
 }
 
 type DismissedAlert = {
-  [alertName: string]: string;
+  [alertName: string]: number;
 };
 
 export function useAlerts(initialAlerts: ClusterAlert[] = []) {
   const [alerts, setAlerts] = useState<ClusterAlert[]>(initialAlerts);
-  const [dismissedAlerts, setDismissedAlerts] = useState<DismissedAlert[]>([]);
+  const [dismissedAlerts, setDismissedAlerts] = useState<DismissedAlert>({});
   const { clusterId } = useStickyClusterId();
 
   useEffect(() => {
-    const disabledAlerts = getItem(DISABLED_BANNERS);
+    const disabledAlerts = getItem(DISABLED_ALERTS);
     if (disabledAlerts) {
       // Loop through the existing ones and remove those that have passed 24h.
       const data = JSON.parse(disabledAlerts);
@@ -59,7 +59,7 @@ export function useAlerts(initialAlerts: ClusterAlert[] = []) {
         }
       });
       setDismissedAlerts(data);
-      setItem(DISABLED_BANNERS, JSON.stringify(data));
+      setItem(DISABLED_ALERTS, JSON.stringify(data));
     }
   }, []);
 
@@ -77,13 +77,14 @@ export function useAlerts(initialAlerts: ClusterAlert[] = []) {
   }, [clusterId]);
 
   function dismissAlert(name: string) {
-    const disabledAlerts = getItem(DISABLED_BANNERS);
-    let data = {};
+    const disabledAlerts = getItem(DISABLED_ALERTS);
+    let data: DismissedAlert = {};
     if (disabledAlerts) {
       data = JSON.parse(disabledAlerts);
     }
     data[name] = addHours(new Date().getTime(), 24);
-    setItem(DISABLED_BANNERS, JSON.stringify(data));
+    setDismissedAlerts(data);
+    setItem(DISABLED_ALERTS, JSON.stringify(data));
   }
 
   const dismissedAlertNames = Object.keys(dismissedAlerts);

--- a/packages/teleport/src/components/BannerList/useAlerts.tsx
+++ b/packages/teleport/src/components/BannerList/useAlerts.tsx
@@ -39,21 +39,21 @@ function setItem(key: string, data: string) {
   window.localStorage.setItem(key, data);
 }
 
-type DismissedAlert = {
+type DismissedAlerts = {
   [alertName: string]: number;
 };
 
 export function useAlerts(initialAlerts: ClusterAlert[] = []) {
   const [alerts, setAlerts] = useState<ClusterAlert[]>(initialAlerts);
-  const [dismissedAlerts, setDismissedAlerts] = useState<DismissedAlert>({});
+  const [dismissedAlerts, setDismissedAlerts] = useState<DismissedAlerts>({});
   const { clusterId } = useStickyClusterId();
 
   useEffect(() => {
     const disabledAlerts = getItem(DISABLED_ALERTS);
     if (disabledAlerts) {
       // Loop through the existing ones and remove those that have passed 24h.
-      const data = JSON.parse(disabledAlerts);
-      Object.entries(data).forEach(([name, expiry]: [string, string]) => {
+      const data: DismissedAlerts = JSON.parse(disabledAlerts);
+      Object.entries(data).forEach(([name, expiry]) => {
         if (new Date().getTime() > +expiry) {
           delete data[name];
         }
@@ -78,7 +78,7 @@ export function useAlerts(initialAlerts: ClusterAlert[] = []) {
 
   function dismissAlert(name: string) {
     const disabledAlerts = getItem(DISABLED_ALERTS);
-    let data: DismissedAlert = {};
+    let data: DismissedAlerts = {};
     if (disabledAlerts) {
       data = JSON.parse(disabledAlerts);
     }

--- a/packages/teleport/src/services/alerts/alerts.tsx
+++ b/packages/teleport/src/services/alerts/alerts.tsx
@@ -25,8 +25,8 @@ export type ClusterAlert = {
   metadata: {
     name: string;
     labels: { [key: string]: string }; //"teleport.internal/alert-on-login": "yes",
+    expires: string; //2022-08-31T17:26:05.728149Z
   };
-  expires: string; //2022-08-31T17:26:05.728149Z
   spec: {
     severity: number;
     message: string;


### PR DESCRIPTION
This will partly fix https://github.com/gravitational/teleport/issues/17670

> We UI alert banner dismissal is currently bugged. After clicking the x button on the alert, it reappears whenever you switch to a different page (e.g. clicking over from Servers to Applications).

Previously:

https://user-images.githubusercontent.com/7922109/204788037-27040182-9a41-4d53-89e9-75f22c45084c.mp4

After:

https://user-images.githubusercontent.com/7922109/204788616-41978d79-12ce-4ad9-8b07-d1423f3d09c7.mp4

The `dismissedAlerts` state was not being updated when an alert is dismissed, so it wouldn't be filtered out the next time `useAlerts` was called (on a route change), so this changes that.

For some reason the state was using `DismissedAlert[]`, but `DismissedAlert` (now `DismissedAlerts`) is an object which contains all the dismissed alerts. I've changed the name and fixed the typings.

Also, `expires` wasn't set correctly in the `ClusterAlert` type - this property is inside `metadata`, so I've moved it accordingly.