### PR TITLE
Connect: Add missing modal stories, misc modal fixes

### DIFF
--- a/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.story.tsx
+++ b/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.story.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import { ClusterAddPresentation } from './ClusterAdd';
 
 export default {
-  title: 'Teleterm/ClusterAdd',
+  title: 'Teleterm/ModalsHost/ClusterAdd',
 };
 
 export const Story = () => {

--- a/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
+++ b/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
@@ -29,7 +29,7 @@ import {
 } from './ClusterLogin';
 
 export default {
-  title: 'Teleterm/ClusterLogin',
+  title: 'Teleterm/ModalsHost/ClusterLogin',
 };
 
 function makeProps(): ClusterLoginPresentationProps {

--- a/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.story.tsx
+++ b/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.story.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { ClusterLogout } from './ClusterLogout';
+
+export default {
+  title: 'Teleterm/ModalsHost/ClusterLogout',
+};
+
+export const Story = () => {
+  return (
+    <ClusterLogout
+      status=""
+      statusText=""
+      removeCluster={() => Promise.resolve([undefined, null])}
+      onClose={() => {}}
+      clusterUri="/clusters/foo"
+      clusterTitle="foo"
+    />
+  );
+};

--- a/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.story.tsx
+++ b/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.story.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { DocumentsReopen } from './DocumentsReopen';
+
+export default {
+  title: 'Teleterm/ModalsHost/DocumentsReopen',
+};
+
+export const Story = () => {
+  return <DocumentsReopen onConfirm={() => {}} onCancel={() => {}} />;
+};

--- a/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.story.tsx
+++ b/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.story.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import { UsageData } from './UsageData';
 
 export default {
-  title: 'Teleterm/UsageData',
+  title: 'Teleterm/ModalsHost/UsageData',
 };
 
 export const Dialog = () => (

--- a/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -136,7 +136,7 @@ export class ModalsService extends ImmutableStore<State> {
   }
 }
 
-export interface DialogBase {
+export interface DialogNone {
   kind: 'none';
 }
 
@@ -144,7 +144,6 @@ export interface DialogClusterConnect {
   kind: 'cluster-connect';
   clusterUri?: RootClusterUri;
   reason?: ClusterConnectReason;
-  onSuccess?(clusterUri: string): void;
   onSuccess?(clusterUri: RootClusterUri): void;
   onCancel?(): void;
 }
@@ -167,23 +166,19 @@ export interface DialogClusterLogout {
 
 export interface DialogDocumentsReopen {
   kind: 'documents-reopen';
-
   onConfirm?(): void;
-
   onCancel?(): void;
 }
 
 export interface DialogUsageData {
   kind: 'usage-data';
-
   onAllow(): void;
-
   onDecline(): void;
 }
 
 export type Dialog =
-  | DialogBase
   | DialogClusterConnect
   | DialogClusterLogout
   | DialogDocumentsReopen
-  | DialogUsageData;
+  | DialogUsageData
+  | DialogNone;


### PR DESCRIPTION
Originally I had these two commits on the branch where I'm working on symlinking tsh on macOS. I wanted to add a new modal, similar to how VSCode prompts you before actually executing osascript, but I found out you can have [a custom prompt for osascript](https://apple.stackexchange.com/a/303363/103152) so the additional modals are no longer necessary.

Still, I'm submitting a PR with small fixes to modals. When I was adding the new modals, I lacked a place where I can quickly look up how all the other modals look like, so I grouped them all together in the storybook and added some missing stories.