### PR TITLE
Connect: Tell fpm to not use symlinks when building the rpm package

### DIFF
--- a/packages/teleterm/README.md
+++ b/packages/teleterm/README.md
@@ -137,6 +137,9 @@ See [Teleport Connect build
 process](https://gravitational.slab.com/posts/teleport-connect-build-process-fu6da5ld) on Slab for
 bulid process documentation that is specific to Gravitational.
 
+### Linux
+To create RPM package for aarch64 target you need to provide `USE_SYSTEM_FPM=1` env var. 
+
 ### macOS
 
 To make a fully-fledged build on macOS with Touch ID support, you need two things:

--- a/packages/teleterm/README.md
+++ b/packages/teleterm/README.md
@@ -137,8 +137,15 @@ See [Teleport Connect build
 process](https://gravitational.slab.com/posts/teleport-connect-build-process-fu6da5ld) on Slab for
 bulid process documentation that is specific to Gravitational.
 
+### Native dependencies
+
+If node-pty doesn't provide precompiled binaries for your system and the specific Electron version,
+you will need to install [the dependencies required by
+node-pty](https://github.com/microsoft/node-pty#dependencies).
+
 ### Linux
-To create RPM package for aarch64 target you need to provide `USE_SYSTEM_FPM=1` env var. 
+
+To create RPM package for aarch64 target you need to provide `USE_SYSTEM_FPM=1` env var.
 
 ### macOS
 

--- a/packages/teleterm/electron-builder-config.js
+++ b/packages/teleterm/electron-builder-config.js
@@ -93,6 +93,9 @@ module.exports = {
   },
   rpm: {
     artifactName: '${name}-${version}.${arch}.${ext}',
+    // --rpm-rpmbuild-define "_build_id_links none" fixes the problem with not being able to install
+    // Connect's rpm next to other Electron apps.
+    // https://github.com/gravitational/teleport/issues/18859
     fpm: ['--rpm-rpmbuild-define', '_build_id_links none'],
   },
   deb: {

--- a/packages/teleterm/electron-builder-config.js
+++ b/packages/teleterm/electron-builder-config.js
@@ -93,6 +93,7 @@ module.exports = {
   },
   rpm: {
     artifactName: '${name}-${version}.${arch}.${ext}',
+    fpm: ['--rpm-rpmbuild-define', '_build_id_links none'],
   },
   deb: {
     artifactName: '${name}_${version}_${arch}.${ext}',


### PR DESCRIPTION
Fixes gravitational/teleport#18859.

Grzegorz added the flag but wasn't able to test this. I installed Fedora on my old Intel MBP, verified that Connect 11.1.0 can't be installed if Slack is already installed. Then I built a local version with this change, verified that it fixes the problem, then I built `11.1.2-dev.ravicious.1` and again verified that it works.