### PR TITLE
[Connect] Async autocomplete

### DIFF
--- a/packages/teleterm/src/services/tshd/createClient.ts
+++ b/packages/teleterm/src/services/tshd/createClient.ts
@@ -65,7 +65,7 @@ export default function createClient(
     async getKubes({
       clusterUri,
       search,
-      sort,
+      sort = { fieldName: 'name', dir: 'ASC' },
       query,
       searchAsRoles,
       startKey,
@@ -145,7 +145,7 @@ export default function createClient(
     async getDatabases({
       clusterUri,
       search,
-      sort,
+      sort = { fieldName: 'name', dir: 'ASC' },
       query,
       searchAsRoles,
       startKey,
@@ -228,7 +228,7 @@ export default function createClient(
       clusterUri,
       search,
       query,
-      sort,
+      sort = { fieldName: 'hostname', dir: 'ASC' },
       searchAsRoles,
       startKey,
       limit,

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
@@ -19,6 +19,7 @@ import styled from 'styled-components';
 import { debounce } from 'lodash';
 import { Box, Flex } from 'design';
 import { color, height, space, width } from 'styled-system';
+import { Spinner } from 'design/Icon';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 
@@ -163,12 +164,17 @@ function QuickInput() {
         onKeyDown={handleKeyDown}
         isOpened={visible}
       />
+      {autocompleteAttempt.status === 'processing' && (
+        <Animate>
+          <Spinner />
+        </Animate>
+      )}
       {!visible && <Shortcut>{props.keyboardShortcut}</Shortcut>}
       {visible && hasSuggestions && (
         <QuickInputList
           ref={refList}
           position={measuredInputTextWidth}
-          items={autocompleteResult.suggestions}
+          items={autocompleteAttempt.data}
           activeItem={activeSuggestion}
           onPick={props.onEnter}
         />
@@ -233,6 +239,24 @@ const Shortcut = styled(Box)`
   line-height: 12px;
   font-size: 12px;
   border-radius: 2px;
+`;
+
+const Animate = styled(Box)`
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  padding: 2px 2px;
+  line-height: 12px;
+  font-size: 12px;
+  animation: spin 1s linear infinite;
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
 `;
 
 const KeyEnum = {

--- a/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
+++ b/packages/teleterm/src/ui/QuickInput/QuickInput.tsx
@@ -38,9 +38,10 @@ export default function Container() {
 
 function QuickInput() {
   const props = useQuickInput();
-  const { visible, activeSuggestion, autocompleteResult, inputValue } = props;
+  const { visible, activeSuggestion, autocompleteAttempt, inputValue } = props;
   const hasSuggestions =
-    autocompleteResult.kind === 'autocomplete.partial-match';
+    autocompleteAttempt.data?.length > 0 &&
+    autocompleteAttempt.status === 'success';
   const refInput = useRef<HTMLInputElement>();
   const measuringInputRef = useRef<HTMLSpanElement>();
   const refList = useRef<HTMLElement>();
@@ -52,7 +53,7 @@ function QuickInput() {
     return debounce(() => {
       props.onInputChange(refInput.current.value);
       measureInputTextWidth();
-    }, 100);
+    }, 200);
   }, []);
 
   // Update input value if it changed outside of this component. This happens when the user pick an
@@ -96,7 +97,7 @@ function QuickInput() {
     }
     const next = getNext(
       activeSuggestion + nudge,
-      autocompleteResult.suggestions.length
+      autocompleteAttempt.data?.length
     );
     props.onActiveSuggestion(next);
   };

--- a/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
+++ b/packages/teleterm/src/ui/QuickInput/useQuickInput.ts
@@ -16,34 +16,63 @@ limitations under the License.
 
 import React, { useEffect } from 'react';
 
+import { useAsync } from 'shared/hooks/useAsync';
+
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import {
   useKeyboardShortcuts,
   useKeyboardShortcutFormatters,
 } from 'teleterm/ui/services/keyboardShortcuts';
 import {
-  AutocompleteResult,
-  AutocompletePartialMatch,
+  AutocompleteCommand,
+  AutocompleteToken,
+  Suggestion,
 } from 'teleterm/ui/services/quickInput/types';
 import { routing } from 'teleterm/ui/uri';
 import { KeyboardShortcutType } from 'teleterm/services/config';
 
+import { retryWithRelogin } from '../utils';
+
 export default function useQuickInput() {
-  const { quickInputService, workspacesService, commandLauncher } =
-    useAppContext();
+  const appContext = useAppContext();
+  const { quickInputService, workspacesService, commandLauncher } = appContext;
   workspacesService.useState();
   const documentsService =
     workspacesService.getActiveWorkspaceDocumentService();
   const { visible, inputValue } = quickInputService.useState();
   const [activeSuggestion, setActiveSuggestion] = React.useState(0);
-  const autocompleteResult = React.useMemo(
-    () => quickInputService.getAutocompleteResult(inputValue),
+
+  const parseResult = React.useMemo(
+    () => quickInputService.parse(inputValue),
     // `localClusterUri` has been added to refresh suggestions from
     // `QuickSshLoginPicker` and `QuickServerPicker` when it changes
     [inputValue, workspacesService.getActiveWorkspace()?.localClusterUri]
   );
+
+  const [suggestionsAttempt, getSuggestions] = useAsync(() =>
+    retryWithRelogin(
+      appContext,
+      workspacesService.getActiveWorkspace()?.localClusterUri,
+      () => parseResult.getSuggestions()
+    )
+  );
+
+  useEffect(() => {
+    if (suggestionsAttempt.status === 'error') {
+      appContext.notificationsService.notifyError({
+        title: 'Error fetching suggestions.',
+        description: suggestionsAttempt.statusText,
+      });
+    }
+  }, [suggestionsAttempt.status]);
+
+  React.useEffect(() => {
+    getSuggestions();
+  }, [parseResult]);
+
   const hasSuggestions =
-    autocompleteResult.kind === 'autocomplete.partial-match';
+    suggestionsAttempt.status === 'success' &&
+    suggestionsAttempt.data.length > 0;
   const openQuickInputShortcutKey: KeyboardShortcutType = 'open-quick-input';
   const { getShortcut } = useKeyboardShortcutFormatters();
 
@@ -62,18 +91,14 @@ export default function useQuickInput() {
 
   const onEnter = (index?: number) => {
     if (!hasSuggestions || !visible) {
-      executeCommand(autocompleteResult);
+      executeCommand(parseResult.command);
       return;
     }
 
-    // Passing `autocompleteResult` directly to narrow down AutocompleteResult type to
-    // AutocompletePartialMatch.
-    pickSuggestion(autocompleteResult, index);
+    pickSuggestion(parseResult.targetToken, suggestionsAttempt.data, index);
   };
 
-  const executeCommand = (autocompleteResult: AutocompleteResult) => {
-    const { command } = autocompleteResult;
-
+  const executeCommand = (command: AutocompleteCommand) => {
     switch (command.kind) {
       case 'command.unknown': {
         const params = routing.parseClusterUri(
@@ -103,18 +128,17 @@ export default function useQuickInput() {
   };
 
   const pickSuggestion = (
-    autocompleteResult: AutocompletePartialMatch,
+    targetToken: AutocompleteToken,
+    suggestions: Suggestion[],
     index?: number
   ) => {
-    const suggestion = autocompleteResult.suggestions[index];
+    const suggestion = suggestions[index];
 
     setActiveSuggestion(index);
-    quickInputService.pickSuggestion(
-      autocompleteResult.targetToken,
-      suggestion
-    );
+    quickInputService.pickSuggestion(targetToken, suggestion);
   };
 
+  // TODO: Find a better name for this function.
   const onBack = () => {
     setActiveSuggestion(0);
 
@@ -136,18 +160,18 @@ export default function useQuickInput() {
   // Reset active suggestion when the suggestion list changes.
   // We extract just the tokens and stringify the list to avoid stringifying big objects.
   // See https://github.com/facebook/react/issues/14476#issuecomment-471199055
+  // TODO: It's another action we should perform after the input has changed.
   useEffect(() => {
     setActiveSuggestion(0);
   }, [
-    hasSuggestions &&
-      JSON.stringify(
-        autocompleteResult.suggestions.map(suggestion => suggestion.token)
-      ),
+    // We want to reset the active suggestion only between successful attempts and only if the
+    // suggestions didn't change.
+    suggestionsAttempt.data?.map(suggestion => suggestion.token).join(','),
   ]);
 
   return {
     visible,
-    autocompleteResult,
+    autocompleteAttempt: suggestionsAttempt,
     activeSuggestion,
     inputValue,
     onFocus,

--- a/packages/teleterm/src/ui/appContext.ts
+++ b/packages/teleterm/src/ui/appContext.ts
@@ -78,6 +78,7 @@ export default class AppContext implements IAppContext {
     this.quickInputService = new QuickInputService(
       this.commandLauncher,
       this.clustersService,
+      this.resourcesService,
       this.workspacesService
     );
 

--- a/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickInputService.ts
@@ -17,11 +17,12 @@ limitations under the License.
 import { Store, useStore } from 'shared/libs/stores';
 
 import { CommandLauncher } from 'teleterm/ui/commandLauncher';
-import { ClustersService } from 'teleterm/ui/services/clusters';
 import { WorkspacesService } from 'teleterm/ui/services/workspacesService';
+import { ResourcesService } from 'teleterm/ui/services/resources';
+import { ClustersService } from 'teleterm/ui/services/clusters';
 
 import * as pickers from './quickPickers';
-import { AutocompleteResult, AutocompleteToken, Suggestion } from './types';
+import { AutocompleteToken, ParseResult, Suggestion } from './types';
 
 type State = {
   inputValue: string;
@@ -29,41 +30,42 @@ type State = {
 };
 
 export class QuickInputService extends Store<State> {
-  private quickCommandPicker: pickers.QuickCommandPicker;
+  private quickCommandParser: pickers.QuickCommandParser;
   lastFocused: WeakRef<HTMLElement>;
 
   constructor(
     launcher: CommandLauncher,
     clustersService: ClustersService,
+    resourcesService: ResourcesService,
     workspacesService: WorkspacesService
   ) {
     super();
     this.lastFocused = new WeakRef(document.createElement('div'));
-    this.quickCommandPicker = new pickers.QuickCommandPicker(this, launcher);
+    this.quickCommandParser = new pickers.QuickCommandParser(launcher);
     this.setState({
       inputValue: '',
     });
 
-    const sshLoginPicker = new pickers.QuickSshLoginPicker(
+    const sshLoginSuggester = new pickers.QuickSshLoginSuggester(
       workspacesService,
       clustersService
     );
-    const serverPicker = new pickers.QuickServerPicker(
+    const serverSuggester = new pickers.QuickServerSuggester(
       workspacesService,
-      clustersService
+      resourcesService
     );
-    const databasePicker = new pickers.QuickDatabasePicker(
+    const databaseSuggester = new pickers.QuickDatabaseSuggester(
       workspacesService,
-      clustersService
+      resourcesService
     );
 
-    this.quickCommandPicker.registerPickerForCommand(
+    this.quickCommandParser.registerParserForCommand(
       'tsh ssh',
-      new pickers.QuickTshSshPicker(sshLoginPicker, serverPicker)
+      new pickers.QuickTshSshParser(sshLoginSuggester, serverSuggester)
     );
-    this.quickCommandPicker.registerPickerForCommand(
+    this.quickCommandParser.registerParserForCommand(
       'tsh proxy db',
-      new pickers.QuickTshProxyDbPicker(databasePicker)
+      new pickers.QuickTshProxyDbParser(databaseSuggester)
     );
   }
 
@@ -99,31 +101,25 @@ export class QuickInputService extends Store<State> {
   // Parses the input string and returns AutocompleteResult which includes information about which
   // token we currently show the autocomplete for and what are the autocomplete suggestions (items)
   // to show.
-  //
-  // TODO(ravicious): This function needs to take cursor index into account instead of assuming that
-  // you want to complete only what's at the end of the input string.
-  getAutocompleteResult(input: string): AutocompleteResult {
-    const autocompleteResult =
-      this.quickCommandPicker.getAutocompleteResult(input);
+  parse(input: string): ParseResult {
+    const parseResult = this.quickCommandParser.parse(input);
 
-    // Automatically handle some universal edge cases so that each individual picker doesn't have to
-    // care about them.
-    if (autocompleteResult.kind === 'autocomplete.partial-match') {
-      const { targetToken, suggestions } = autocompleteResult;
-      const isEmpty = suggestions.length === 0;
-      // Don't show suggestions if the only suggestion completely matches the target token.
-      const hasSingleCompleteMatch =
-        suggestions.length === 1 && suggestions[0].token === targetToken.value;
+    // Automatically handle a universal edge case so that each individual suggester doesn't have to
+    // care about it.
+    const getSuggestionsThenHandleEdgeCase = () =>
+      parseResult.getSuggestions().then(suggestions => {
+        // Don't show suggestions if the only suggestion completely matches the target token.
+        const hasSingleCompleteMatch =
+          suggestions.length === 1 &&
+          suggestions[0].token === parseResult.targetToken.value;
 
-      if (isEmpty || hasSingleCompleteMatch) {
-        return {
-          kind: 'autocomplete.no-match',
-          command: autocompleteResult.command,
-        };
-      }
-    }
+        return hasSingleCompleteMatch ? [] : suggestions;
+      });
 
-    return autocompleteResult;
+    return {
+      ...parseResult,
+      getSuggestions: getSuggestionsThenHandleEdgeCase,
+    };
   }
 
   // Replaces the token that is being autocompleted with the token from the suggestion.

--- a/packages/teleterm/src/ui/services/quickInput/quickPickers.test.ts
+++ b/packages/teleterm/src/ui/services/quickInput/quickPickers.test.ts
@@ -1,4 +1,4 @@
-import { QuickSshLoginPicker, QuickServerPicker } from './quickPickers';
+import { QuickSshLoginSuggester, QuickServerSuggester } from './quickPickers';
 
 // Jest doesn't let us selectively automock classes. See https://github.com/facebook/jest/issues/11995
 //
@@ -10,49 +10,49 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-test("tsh ssh picker returns unknown command if it's missing the first positional arg", () => {
-  const QuickSshLoginPickerMock = QuickSshLoginPicker as jest.MockedClass<
-    typeof QuickSshLoginPicker
+test("tsh ssh picker returns unknown command if it's missing the first positional arg", async () => {
+  const QuickSshLoginSuggesterMock = QuickSshLoginSuggester as jest.MockedClass<
+    typeof QuickSshLoginSuggester
   >;
-  const QuickServerPickerMock = QuickServerPicker as jest.MockedClass<
-    typeof QuickServerPicker
+  const QuickServerSuggesterMock = QuickServerSuggester as jest.MockedClass<
+    typeof QuickServerSuggester
   >;
-  const ActualQuickTshSshPicker =
-    jest.requireActual('./quickPickers').QuickTshSshPicker;
+  const ActualQuickTshSshParser =
+    jest.requireActual('./quickPickers').QuickTshSshParser;
 
-  const picker = new ActualQuickTshSshPicker(
-    new QuickSshLoginPickerMock(undefined, undefined),
-    new QuickServerPickerMock(undefined, undefined)
+  const parser = new ActualQuickTshSshParser(
+    new QuickSshLoginSuggesterMock(undefined, undefined),
+    new QuickServerSuggesterMock(undefined, undefined)
   );
 
-  const emptyInput = picker.getAutocompleteResult('', 0);
+  const emptyInput = await parser.parse('', 0);
   expect(emptyInput.command).toEqual({ kind: 'command.unknown' });
 
-  const whitespace = picker.getAutocompleteResult(' ', 0);
+  const whitespace = await parser.parse(' ', 0);
   expect(whitespace.command).toEqual({ kind: 'command.unknown' });
 });
 
-test('tsh ssh picker returns unknown command if the input includes any additional flags', () => {
-  const QuickSshLoginPickerMock = QuickSshLoginPicker as jest.MockedClass<
-    typeof QuickSshLoginPicker
+test('tsh ssh picker returns unknown command if the input includes any additional flags', async () => {
+  const QuickSshLoginSuggesterMock = QuickSshLoginSuggester as jest.MockedClass<
+    typeof QuickSshLoginSuggester
   >;
-  const QuickServerPickerMock = QuickServerPicker as jest.MockedClass<
-    typeof QuickServerPicker
+  const QuickServerSuggesterMock = QuickServerSuggester as jest.MockedClass<
+    typeof QuickServerSuggester
   >;
-  const ActualQuickTshSshPicker =
-    jest.requireActual('./quickPickers').QuickTshSshPicker;
+  const ActualQuickTshSshParser =
+    jest.requireActual('./quickPickers').QuickTshSshParser;
 
-  const picker = new ActualQuickTshSshPicker(
-    new QuickSshLoginPickerMock(undefined, undefined),
-    new QuickServerPickerMock(undefined, undefined)
+  const parser = new ActualQuickTshSshParser(
+    new QuickSshLoginSuggesterMock(undefined, undefined),
+    new QuickServerSuggesterMock(undefined, undefined)
   );
 
-  const fullFlagBefore = picker.getAutocompleteResult('--foo user@node', 0);
+  const fullFlagBefore = await parser.parse('--foo user@node', 0);
   expect(fullFlagBefore.command).toEqual({ kind: 'command.unknown' });
 
-  const shortFlagBefore = picker.getAutocompleteResult('-p 22 user@node', 0);
+  const shortFlagBefore = await parser.parse('-p 22 user@node', 0);
   expect(shortFlagBefore.command).toEqual({ kind: 'command.unknown' });
 
-  const commandAfter = picker.getAutocompleteResult('user@node ls', 0);
+  const commandAfter = await parser.parse('user@node ls', 0);
   expect(commandAfter.command).toEqual({ kind: 'command.unknown' });
 });

--- a/packages/teleterm/src/ui/services/quickInput/types.ts
+++ b/packages/teleterm/src/ui/services/quickInput/types.ts
@@ -30,33 +30,27 @@ export type Suggestion =
   | SuggestionServer
   | SuggestionDatabase;
 
-export type QuickInputPicker = {
-  getAutocompleteResult(input: string, startIndex: number): AutocompleteResult;
+export type QuickInputParser = {
+  parse(input: string, startIndex: number): ParseResult;
+};
+
+export type ParseResult = {
+  // Command includes the result of parsing whatever was parsed so far.
+  // This means that in case of `tsh ssh roo`, the command will say that we want to launch `tsh ssh`
+  // with `roo` as `loginHost`.
+  command: AutocompleteCommand;
+  readonly targetToken: AutocompleteToken;
+  getSuggestions(): Promise<Suggestion[]>;
+};
+
+export type QuickInputSuggester<SuggestionType extends Suggestion> = {
+  getSuggestions(filter: string): Promise<SuggestionType[]>;
 };
 
 export type AutocompleteToken = {
   value: string;
   startIndex: number;
 };
-
-type AutocompleteResultBase<T> = {
-  kind: T;
-  // Command includes the result of parsing whatever was parsed so far.
-  // This means that in case of `tsh ssh roo`, the command will say that we want to launch `tsh ssh`
-  // with `roo` as `loginHost`.
-  command: AutocompleteCommand;
-};
-
-export type AutocompletePartialMatch =
-  AutocompleteResultBase<'autocomplete.partial-match'> & {
-    suggestions: Suggestion[];
-    targetToken: AutocompleteToken;
-  };
-
-export type AutocompleteNoMatch =
-  AutocompleteResultBase<'autocomplete.no-match'>;
-
-export type AutocompleteResult = AutocompletePartialMatch | AutocompleteNoMatch;
 
 type CommandBase<T> = {
   kind: T;


### PR DESCRIPTION
After we [enabled serverside search](https://github.com/gravitational/webapps/pull/1307) in the resource tables, this basically "fixed" Connect to work with large clusters. The last chunk to fix was autocomplete because it still used the old paradigm of loading everything at the start and then client side filtering on input.

This PR updates the quickpickers to provide an interface for using serverside search results in the QuickInput. 

https://user-images.githubusercontent.com/5201977/205326673-427c32ad-377c-41d6-a8db-5c4fb86f354c.mov

I've opted for a spinner icon (where the shortcut key normally is) as the loading state, but this is just first pass. Other options would be showing the suggestion menu with skeleton data, or just the suggestion menu saying "loading..." or something. I think spinner looks best but I will not die on that hill. 