### PR TITLE
Lazy load Telemetry only when needed

### DIFF
--- a/packages/teleport/src/boot.tsx
+++ b/packages/teleport/src/boot.tsx
@@ -21,7 +21,6 @@ import history from 'teleport/services/history';
 
 import Teleport from './Teleport';
 import TeleportContext from './teleportContext';
-import { instantiateTelemetry } from './telemetry-boot';
 import cfg from './config';
 
 // apply configuration received from the server
@@ -31,7 +30,9 @@ cfg.init(window['GRV_CONFIG']);
 history.init();
 
 if (localStorage.getItem('enable-telemetry') === 'true') {
-  instantiateTelemetry();
+  import(/* webpackChunkName: "telemetry" */ './telemetry-boot').then(m =>
+    m.instantiateTelemetry()
+  );
 }
 
 const teleportContext = new TeleportContext();


### PR DESCRIPTION
The introduction of https://github.com/gravitational/webapps/pull/1361 caused our main production entry bundle (the JS the user loads when first opening teleport) to increase by 152 KiB, a 30% increase.

Before the PR:
![image](https://user-images.githubusercontent.com/7922109/204799387-8d617afb-4eba-405c-8520-2028de5bcde7.png)

After the PR:
![image](https://user-images.githubusercontent.com/7922109/204798439-5e50e6ae-d462-44a9-9693-1cfaca4b0c43.png)

This changes the code to only import the `telemetry-boot` file, which in turn includes 13 Telemetry packages, when needed (the user has set `enable-telemetry` to `true` in local storage and refreshed the page).

After this change:
![image](https://user-images.githubusercontent.com/7922109/204798768-ed165aa7-eb19-40e4-9d4d-8741f380e842.png)

This will also make the time to first render faster for those that have enabled telemetry, as the telemetry instantiation is no longer blocking React from rendering the app.
