### PR TITLE
Fix large zip file sharing

### DIFF
--- a/packages/teleport/src/lib/tdp/sharedDirectoryManager.ts
+++ b/packages/teleport/src/lib/tdp/sharedDirectoryManager.ts
@@ -153,8 +153,8 @@ export class SharedDirectoryManager {
     }
 
     const file = await fileHandle.createWritable({ keepExistingData: true });
-    file.write({ type: 'write', position: Number(offset), data });
-    file.close(); // Needed to actually write data to disk.
+    await file.write({ type: 'write', position: Number(offset), data });
+    await file.close(); // Needed to actually write data to disk.
 
     return data.length;
   }


### PR DESCRIPTION
It's still not entirely clear to me why this was only showing up with large zip files (whereas I wasn't able to induce it with merely large text files). However after making this change, previously problematic large zip files are being copied correctly. 

Generally it makes sense that these operations need to be `await`ed, to ensure that the write completes before another comes in, the file is closed, etc. When testing, I noticed that the way the zip files were becoming corrupted wasn't entirely consistent from run to run (i.e. one time byte 115 was incorrect, the next time it was written correctly). So I believe that by not `await`ing, I was creating a race condition that was for whatever reason more likely to be beaten by a big binary file like a zip.

Fixes https://github.com/gravitational/teleport/issues/19731 (🤞)