### PR TITLE
Connect: Use default config in main process fixtures

### DIFF
--- a/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -1,6 +1,9 @@
 import { RuntimeSettings, MainProcessClient } from 'teleterm/types';
 import { createMockFileStorage } from 'teleterm/services/fileStorage/fixtures/mocks';
-import { createMockConfigService } from 'teleterm/services/config/fixtures/mocks';
+// createConfigService has to be imported directly from configService.ts.
+// teleterm/services/config/index.ts reexports the config service client which depends on electron.
+// Importing electron breaks the fixtures if that's done from within storybook.
+import { createConfigService } from 'teleterm/services/config/configService';
 
 const platform = 'darwin';
 
@@ -44,7 +47,7 @@ export class MockMainProcessClient implements MainProcessClient {
     return Promise.resolve({ canceled: false, filePath: '' });
   }
 
-  configService = createMockConfigService({});
+  configService = createConfigService(createMockFileStorage(), platform);
 
   fileStorage = createMockFileStorage();
 


### PR DESCRIPTION
This unbreaks some Connect stories which depend on keyboard shortcuts config.

If we ever need to change the config in stories or tests, we should revisit the mock. But it might be enough to call the `set` method on the config service.