### PR TITLE
Improve error message when trying to rename resource

### DIFF
--- a/packages/teleport/package.json
+++ b/packages/teleport/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@gravitational/design": "1.0.0",
     "@gravitational/shared": "1.0.0",
+    "yaml": "^2.2.0",
     "xterm": "^5.0.0",
     "xterm-addon-fit": "^0.5.0"
   },

--- a/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
+++ b/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
@@ -46,7 +46,8 @@ export function AuthConnectors(props: State) {
 
   function handleOnSave(content: string) {
     const isNew = resources.status === 'creating';
-    return save(content, isNew);
+    const previousName = resources.item.name;
+    return save(content, isNew, previousName);
   }
 
   return (

--- a/packages/teleport/src/AuthConnectors/useAuthConnectors.tsx
+++ b/packages/teleport/src/AuthConnectors/useAuthConnectors.tsx
@@ -31,11 +31,11 @@ export default function useAuthConnectors() {
     });
   }
 
-  function save(yaml: string, isNew: boolean) {
+  function save(yaml: string, isNew: boolean, previousName: string) {
     if (isNew) {
       return ctx.resourceService.createGithubConnector(yaml).then(fetchData);
     }
-    return ctx.resourceService.updateGithubConnector(yaml).then(fetchData);
+    return ctx.resourceService.updateGithubConnector(yaml, previousName).then(fetchData);
   }
 
   function remove(name: string) {

--- a/packages/teleport/src/Roles/Roles.tsx
+++ b/packages/teleport/src/Roles/Roles.tsx
@@ -46,7 +46,7 @@ export function Roles(props: State) {
 
   function handleSave(content: string) {
     const isNew = resources.status === 'creating';
-    return save(content, isNew);
+    return save(content, isNew, resources.item.name);
   }
 
   return (

--- a/packages/teleport/src/Roles/useRoles.ts
+++ b/packages/teleport/src/Roles/useRoles.ts
@@ -32,14 +32,14 @@ export default function useRoles(ctx: TeleportContext) {
 
   // TODO: we cannot refetch the data right after saving because this backend
   // operation is not atomic.
-  function save(yaml: string, isNew: boolean) {
+  function save(yaml: string, isNew: boolean, previousName: string) {
     if (isNew) {
       return ctx.resourceService.createRole(yaml).then(result => {
         setItems([result, ...items]);
       });
     }
 
-    return ctx.resourceService.updateRole(yaml).then(result => {
+    return ctx.resourceService.updateRole(yaml, previousName).then(result => {
       setItems([result, ...items.filter(r => r.name !== result.name)]);
     });
   }

--- a/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
+++ b/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
@@ -52,7 +52,8 @@ export default function TrustedClusters() {
 
   function save(content: string) {
     const isNew = resources.status === 'creating';
-    return tclusters.save(content, isNew);
+    const previousName = resources.item.name;
+    return tclusters.save(content, isNew, previousName);
   }
 
   return (

--- a/packages/teleport/src/TrustedClusters/useTrustedClusters.ts
+++ b/packages/teleport/src/TrustedClusters/useTrustedClusters.ts
@@ -31,14 +31,14 @@ export default function useTrustedClusters() {
     });
   }
 
-  function save(yaml: string, isNew: boolean) {
+  function save(yaml: string, isNew: boolean, previousName: string) {
     if (isNew) {
       return teleContext.resourceService
         .createTrustedCluster(yaml)
         .then(fetchData);
     }
     return teleContext.resourceService
-      .updateTrustedCluster(yaml)
+      .updateTrustedCluster(yaml, previousName)
       .then(fetchData);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15959,6 +15959,11 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.0.tgz#882c762992888b4144bffdec5745df340627fdd3"
+  integrity sha512-auf7Gi6QwO7HW//GA9seGvTXVGWl1CM/ADWh1+RxtXr6XOxnT65ovDl9fTi4e0monEyJxCHqDpF6QnFDXmJE4g==
+
 yargs-parser@^20.2.2, yargs-parser@^20.2.7:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/18771.

(Previous attempt at https://github.com/gravitational/teleport/pull/19624)

This commit improves the error message when a user tries to rename a resource (role, auth connector and trusted cluster) using the web UI.

Doing this validation on the client-side prevents the situation described in https://github.com/gravitational/teleport/pull/19624#discussion_r1057335629.

#### Testing


<img width="500" alt="Screenshot 2022-12-28 at 20 23 35" src="https://user-images.githubusercontent.com/4520516/209869409-dce437a4-a19d-4acd-bd0a-a685cbb3f064.png">
<img width="500" alt="Screenshot 2022-12-28 at 20 24 33" src="https://user-images.githubusercontent.com/4520516/209869415-581baf5b-5c8f-4d22-b598-c339bbd0e7a1.png">
<img width="500" alt="Screenshot 2022-12-28 at 20 24 07" src="https://user-images.githubusercontent.com/4520516/209869413-a3c5389c-4ece-4160-95ec-3e3ae9caeec5.png">


