### PR TITLE
update alert field on banner capture

### DIFF
--- a/packages/teleport/src/components/BannerList/Banner.tsx
+++ b/packages/teleport/src/components/BannerList/Banner.tsx
@@ -68,7 +68,7 @@ export function Banner({
             onClick={() =>
               userEventService.captureUserEvent({
                 event: CaptureEvent.BannerClickEvent,
-                alertId: id,
+                alert: id,
               })
             }
           >

--- a/packages/teleport/src/services/userEvent/userEvent.ts
+++ b/packages/teleport/src/services/userEvent/userEvent.ts
@@ -5,7 +5,7 @@ import { CaptureEvent } from './types';
 
 export type UserEvent = {
   event: CaptureEvent;
-  alertId?: string;
+  alert?: string;
 };
 
 export type PreUserEvent = UserEvent & {


### PR DESCRIPTION
Updates the alert field to match the grpc method/expected request on the API->Prehog side of the fence

`alertId -> alert`

Fixes the dropped field from event capture:
```
{"caller":"local/usagereporter.go:198","component":"usage-reporting","level":"warning","message":"Failed to submit batch of 2 usage events: invalid_argument: missing alert","timestamp":"2022-12-08T22:32:39Z"}
```