### PR TITLE
[v10] awaits the file write and close to avoid data corruption (#1471)

### DIFF
--- a/packages/teleport/src/lib/tdp/sharedDirectoryManager.ts
+++ b/packages/teleport/src/lib/tdp/sharedDirectoryManager.ts
@@ -153,8 +153,8 @@ export class SharedDirectoryManager {
     }
 
     const file = await fileHandle.createWritable({ keepExistingData: true });
-    file.write({ type: 'write', position: Number(offset), data });
-    file.close(); // Needed to actually write data to disk.
+    await file.write({ type: 'write', position: Number(offset), data });
+    await file.close(); // Needed to actually write data to disk.
 
     return data.length;
   }


### PR DESCRIPTION
backports https://github.com/gravitational/webapps/pull/1471 to teleport-v10