### PR TITLE
Notifications: Add showcase story & fix icon alignment

### DIFF
--- a/packages/design/src/ButtonIcon/ButtonIcon.jsx
+++ b/packages/design/src/ButtonIcon/ButtonIcon.jsx
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 import styled from 'styled-components';
 
-import { space, color } from 'design/system';
+import { space, color, alignSelf } from 'design/system';
 
 import Icon from '../Icon';
 
@@ -95,5 +95,6 @@ const StyledButtonIcon = styled.button`
   ${size}
   ${space}
   ${color}
+  ${alignSelf}
 `;
 export default ButtonIcon;

--- a/packages/shared/components/Notification/Notification.story.tsx
+++ b/packages/shared/components/Notification/Notification.story.tsx
@@ -16,6 +16,7 @@ limitations under the License.
 
 import React, { useState } from 'react';
 import { Info, Warning } from 'design/Icon';
+import Flex from 'design/Flex';
 
 import { Notification } from './Notification';
 
@@ -23,15 +24,143 @@ export default {
   title: 'Shared/Notification',
 };
 
+export const Notifications = () => {
+  return (
+    <Flex gap={8}>
+      <Flex flexDirection="column" gap={4}>
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'info',
+            content: {
+              title: 'Info with title and description',
+              description: loremIpsum,
+            },
+          }}
+          Icon={Info}
+          getColor={theme => theme.colors.info}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'warn',
+            content: {
+              title: 'Warning with title and description',
+              description: loremIpsum,
+            },
+          }}
+          Icon={Warning}
+          getColor={theme => theme.colors.warning}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'error',
+            content: {
+              title: 'Error with title and description',
+              description: loremIpsum,
+            },
+          }}
+          Icon={Warning}
+          getColor={theme => theme.colors.danger}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+      </Flex>
+
+      <Flex flexDirection="column" gap={4}>
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'info',
+            content: 'Multiline info without title. ' + loremIpsum,
+          }}
+          Icon={Info}
+          getColor={theme => theme.colors.info}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'warn',
+            content: 'Multiline warning without title. ' + loremIpsum,
+          }}
+          Icon={Warning}
+          getColor={theme => theme.colors.warning}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'error',
+            content: 'Multiline error without title. ' + loremIpsum,
+          }}
+          Icon={Warning}
+          getColor={theme => theme.colors.danger}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+      </Flex>
+
+      <Flex flexDirection="column" gap={4}>
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'info',
+            content: 'Info without title',
+          }}
+          Icon={Info}
+          getColor={theme => theme.colors.info}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'warn',
+            content: 'Warning without title',
+          }}
+          Icon={Warning}
+          getColor={theme => theme.colors.warning}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+
+        <Notification
+          item={{
+            id: crypto.randomUUID(),
+            severity: 'error',
+            content: 'Error without title',
+          }}
+          Icon={Warning}
+          getColor={theme => theme.colors.danger}
+          onRemove={() => {}}
+          isAutoRemovable={false}
+        />
+      </Flex>
+    </Flex>
+  );
+};
+
 export const AutoRemovable = () => {
   const [showInfo, setShowInfo] = useState(true);
   const [showWarning, setShowWarning] = useState(true);
   const [showError, setShowError] = useState(true);
   return (
-    <>
+    <Flex flexDirection="column" gap={4}>
       {showInfo ? (
         <Notification
-          mt={4}
           item={{
             id: crypto.randomUUID(),
             severity: 'info',
@@ -49,7 +178,6 @@ export const AutoRemovable = () => {
       )}
       {showWarning ? (
         <Notification
-          mt={4}
           item={{
             id: crypto.randomUUID(),
             severity: 'warn',
@@ -67,7 +195,6 @@ export const AutoRemovable = () => {
       )}
       {showError ? (
         <Notification
-          mt={4}
           item={{
             id: crypto.randomUUID(),
             severity: 'error',
@@ -82,6 +209,9 @@ export const AutoRemovable = () => {
       ) : (
         <div>Error notification has been removed</div>
       )}
-    </>
+    </Flex>
   );
 };
+
+const loremIpsum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut non ipsum dignissim, dignissim est vitae, facilisis nunc.';

--- a/packages/shared/components/Notification/Notification.tsx
+++ b/packages/shared/components/Notification/Notification.tsx
@@ -19,8 +19,6 @@ import styled, { css, useTheme } from 'styled-components';
 import { ButtonIcon, Flex, Text } from 'design';
 import { Close } from 'design/Icon';
 
-import type { propTypes } from 'design/system';
-
 import type { NotificationItem, NotificationItemContent } from './types';
 
 interface NotificationProps {
@@ -30,11 +28,18 @@ interface NotificationProps {
   getColor(theme): string;
   isAutoRemovable: boolean;
   autoRemoveDurationMs?: number;
+  // Workaround until `styled` gets types.
+  // Once the types are available, we can switch the type of Notification props to:
+  //
+  //     NotificationProps & React.ComponentProps<typeof Container>
+  //
+  // and remove the next line.
+  [key: string]: any;
 }
 
 const defaultAutoRemoveDurationMs = 10_000; // 10s
 
-export function Notification(props: NotificationProps & propTypes) {
+export function Notification(props: NotificationProps) {
   const {
     item,
     onRemove,

--- a/packages/shared/components/Notification/Notification.tsx
+++ b/packages/shared/components/Notification/Notification.tsx
@@ -78,6 +78,7 @@ export function Notification(props: NotificationProps) {
       size={0}
       ml={1}
       mr={-1}
+      alignSelf="baseline"
       style={{ visibility: isHovered ? 'visible' : 'hidden' }}
       onClick={e => {
         e.stopPropagation();
@@ -123,7 +124,7 @@ function getRenderedContent(
 
   if (typeof content === 'string') {
     return (
-      <Flex justifyContent="space-between" width="100%">
+      <Flex alignItems="center" justifyContent="space-between" width="100%">
         <Text
           typography="body1"
           fontSize={13}


### PR DESCRIPTION
I noticed that when the notification has a single line with no title, the text and the icon are misaligned.

before | after
--- | ---
![before](https://user-images.githubusercontent.com/27113/210259228-8ce27bf6-861f-4c24-b637-54742f6b5d0b.png) | ![after](https://user-images.githubusercontent.com/27113/210259243-048086bf-03f8-47fd-ae6d-ff9f2db27042.png)




To make sure I can fix this without breaking everything else, I added a story which shows each notification type.

While adding the story, I noticed that the types for the Notification component don't alert me when I forgot to add required props, so I fixed that too.