### PR TITLE
[Discover] Database Tweaks and Add ons

### DIFF
--- a/packages/teleport/src/Databases/fixtures/index.ts
+++ b/packages/teleport/src/Databases/fixtures/index.ts
@@ -26,6 +26,7 @@ export const databases: Database[] = [
       { name: 'cluster', value: 'root' },
       { name: 'env', value: 'aws' },
     ],
+    hostname: 'aurora-hostname',
   },
   {
     name: 'postgres-gcp',
@@ -36,6 +37,7 @@ export const databases: Database[] = [
       { name: 'cluster', value: 'root' },
       { name: 'env', value: 'gcp' },
     ],
+    hostname: 'postgres-hostname',
   },
   {
     name: 'mysql-aurora-56',
@@ -46,5 +48,6 @@ export const databases: Database[] = [
       { name: 'cluster', value: 'root' },
       { name: 'env', value: 'aws' },
     ],
+    hostname: 'mysql-hostname',
   },
 ];

--- a/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
+++ b/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
@@ -31,6 +31,12 @@ export const Init = () => (
   </MemoryRouter>
 );
 
+export const NoPerm = () => (
+  <MemoryRouter>
+    <CreateDatabaseView {...props} canCreateDatabase={false} />
+  </MemoryRouter>
+);
+
 export const Processing = () => (
   <MemoryRouter>
     <CreateDatabaseView {...props} attempt={{ status: 'processing' }} />
@@ -49,4 +55,5 @@ export const Failed = () => (
 const props: State = {
   attempt: { status: '' },
   createDbAndQueryDb: () => null,
+  canCreateDatabase: true,
 };

--- a/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
@@ -46,9 +46,16 @@ export default function Container(
   props: AgentStepProps & { runJoinTokenPromise?: boolean }
 ) {
   const [showScript, setShowScript] = useState(props.runJoinTokenPromise);
-  const [labels, setLabels] = useState<AgentLabel[]>([
-    { name: '*', value: '*' },
-  ]);
+  const [labels, setLabels] = useState<AgentLabel[]>(
+    props.agentMeta?.agentMatcherLabels?.length > 0
+      ? // TODO (lisa): make it so that either asteriks, or one of the
+        // user defined labels is included
+        props.agentMeta.agentMatcherLabels
+      : // If user did not define any labels from previous step (create db)
+        // then the only way the agent will know how to pick up the
+        // new db is through asteriks.
+        [{ name: '*', value: '*' }]
+  );
 
   function handleGenerateCommand(validator: Validator) {
     if (!validator.validate()) {

--- a/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
@@ -147,7 +147,7 @@ export function DownloadScript(
     timedOut: pollingTimedOut,
     start,
     result,
-  } = usePingTeleport<Database>();
+  } = usePingTeleport<Database>(props.agentMeta.resourceName);
 
   function regenerateScriptAndRepoll() {
     reloadJoinToken();

--- a/packages/teleport/src/Discover/Database/DownloadScript/index.ts
+++ b/packages/teleport/src/Discover/Database/DownloadScript/index.ts
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export { DownloadScript } from './DownloadScript';
+import DownloadScript from './DownloadScript';
+export { DownloadScript };

--- a/packages/teleport/src/Discover/Database/TestConnection/TestConnection.story.tsx
+++ b/packages/teleport/src/Discover/Database/TestConnection/TestConnection.story.tsx
@@ -64,5 +64,6 @@ const props: State = {
     labels: [],
     names: ['name1', 'name2'],
     users: ['user1', 'user2'],
+    hostname: 'db-hostname',
   },
 };

--- a/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -118,7 +118,9 @@ export function TestConnectionView({
         attempt={attempt}
         diagnosis={diagnosis}
         canTestConnection={canTestConnection}
-        testConnection={testConnection}
+        testConnection={() =>
+          testConnection({ name: selectedName.value, user: selectedUser.value })
+        }
         stepNumber={2}
         stepDescription="Verify that your database is accessible"
       />

--- a/packages/teleport/src/Discover/Database/TestConnection/useTestConnection.ts
+++ b/packages/teleport/src/Discover/Database/TestConnection/useTestConnection.ts
@@ -24,12 +24,14 @@ export function useTestConnection(props: AgentStepProps) {
   const { runConnectionDiagnostic, ...connectionDiagnostic } =
     useConnectionDiagnostic(props);
 
-  function testConnection() {
+  function testConnection({ name, user }: { name: string; user: string }) {
     runConnectionDiagnostic({
       resourceKind: 'db',
       resourceName: props.agentMeta.resourceName,
-      // TODO (lisa or ryan): possible more fields specific to database
-      // once backend finalizes.
+      dbTester: {
+        name,
+        user,
+      },
     });
   }
 

--- a/packages/teleport/src/Discover/Discover.test.tsx
+++ b/packages/teleport/src/Discover/Discover.test.tsx
@@ -49,6 +49,7 @@ const fullAcl: Acl = {
   accessRequests: fullAccess,
   billing: fullAccess,
   dbServers: fullAccess,
+  db: fullAccess,
   desktops: fullAccess,
   nodes: fullAccess,
   clipboardSharingEnabled: true,

--- a/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
+++ b/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
@@ -49,6 +49,7 @@ const fullAcl: Acl = {
   accessRequests: fullAccess,
   billing: fullAccess,
   dbServers: fullAccess,
+  db: fullAccess,
   desktops: fullAccess,
   nodes: fullAccess,
   clipboardSharingEnabled: true,

--- a/packages/teleport/src/Discover/Shared/JoinTokenContext.tsx
+++ b/packages/teleport/src/Discover/Shared/JoinTokenContext.tsx
@@ -80,7 +80,7 @@ export function useJoinTokenValue() {
 
 export function useJoinToken(
   resourceKind: ResourceKind,
-  agentMatcherLabel: AgentLabel[] = [],
+  suggestedAgentMatcherLabels: AgentLabel[] = [],
   joinMethod: JoinMethod = 'token'
 ): {
   joinToken: JoinToken;
@@ -100,7 +100,7 @@ export function useJoinToken(
           {
             roles: [resourceKindToJoinRole(resourceKind)],
             method: joinMethod,
-            agentMatcherLabel,
+            suggestedAgentMatcherLabels,
           },
           abortController.signal
         )

--- a/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.tsx
+++ b/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.tsx
@@ -24,7 +24,7 @@ import { requiredField } from 'shared/components/Validation/rules';
 import { AgentLabel } from 'teleport/services/agents';
 
 export function LabelsCreater({
-  labels,
+  labels = [],
   setLabels,
   disableBtns = false,
   isLabelOptional = false,

--- a/packages/teleport/src/Discover/useDiscover.tsx
+++ b/packages/teleport/src/Discover/useDiscover.tsx
@@ -76,7 +76,7 @@ export function useDiscover(config: UseMainConfig) {
     const nextView = findViewAtIndex(views, currentStep + numToIncrement);
 
     if (nextView) {
-      setCurrentStep(currentStep + 1);
+      setCurrentStep(currentStep + numToIncrement);
     }
   }
 

--- a/packages/teleport/src/Discover/useDiscover.tsx
+++ b/packages/teleport/src/Discover/useDiscover.tsx
@@ -30,6 +30,7 @@ import { resources } from './resources';
 import type { Node } from 'teleport/services/nodes';
 import type { Kube } from 'teleport/services/kube';
 import type { Database } from 'teleport/services/databases';
+import type { AgentLabel } from 'teleport/services/agents';
 
 export function getKindFromString(value: string) {
   switch (value) {
@@ -120,6 +121,10 @@ type BaseMeta = {
   // by different field names.
   // Eg. used in Finish (last step) component.
   resourceName: string;
+  // agentMatcherLabels are labels that will be used by the agent
+  // to pick up the newly created database (looks for matching labels).
+  // At least one must match.
+  agentMatcherLabels: AgentLabel[];
 };
 
 // NodeMeta describes the fields for node resource

--- a/packages/teleport/src/Discover/yamlTemplates/dbCU.yaml
+++ b/packages/teleport/src/Discover/yamlTemplates/dbCU.yaml
@@ -1,0 +1,10 @@
+kind: role
+spec:
+  allow:
+    rules:
+    # Rule that allows users to create and update database.
+    - resources:
+      - db
+      verbs:
+      - create
+      - update

--- a/packages/teleport/src/Discover/yamlTemplates/index.ts
+++ b/packages/teleport/src/Discover/yamlTemplates/index.ts
@@ -21,6 +21,7 @@ import kubeAccessRW from './kubeAccessRW.yaml?raw';
 import kubeAccessRO from './kubeAccessRO.yaml?raw';
 import dbAccessRW from './dbAccessRW.yaml?raw';
 import dbAccessRO from './dbAccessRO.yaml?raw';
+import dbCU from './dbCU.yaml?raw';
 
 export {
   nodeAccessRO,
@@ -30,4 +31,5 @@ export {
   kubeAccessRO,
   dbAccessRO,
   dbAccessRW,
+  dbCU,
 };

--- a/packages/teleport/src/Main/fixtures/index.ts
+++ b/packages/teleport/src/Main/fixtures/index.ts
@@ -40,6 +40,7 @@ export const fullAcl: Acl = {
   accessRequests: fullAccess,
   billing: fullAccess,
   dbServers: fullAccess,
+  db: fullAccess,
   desktops: fullAccess,
   nodes: fullAccess,
   connectionDiagnostic: fullAccess,

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -175,6 +175,8 @@ const cfg = {
     mfaDevicesPath: '/v1/webapi/mfa/devices',
     mfaDevicePath: '/v1/webapi/mfa/token/:tokenId/devices/:deviceName',
 
+    dbSign: 'v1/webapi/sites/:clusterId/sign/db',
+
     installADDSPath: '/v1/webapi/scripts/desktop-access/install-ad-ds.ps1',
     installADCSPath: '/v1/webapi/scripts/desktop-access/install-ad-cs.ps1',
     configureADPath:
@@ -428,7 +430,7 @@ const cfg = {
   },
 
   getDatabaseUrl(clusterId: string, dbName: string) {
-    return generateResourcePath(cfg.api.databasePath, {
+    return generatePath(cfg.api.databasePath, {
       clusterId,
       database: dbName,
     });
@@ -439,6 +441,10 @@ const cfg = {
       clusterId,
       ...params,
     });
+  },
+
+  getDatabaseSignUrl(clusterId: string) {
+    return generatePath(cfg.api.dbSign, { clusterId });
   },
 
   getDesktopsUrl(clusterId: string, params: UrlResourcesParams) {

--- a/packages/teleport/src/mocks/contexts.ts
+++ b/packages/teleport/src/mocks/contexts.ts
@@ -41,6 +41,7 @@ export const fullAcl: Acl = {
   accessRequests: fullAccess,
   billing: fullAccess,
   dbServers: fullAccess,
+  db: fullAccess,
   desktops: fullAccess,
   nodes: fullAccess,
   connectionDiagnostic: fullAccess,

--- a/packages/teleport/src/services/agents/agents.test.ts
+++ b/packages/teleport/src/services/agents/agents.test.ts
@@ -36,6 +36,8 @@ test('createConnectionDiagnostic request', () => {
       kubernetes_user: undefined,
       kubernetes_groups: undefined,
     },
+    database_name: undefined,
+    database_user: undefined,
   });
 
   // Test all fields gets set as requested.
@@ -48,6 +50,10 @@ test('createConnectionDiagnostic request', () => {
       user: 'kubernetes_user',
       groups: ['group1', 'group2'],
     },
+    dbTester: {
+      name: 'db_name',
+      user: 'db_user',
+    },
   };
   agentService.createConnectionDiagnostic(mock);
   expect(api.post).toHaveBeenCalledWith(cfg.getConnectionDiagnosticUrl(), {
@@ -59,6 +65,8 @@ test('createConnectionDiagnostic request', () => {
       kubernetes_user: 'kubernetes_user',
       kubernetes_groups: ['group1', 'group2'],
     },
+    database_name: 'db_name',
+    database_user: 'db_user',
   });
 });
 

--- a/packages/teleport/src/services/agents/agents.ts
+++ b/packages/teleport/src/services/agents/agents.ts
@@ -38,6 +38,8 @@ export const agentService = {
           kubernetes_user: req.kubeImpersonation?.user,
           kubernetes_groups: req.kubeImpersonation?.groups,
         },
+        database_name: req.dbTester?.name,
+        database_user: req.dbTester?.user,
       })
       .then(makeConnectionDiagnostic);
   },

--- a/packages/teleport/src/services/agents/types.ts
+++ b/packages/teleport/src/services/agents/types.ts
@@ -98,6 +98,7 @@ export type ConnectionDiagnosticRequest = {
   resourceName: string; //`json:"resource_name"`
   sshPrincipal?: string; //`json:"ssh_principal"`
   kubeImpersonation?: KubeImpersonation; // `json:"kubernetes_impersonation`
+  dbTester?: DatabaseTester;
 };
 
 export type KubeImpersonation = {
@@ -111,4 +112,9 @@ export type KubeImpersonation = {
   // When KubernetesGroups is specified, KubernetesUser must be provided
   // as well.
   groups?: string[]; // `json:"kubernetes_impersonation.kubernetes_groups"
+};
+
+export type DatabaseTester = {
+  user?: string; // `json:"database_user"`
+  name?: string; // `json:"database_name"`
 };

--- a/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/packages/teleport/src/services/databases/makeDatabase.ts
@@ -31,5 +31,6 @@ export default function makeDatabase(json: any): Database {
     labels,
     names: json.database_names || [],
     users: json.database_users || [],
+    hostname: json.hostname,
   };
 }

--- a/packages/teleport/src/services/databases/types.ts
+++ b/packages/teleport/src/services/databases/types.ts
@@ -26,6 +26,7 @@ export interface Database {
   labels: AgentLabel[];
   names?: string[];
   users?: string[];
+  hostname: string;
 }
 
 export type DatabasesResponse = {

--- a/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -33,7 +33,7 @@ test('fetchJoinToken with an empty request properly sets defaults', () => {
       roles: undefined,
       join_method: 'token',
       allow: [],
-      agent_matcher_labels: {},
+      suggested_agent_matcher_labels: {},
     },
     null
   );
@@ -56,7 +56,7 @@ test('fetchJoinToken request fields are set as requested', () => {
       roles: ['Node'],
       join_method: 'iam',
       allow: [{ aws_account: '1234', aws_arn: 'xxxx' }],
-      agent_matcher_labels: { env: ['dev'] },
+      suggested_agent_matcher_labels: { env: ['dev'] },
     },
     null
   );

--- a/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -47,7 +47,7 @@ test('fetchJoinToken request fields are set as requested', () => {
     roles: ['Node'],
     rules: [{ awsAccountId: '1234', awsArn: 'xxxx' }],
     method: 'iam',
-    agentMatcherLabel: [{ name: 'env', value: 'dev' }],
+    suggestedAgentMatcherLabels: [{ name: 'env', value: 'dev' }],
   };
   svc.fetchJoinToken(mock);
   expect(api.post).toHaveBeenCalledWith(

--- a/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/packages/teleport/src/services/joinToken/joinToken.ts
@@ -34,7 +34,9 @@ class JoinTokenService {
           roles: req.roles,
           join_method: req.method || 'token',
           allow: makeAllowField(req.rules || []),
-          agent_matcher_labels: makeLabelMapOfStrArrs(req.agentMatcherLabel),
+          suggested_agent_matcher_labels: makeLabelMapOfStrArrs(
+            req.suggestedAgentMatcherLabels
+          ),
         },
         signal
       )

--- a/packages/teleport/src/services/joinToken/types.ts
+++ b/packages/teleport/src/services/joinToken/types.ts
@@ -63,10 +63,10 @@ export type JoinTokenRequest = {
   // rules is a list of allow rules associated with the join token
   // and the node using this token must match one of the rules.
   rules?: JoinRule[];
-  // agentMatcherLabel is a set of labels to be used by agents to match
+  // suggestedAgentMatcherLabels is a set of labels to be used by agents to match
   // on resources. When an agent uses this token, the agent should
   // monitor resources that match those labels. For databases, this
   // means adding the labels to `db_service.resources.labels`.
-  agentMatcherLabel?: AgentLabel[];
+  suggestedAgentMatcherLabels?: AgentLabel[];
   method?: JoinMethod;
 };

--- a/packages/teleport/src/services/user/makeAcl.ts
+++ b/packages/teleport/src/services/user/makeAcl.ts
@@ -32,6 +32,7 @@ export default function makeAcl(json): Acl {
   const accessRequests = json.accessRequests || defaultAccess;
   const billing = json.billing || defaultAccess;
   const dbServers = json.dbServers || defaultAccess;
+  const db = json.db || defaultAccess;
   const desktops = json.desktops || defaultAccess;
   const connectionDiagnostic = json.connectionDiagnostic || defaultAccess;
   // Defaults to true, see RFD 0049
@@ -66,6 +67,7 @@ export default function makeAcl(json): Acl {
     accessRequests,
     billing,
     dbServers,
+    db,
     desktops,
     clipboardSharingEnabled,
     desktopSessionRecordingEnabled,

--- a/packages/teleport/src/services/user/types.ts
+++ b/packages/teleport/src/services/user/types.ts
@@ -65,6 +65,7 @@ export interface Acl {
   accessRequests: Access;
   billing: Access;
   dbServers: Access;
+  db: Access;
   desktops: Access;
   nodes: Access;
   connectionDiagnostic: Access;

--- a/packages/teleport/src/services/user/user.test.ts
+++ b/packages/teleport/src/services/user/user.test.ts
@@ -156,6 +156,13 @@ test('undefined values in context response gives proper default values', async (
         create: false,
         remove: false,
       },
+      db: {
+        list: false,
+        read: false,
+        edit: false,
+        create: false,
+        remove: false,
+      },
       connectionDiagnostic: {
         list: false,
         read: false,

--- a/packages/teleport/src/stores/storeUserContext.ts
+++ b/packages/teleport/src/stores/storeUserContext.ts
@@ -90,8 +90,12 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state.acl.billing;
   }
 
-  getDatabaseAccess() {
+  getDatabaseServerAccess() {
     return this.state.acl.dbServers;
+  }
+
+  getDatabaseAccess() {
+    return this.state.acl.db;
   }
 
   getDesktopAccess() {

--- a/packages/teleport/src/teleportContext.tsx
+++ b/packages/teleport/src/teleportContext.tsx
@@ -96,7 +96,7 @@ class TeleportContext implements types.Context {
       applications: userContext.getAppServerAccess().list,
       kubernetes: userContext.getKubeServerAccess().list,
       billing: userContext.getBillingAccess().list,
-      databases: userContext.getDatabaseAccess().list,
+      databases: userContext.getDatabaseServerAccess().list,
       desktops: userContext.getDesktopAccess().list,
       nodes: userContext.getNodeAccess().list,
       activeSessions: userContext.getActiveSessionsAccess().list,


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/16858

Note: recommend reviewing by commit (they are pretty self contained)

#### Description
- Adds db access flags (required to create and update database resource)
  - Adds missing permission check when users are at create db step
- Add `sign/db` endpoint (required to create certs eg `mutual tls step`)
  - Add db hostname field (hostname is expected with use of `sign/db`)
- Adds TODO for:
  - when [this issue](https://github.com/gravitational/teleport/issues/19032) gets resolved, change the logic as described in code
  - for `configure service (downloadscript, poor name)` step, make label creator more resilient to failure (eg: prevent users from creating a service with no labels, either asteriks or user defined label is required)
- Allow PingTeleportContext to take in an alternate search term (querying for database agents require querying by database name)
- Adds expected json fields for db tester, pulled from https://github.com/gravitational/teleport/pull/18558

#### Dependent PR
- [x] requires https://github.com/gravitational/teleport/pull/19063

#### TODO
- [ ] backport to v11
- [x] update e-ref (db hostname field) after merge https://github.com/gravitational/webapps.e/pull/451