### PR TITLE
Include session id in Session Uploaded event display

### DIFF
--- a/packages/teleport/src/services/audit/makeEvent.ts
+++ b/packages/teleport/src/services/audit/makeEvent.ts
@@ -557,7 +557,7 @@ export const formatters: Formatters = {
   [eventCodes.SESSION_UPLOAD]: {
     type: 'session.upload',
     desc: 'Session Uploaded',
-    format: () => `Recorded session has been uploaded`,
+    format: ({ sid }) => `Recorded session [${sid}] has been uploaded`,
   },
   [eventCodes.APP_SESSION_START]: {
     type: 'app.session.start',


### PR DESCRIPTION
Includes the session id in the Session Uploaded display.  Currently if you search for a session id you won't get the uploaded which tells you the session is now available.

Before

<img width="1323" alt="image" src="https://user-images.githubusercontent.com/60704961/210283755-ce05d79c-1903-4ae9-8fa9-d2d8e08013d3.png">


After
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/60704961/210283707-5b0e5ca0-48da-4675-a2dd-fbdb3bd54e65.png">


