### PR TITLE
Update sessionPath value to new endpoint

### DIFF
--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -121,9 +121,9 @@ const cfg = {
     checkAccessToRegisteredResource: `/v1/webapi/sites/:clusterId/resources/check`,
 
     scp: '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
-    renewTokenPath: '/v1/webapi/sessions/web/renew',
+    webRenewTokenPath: '/v1/webapi/sessions/web/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
-    sessionPath: '/v1/webapi/sessions/web',
+    webSessionPath: '/v1/webapi/sessions/web',
     userContextPath: '/v1/webapi/sites/:clusterId/context',
     userStatusPath: '/v1/webapi/user/status',
     passwordTokenPath: '/v1/webapi/users/password/token/:tokenId?',
@@ -494,7 +494,7 @@ const cfg = {
   },
 
   getRenewTokenUrl() {
-    return cfg.api.renewTokenPath;
+    return cfg.api.webRenewTokenPath;
   },
 
   getGithubConnectorsUrl(name?: string) {

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -123,7 +123,7 @@ const cfg = {
     scp: '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
     renewTokenPath: '/v1/webapi/sessions/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
-    sessionPath: '/v1/webapi/sessions',
+    sessionPath: '/v1/webapi/sessions/web',
     userContextPath: '/v1/webapi/sites/:clusterId/context',
     userStatusPath: '/v1/webapi/user/status',
     passwordTokenPath: '/v1/webapi/users/password/token/:tokenId?',

--- a/packages/teleport/src/config.ts
+++ b/packages/teleport/src/config.ts
@@ -121,7 +121,7 @@ const cfg = {
     checkAccessToRegisteredResource: `/v1/webapi/sites/:clusterId/resources/check`,
 
     scp: '/v1/webapi/sites/:clusterId/nodes/:serverId/:login/scp?location=:location&filename=:filename',
-    renewTokenPath: '/v1/webapi/sessions/renew',
+    renewTokenPath: '/v1/webapi/sessions/web/renew',
     resetPasswordTokenPath: '/v1/webapi/users/password/token',
     sessionPath: '/v1/webapi/sessions/web',
     userContextPath: '/v1/webapi/sites/:clusterId/context',

--- a/packages/teleport/src/services/auth/auth.test.ts
+++ b/packages/teleport/src/services/auth/auth.test.ts
@@ -33,7 +33,7 @@ describe('services/auth', () => {
     jest.spyOn(api, 'post').mockResolvedValue({});
 
     await auth.login(email, password, '');
-    expect(api.post).toHaveBeenCalledWith(cfg.api.sessionPath, {
+    expect(api.post).toHaveBeenCalledWith(cfg.api.webSessionPath, {
       user: email,
       pass: password,
       second_factor_token: '',
@@ -49,7 +49,7 @@ describe('services/auth', () => {
     };
 
     await auth.login(email, password, 'xxx');
-    expect(api.post).toHaveBeenCalledWith(cfg.api.sessionPath, data);
+    expect(api.post).toHaveBeenCalledWith(cfg.api.webSessionPath, data);
   });
 
   test('resetPassword()', async () => {

--- a/packages/teleport/src/services/auth/auth.ts
+++ b/packages/teleport/src/services/auth/auth.ts
@@ -89,7 +89,7 @@ const auth = {
       second_factor_token: otpCode,
     };
 
-    return api.post(cfg.api.sessionPath, data);
+    return api.post(cfg.api.webSessionPath, data);
   },
 
   loginWithWebauthn(creds?: UserCredentials) {

--- a/packages/teleport/src/services/websession/websession.ts
+++ b/packages/teleport/src/services/websession/websession.ts
@@ -37,7 +37,7 @@ export class WebSession extends StoreWebSession {
   _isRenewing = false;
 
   logout() {
-    api.delete(cfg.api.sessionPath).finally(() => {
+    api.delete(cfg.api.webSessionPath).finally(() => {
       history.goToLogin();
     });
 


### PR DESCRIPTION
When https://github.com/gravitational/teleport/pull/19593 went in, it removed the deprecated(?) route to `webapi/sessions` in favor of `webapi/sessions/web` but the frontend was never updated since v5 to change this route. It looks like we were always calling to the same old route instead of the updated one. When the old route was removed, you can no longer login on the web ui. 

This change allows the login with the web ui again. I've checked around to find other instances and so far haven't found any but I may have missed something. Some sets of eyes and any historical data around this route would be great!

Teleport buddy: https://github.com/gravitational/teleport/pull/19892