### PR TITLE
[v11] Connect: Tell fpm to not use symlinks when building the rpm package

### DIFF
--- a/packages/teleterm/README.md
+++ b/packages/teleterm/README.md
@@ -137,6 +137,16 @@ See [Teleport Connect build
 process](https://gravitational.slab.com/posts/teleport-connect-build-process-fu6da5ld) on Slab for
 bulid process documentation that is specific to Gravitational.
 
+### Native dependencies
+
+If node-pty doesn't provide precompiled binaries for your system and the specific Electron version,
+you will need to install [the dependencies required by
+node-pty](https://github.com/microsoft/node-pty#dependencies).
+
+### Linux
+
+To create an RPM package for an arm64 target you need to provide `USE_SYSTEM_FPM=1` env var.
+
 ### macOS
 
 To make a fully-fledged build on macOS with Touch ID support, you need two things:

--- a/packages/teleterm/electron-builder-config.js
+++ b/packages/teleterm/electron-builder-config.js
@@ -93,6 +93,10 @@ module.exports = {
   },
   rpm: {
     artifactName: '${name}-${version}.${arch}.${ext}',
+    // --rpm-rpmbuild-define "_build_id_links none" fixes the problem with not being able to install
+    // Connect's rpm next to other Electron apps.
+    // https://github.com/gravitational/teleport/issues/18859
+    fpm: ['--rpm-rpmbuild-define', '_build_id_links none'],
   },
   deb: {
     artifactName: '${name}_${version}_${arch}.${ext}',


### PR DESCRIPTION
Backport #1407.