### PR TITLE
[Discover] Temp remove db service checker

### DIFF
--- a/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
+++ b/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
@@ -69,7 +69,7 @@ const props: State = {
   clearAttempt: () => null,
   registerDatabase: () => null,
   canCreateDatabase: true,
-  pollTimeout: Date.now() + 30000,
+  // pollTimeout: Date.now() + 30000,
   dbEngine: DatabaseEngine.PostgreSQL,
   dbLocation: DatabaseLocation.SelfHosted,
 };

--- a/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
+++ b/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
@@ -19,18 +19,21 @@ import {
   Text,
   Box,
   Flex,
-  AnimatedProgressBar,
-  ButtonPrimary,
-  ButtonSecondary,
+
+  // AnimatedProgressBar,
+  // ButtonPrimary,
+  // ButtonSecondary,
 } from 'design';
-import Dialog, { DialogContent } from 'design/DialogConfirmation';
-import * as Icons from 'design/Icon';
+import { Danger } from 'design/Alert';
+
+// import Dialog, { DialogContent } from 'design/DialogConfirmation';
+// import * as Icons from 'design/Icon';
 import Validation, { Validator } from 'shared/components/Validation';
 import FieldInput from 'shared/components/FieldInput';
 import { requiredField } from 'shared/components/Validation/rules';
 import TextEditor from 'shared/components/TextEditor';
 
-import { Timeout } from 'teleport/Discover/Shared/Timeout';
+// import { Timeout } from 'teleport/Discover/Shared/Timeout';
 
 import {
   ActionButtons,
@@ -38,7 +41,7 @@ import {
   Header,
   LabelsCreater,
   Mark,
-  TextIcon,
+  // TextIcon,
 } from '../../Shared';
 import { dbCU } from '../../yamlTemplates';
 import { DatabaseLocation, getDatabaseProtocol } from '../resources';
@@ -47,7 +50,7 @@ import { useCreateDatabase, State } from './useCreateDatabase';
 
 import type { AgentStepProps } from '../../types';
 import type { AgentLabel } from 'teleport/services/agents';
-import type { Attempt } from 'shared/hooks/useAttemptNext';
+// import type { Attempt } from 'shared/hooks/useAttemptNext';
 import type { AwsRds } from 'teleport/services/databases';
 
 export function CreateDatabase(props: AgentStepProps) {
@@ -57,10 +60,10 @@ export function CreateDatabase(props: AgentStepProps) {
 
 export function CreateDatabaseView({
   attempt,
-  clearAttempt,
+  // clearAttempt,
   registerDatabase,
   canCreateDatabase,
-  pollTimeout,
+  // pollTimeout,
   dbEngine,
   dbLocation,
 }: State) {
@@ -105,6 +108,9 @@ export function CreateDatabaseView({
           <HeaderSubtitle>
             Create a new database resource for the database server.
           </HeaderSubtitle>
+          {attempt.status === 'failed' && (
+            <Danger children={attempt.statusText} />
+          )}
           {!canCreateDatabase && (
             <Box>
               <Text>
@@ -129,7 +135,7 @@ export function CreateDatabaseView({
                   // We need this name to comply with AWS policy name
                   // since it will be used as part of the policy name
                   // for the AWS flow.
-                  rule={conformNameWithAWSPolicyNameReq}
+                  rule={requiredField('database name is required')}
                   autoFocus
                   value={dbName}
                   placeholder="Enter database name"
@@ -211,82 +217,82 @@ export function CreateDatabaseView({
               attempt.status === 'processing' || !canCreateDatabase
             }
           />
-          {(attempt.status === 'processing' || attempt.status === 'failed') && (
+          {/* {(attempt.status === 'processing' || attempt.status === 'failed') && (
             <CreateDatabaseDialog
               pollTimeout={pollTimeout}
               attempt={attempt}
               retry={() => handleOnProceed(validator)}
               close={clearAttempt}
             />
-          )}
+          )} */}
         </Box>
       )}
     </Validation>
   );
 }
 
-const CreateDatabaseDialog = ({
-  pollTimeout,
-  attempt,
-  retry,
-  close,
-}: {
-  pollTimeout: number;
-  attempt: Attempt;
-  retry(): void;
-  close(): void;
-}) => {
-  return (
-    <Dialog disableEscapeKeyDown={false} open={true}>
-      <DialogContent
-        width="400px"
-        alignItems="center"
-        mb={0}
-        textAlign="center"
-      >
-        {attempt.status !== 'failed' ? (
-          <>
-            {' '}
-            <Text bold caps mb={4}>
-              Registering Database
-            </Text>
-            <AnimatedProgressBar />
-            <TextIcon
-              css={`
-                white-space: pre;
-              `}
-            >
-              <Icons.Restore fontSize={4} />
-              <Timeout
-                timeout={pollTimeout}
-                message=""
-                tailMessage={' seconds left'}
-              />
-            </TextIcon>
-          </>
-        ) : (
-          <Box width="100%">
-            <Text bold caps mb={3}>
-              Database Register Failed
-            </Text>
-            <Text mb={5}>
-              <Icons.Warning ml={1} mr={2} color="danger" />
-              Error: {attempt.statusText}
-            </Text>
-            <Flex>
-              <ButtonPrimary mr={2} width="50%" onClick={retry}>
-                Retry
-              </ButtonPrimary>
-              <ButtonSecondary width="50%" onClick={close}>
-                Close
-              </ButtonSecondary>
-            </Flex>
-          </Box>
-        )}
-      </DialogContent>
-    </Dialog>
-  );
-};
+// const CreateDatabaseDialog = ({
+//   pollTimeout,
+//   attempt,
+//   retry,
+//   close,
+// }: {
+//   pollTimeout: number;
+//   attempt: Attempt;
+//   retry(): void;
+//   close(): void;
+// }) => {
+//   return (
+//     <Dialog disableEscapeKeyDown={false} open={true}>
+//       <DialogContent
+//         width="400px"
+//         alignItems="center"
+//         mb={0}
+//         textAlign="center"
+//       >
+//         {attempt.status !== 'failed' ? (
+//           <>
+//             {' '}
+//             <Text bold caps mb={4}>
+//               Registering Database
+//             </Text>
+//             <AnimatedProgressBar />
+//             <TextIcon
+//               css={`
+//                 white-space: pre;
+//               `}
+//             >
+//               <Icons.Restore fontSize={4} />
+//               <Timeout
+//                 timeout={pollTimeout}
+//                 message=""
+//                 tailMessage={' seconds left'}
+//               />
+//             </TextIcon>
+//           </>
+//         ) : (
+//           <Box width="100%">
+//             <Text bold caps mb={3}>
+//               Database Register Failed
+//             </Text>
+//             <Text mb={5}>
+//               <Icons.Warning ml={1} mr={2} color="danger" />
+//               Error: {attempt.statusText}
+//             </Text>
+//             <Flex>
+//               <ButtonPrimary mr={2} width="50%" onClick={retry}>
+//                 Retry
+//               </ButtonPrimary>
+//               <ButtonSecondary width="50%" onClick={close}>
+//                 Close
+//               </ButtonSecondary>
+//             </Flex>
+//           </Box>
+//         )}
+//       </DialogContent>
+//     </Dialog>
+//   );
+// };
 
 // PORT_REGEXP only allows digits with length 4.
 export const PORT_REGEX = /^\d{4}$/;
@@ -318,21 +324,24 @@ const requiredAwsAccountId = value => () => {
   };
 };
 
-// AWS_POLICY_NAME_REGEX only allows alphanumeric including the
-// following common characters: plus (+), equal (=), comma (,),
-// period (.), at (@), underscore (_), and hyphen (-).
-// As defined in: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
-export const AWS_POLICY_NAME_REGEX = /^[\w@+=,.:/-]+$/;
-const conformNameWithAWSPolicyNameReq = value => () => {
-  const isValid = value.match(AWS_POLICY_NAME_REGEX);
-  if (!isValid) {
-    return {
-      valid: false,
-      message:
-        'name must be alphanumerics, including characters such as _ @ = , . + -',
-    };
-  }
-  return {
-    valid: true,
-  };
-};
+// TODO(lisa): this check and the backend check does not match
+// re-visit and let backend do the checking for now.
+//
+// // AWS_POLICY_NAME_REGEX only allows alphanumeric including the
+// // following common characters: plus (+), equal (=), comma (,),
+// // period (.), at (@), underscore (_), and hyphen (-).
+// // As defined in: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
+// export const AWS_POLICY_NAME_REGEX = /^[\w@+=,.:/-]+$/;
+// const conformNameWithAWSPolicyNameReq = value => () => {
+//   const isValid = value.match(AWS_POLICY_NAME_REGEX);
+//   if (!isValid) {
+//     return {
+//       valid: false,
+//       message:
+//         'name must be alphanumerics, including characters such as _ @ = , . + -',
+//     };
+//   }
+//   return {
+//     valid: true,
+//   };
+// };

--- a/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.test.tsx
+++ b/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.test.tsx
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import { renderHook, act } from '@testing-library/react-hooks';
+// import React from 'react';
+// import { renderHook, act } from '@testing-library/react-hooks';
 
-import { createTeleportContext } from 'teleport/mocks/contexts';
-import { ContextProvider } from 'teleport';
+// import { createTeleportContext } from 'teleport/mocks/contexts';
+// import { ContextProvider } from 'teleport';
 
 import {
-  useCreateDatabase,
+  // useCreateDatabase,
   findActiveDatabaseSvc,
-  WAITING_TIMEOUT,
+  // WAITING_TIMEOUT,
 } from './useCreateDatabase';
 
-import type { CreateDatabaseRequest } from 'teleport/services/databases';
+// import type { CreateDatabaseRequest } from 'teleport/services/databases';
 
 const dbLabels = [
   { name: 'env', value: 'prod' },
@@ -63,201 +63,207 @@ describe('findActiveDatabaseSvc', () => {
   });
 });
 
-const newDatabaseReq: CreateDatabaseRequest = {
-  name: 'db-name',
-  protocol: 'postgres',
-  uri: 'https://localhost:5432',
-  labels: dbLabels,
-};
+// const newDatabaseReq: CreateDatabaseRequest = {
+//   name: 'db-name',
+//   protocol: 'postgres',
+//   uri: 'https://localhost:5432',
+//   labels: dbLabels,
+// };
 
-jest.useFakeTimers();
+// jest.useFakeTimers();
 
-describe('registering new databases, mainly error checking', () => {
-  const props = {
-    agentMeta: {} as any,
-    updateAgentMeta: jest.fn(x => x),
-    nextStep: jest.fn(x => x),
-    resourceState: {},
-  };
-  const ctx = createTeleportContext();
+// eslint-disable-next-line jest/no-commented-out-tests
+// describe('registering new databases, mainly error checking', () => {
+//   const props = {
+//     agentMeta: {} as any,
+//     updateAgentMeta: jest.fn(x => x),
+//     nextStep: jest.fn(x => x),
+//     resourceState: {},
+//   };
+//   const ctx = createTeleportContext();
 
-  let wrapper;
+//   let wrapper;
 
-  beforeEach(() => {
-    jest
-      .spyOn(ctx.databaseService, 'fetchDatabases')
-      .mockResolvedValue({ agents: [{ name: 'new-db' } as any] });
-    jest.spyOn(ctx.databaseService, 'createDatabase').mockResolvedValue(null); // ret val not used
-    jest
-      .spyOn(ctx.databaseService, 'fetchDatabaseServices')
-      .mockResolvedValue({ services });
+//   beforeEach(() => {
+//     jest
+//       .spyOn(ctx.databaseService, 'fetchDatabases')
+//       .mockResolvedValue({ agents: [{ name: 'new-db' } as any] });
+//     jest.spyOn(ctx.databaseService, 'createDatabase').mockResolvedValue(null); // ret val not used
+//     jest
+//       .spyOn(ctx.databaseService, 'fetchDatabaseServices')
+//       .mockResolvedValue({ services });
 
-    wrapper = ({ children }) => (
-      <ContextProvider ctx={ctx}>{children}</ContextProvider>
-    );
-  });
+//     wrapper = ({ children }) => (
+//       <ContextProvider ctx={ctx}>{children}</ContextProvider>
+//     );
+//   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+//   afterEach(() => {
+//     jest.clearAllMocks();
+//   });
 
-  test('with matching service, activates polling', async () => {
-    const { result } = renderHook(() => useCreateDatabase(props), {
-      wrapper,
-    });
+// eslint-disable-next-line jest/no-commented-out-tests
+//   test('with matching service, activates polling', async () => {
+//     const { result } = renderHook(() => useCreateDatabase(props), {
+//       wrapper,
+//     });
 
-    // Check polling hasn't started.
-    expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
+//     // Check polling hasn't started.
+//     expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
 
-    await act(async () => {
-      result.current.registerDatabase(newDatabaseReq);
-    });
-    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+//     await act(async () => {
+//       result.current.registerDatabase(newDatabaseReq);
+//     });
+//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
 
-    await act(async () => jest.advanceTimersByTime(3000));
-    expect(ctx.databaseService.fetchDatabases).toHaveBeenCalledTimes(1);
-    expect(props.nextStep).toHaveBeenCalledWith(2);
-    expect(props.updateAgentMeta).toHaveBeenCalledWith({
-      resourceName: 'db-name',
-      agentMatcherLabels: dbLabels,
-      db: { name: 'new-db' },
-    });
-  });
+//     await act(async () => jest.advanceTimersByTime(3000));
+//     expect(ctx.databaseService.fetchDatabases).toHaveBeenCalledTimes(1);
+//     expect(props.nextStep).toHaveBeenCalledWith(2);
+//     expect(props.updateAgentMeta).toHaveBeenCalledWith({
+//       resourceName: 'db-name',
+//       agentMatcherLabels: dbLabels,
+//       db: { name: 'new-db' },
+//     });
+//   });
 
-  test('when there are no services, skips polling', async () => {
-    jest
-      .spyOn(ctx.databaseService, 'fetchDatabaseServices')
-      .mockResolvedValue({ services: [] } as any);
-    const { result, waitFor } = renderHook(() => useCreateDatabase(props), {
-      wrapper,
-    });
+// eslint-disable-next-line jest/no-commented-out-tests
+//   test('when there are no services, skips polling', async () => {
+//     jest
+//       .spyOn(ctx.databaseService, 'fetchDatabaseServices')
+//       .mockResolvedValue({ services: [] } as any);
+//     const { result, waitFor } = renderHook(() => useCreateDatabase(props), {
+//       wrapper,
+//     });
 
-    act(() => {
-      result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
-    });
+//     act(() => {
+//       result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
+//     });
 
-    await waitFor(() => {
-      expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-    });
+//     await waitFor(() => {
+//       expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+//     });
 
-    await waitFor(() => {
-      expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(
-        1
-      );
-    });
+//     await waitFor(() => {
+//       expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(
+//         1
+//       );
+//     });
 
-    expect(props.nextStep).toHaveBeenCalledWith();
-    expect(props.updateAgentMeta).toHaveBeenCalledWith({
-      resourceName: 'db-name',
-      agentMatcherLabels: [],
-    });
-    expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
-  });
+//     expect(props.nextStep).toHaveBeenCalledWith();
+//     expect(props.updateAgentMeta).toHaveBeenCalledWith({
+//       resourceName: 'db-name',
+//       agentMatcherLabels: [],
+//     });
+//     expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
+//   });
 
-  test('when failed to create db, stops flow', async () => {
-    jest.spyOn(ctx.databaseService, 'createDatabase').mockRejectedValue(null);
-    const { result } = renderHook(() => useCreateDatabase(props), {
-      wrapper,
-    });
+// eslint-disable-next-line jest/no-commented-out-tests
+//   test('when failed to create db, stops flow', async () => {
+//     jest.spyOn(ctx.databaseService, 'createDatabase').mockRejectedValue(null);
+//     const { result } = renderHook(() => useCreateDatabase(props), {
+//       wrapper,
+//     });
 
-    await act(async () => {
-      result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
-    });
+//     await act(async () => {
+//       result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
+//     });
 
-    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
-    expect(props.nextStep).not.toHaveBeenCalled();
-    expect(result.current.attempt.status).toBe('failed');
-  });
+//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
+//     expect(props.nextStep).not.toHaveBeenCalled();
+//     expect(result.current.attempt.status).toBe('failed');
+//   });
 
-  test('when failed to fetch services, stops flow and retries properly', async () => {
-    jest
-      .spyOn(ctx.databaseService, 'fetchDatabaseServices')
-      .mockRejectedValue(null);
-    const { result } = renderHook(() => useCreateDatabase(props), {
-      wrapper,
-    });
+// eslint-disable-next-line jest/no-commented-out-tests
+//   test('when failed to fetch services, stops flow and retries properly', async () => {
+//     jest
+//       .spyOn(ctx.databaseService, 'fetchDatabaseServices')
+//       .mockRejectedValue(null);
+//     const { result } = renderHook(() => useCreateDatabase(props), {
+//       wrapper,
+//     });
 
-    await act(async () => {
-      result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
-    });
+//     await act(async () => {
+//       result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
+//     });
 
-    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
-    expect(props.nextStep).not.toHaveBeenCalled();
-    expect(result.current.attempt.status).toBe('failed');
+//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabases).not.toHaveBeenCalled();
+//     expect(props.nextStep).not.toHaveBeenCalled();
+//     expect(result.current.attempt.status).toBe('failed');
 
-    // Test retrying with same request, skips creating database since it's been already created.
-    jest.clearAllMocks();
-    await act(async () => {
-      result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
-    });
-    expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
-    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-    expect(result.current.attempt.status).toBe('failed');
+//     // Test retrying with same request, skips creating database since it's been already created.
+//     jest.clearAllMocks();
+//     await act(async () => {
+//       result.current.registerDatabase({ ...newDatabaseReq, labels: [] });
+//     });
+//     expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
+//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+//     expect(result.current.attempt.status).toBe('failed');
 
-    // Test retrying with a new db request (new name), triggers create database.
-    jest.clearAllMocks();
-    await act(async () => {
-      result.current.registerDatabase({
-        ...newDatabaseReq,
-        labels: [],
-        name: 'new-db-name',
-      });
-    });
-    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-    expect(result.current.attempt.status).toBe('failed');
-  });
+//     // Test retrying with a new db request (new name), triggers create database.
+//     jest.clearAllMocks();
+//     await act(async () => {
+//       result.current.registerDatabase({
+//         ...newDatabaseReq,
+//         labels: [],
+//         name: 'new-db-name',
+//       });
+//     });
+//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+//     expect(result.current.attempt.status).toBe('failed');
+//   });
 
-  test('when polling timeout, retries properly', async () => {
-    jest
-      .spyOn(ctx.databaseService, 'fetchDatabases')
-      .mockResolvedValue({ agents: [] });
-    const { result } = renderHook(() => useCreateDatabase(props), {
-      wrapper,
-    });
+// eslint-disable-next-line jest/no-commented-out-tests
+//   test('when polling timeout, retries properly', async () => {
+//     jest
+//       .spyOn(ctx.databaseService, 'fetchDatabases')
+//       .mockResolvedValue({ agents: [] });
+//     const { result } = renderHook(() => useCreateDatabase(props), {
+//       wrapper,
+//     });
 
-    await act(async () => {
-      result.current.registerDatabase(newDatabaseReq);
-    });
+//     await act(async () => {
+//       result.current.registerDatabase(newDatabaseReq);
+//     });
 
-    act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
+//     act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
 
-    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
-    expect(props.nextStep).not.toHaveBeenCalled();
-    expect(result.current.attempt.status).toBe('failed');
-    expect(result.current.attempt.statusText).toContain('could not detect');
+//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
+//     expect(props.nextStep).not.toHaveBeenCalled();
+//     expect(result.current.attempt.status).toBe('failed');
+//     expect(result.current.attempt.statusText).toContain('could not detect');
 
-    // Test retrying with same request, skips creating database.
-    jest.clearAllMocks();
-    await act(async () => {
-      result.current.registerDatabase(newDatabaseReq);
-    });
-    act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
+//     // Test retrying with same request, skips creating database.
+//     jest.clearAllMocks();
+//     await act(async () => {
+//       result.current.registerDatabase(newDatabaseReq);
+//     });
+//     act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
 
-    expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
-    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
-    expect(result.current.attempt.status).toBe('failed');
+//     expect(ctx.databaseService.createDatabase).not.toHaveBeenCalled();
+//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
+//     expect(result.current.attempt.status).toBe('failed');
 
-    // Test retrying with request with diff db name, creates and fetches new services.
-    jest.clearAllMocks();
-    await act(async () => {
-      result.current.registerDatabase({
-        ...newDatabaseReq,
-        name: 'new-db-name',
-      });
-    });
-    act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
+//     // Test retrying with request with diff db name, creates and fetches new services.
+//     jest.clearAllMocks();
+//     await act(async () => {
+//       result.current.registerDatabase({
+//         ...newDatabaseReq,
+//         name: 'new-db-name',
+//       });
+//     });
+//     act(() => jest.advanceTimersByTime(WAITING_TIMEOUT + 1));
 
-    expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
-    expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
-    expect(result.current.attempt.status).toBe('failed');
-  });
-});
+//     expect(ctx.databaseService.createDatabase).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabaseServices).toHaveBeenCalledTimes(1);
+//     expect(ctx.databaseService.fetchDatabases).toHaveBeenCalled();
+//     expect(result.current.attempt.status).toBe('failed');
+//   });
+// });

--- a/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.story.tsx
+++ b/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.story.tsx
@@ -55,6 +55,7 @@ export const InitWithLabels = () => {
   return (
     <Provider>
       <DownloadScript
+        {...props}
         agentMeta={{
           ...props.agentMeta,
           agentMatcherLabels: [{ name: 'env', value: 'prod' }],
@@ -116,7 +117,7 @@ export const Processing = () => {
   );
   return (
     <Provider interval={5}>
-      <DownloadScript runJoinTokenPromise={true} />
+      <DownloadScript runJoinTokenPromise={true} {...props} />
     </Provider>
   );
 };
@@ -129,7 +130,7 @@ export const Failed = () => {
   );
   return (
     <Provider>
-      <DownloadScript runJoinTokenPromise={true} />
+      <DownloadScript runJoinTokenPromise={true} {...props} />
     </Provider>
   );
 };
@@ -169,4 +170,5 @@ const props = {
     agentMatcherLabels: [],
     db: {} as any,
   },
+  nextStep: () => null,
 };

--- a/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
@@ -74,7 +74,7 @@ export default function Container(
       {({ validator }) => (
         <CatchError
           onRetry={clearCachedJoinTokenResult}
-          fallbackFn={props => (
+          fallbackFn={fbProps => (
             <Box>
               <Heading />
               <Labels
@@ -85,7 +85,7 @@ export default function Container(
                       if (!validator.validate()) {
                         return;
                       }
-                      props.retry();
+                      fbProps.retry();
                     }}
                   />
                 }
@@ -93,10 +93,14 @@ export default function Container(
               <Box>
                 <TextIcon mt={3}>
                   <Icons.Warning ml={1} color="danger" />
-                  Encountered Error: {props.error.message}
+                  Encountered Error: {fbProps.error.message}
                 </TextIcon>
               </Box>
-              <ActionButtons onProceed={() => null} disableProceed={true} />
+              <ActionButtons
+                onProceed={() => null}
+                disableProceed={true}
+                onSkip={props.nextStep}
+              />
             </Box>
           )}
         >
@@ -109,7 +113,11 @@ export default function Container(
                   disableBtns={true}
                   generateBtn={<ButtonGenerateCmd disabled={true} />}
                 />
-                <ActionButtons onProceed={() => null} disableProceed={true} />
+                <ActionButtons
+                  onProceed={() => null}
+                  disableProceed={true}
+                  onSkip={props.nextStep}
+                />
               </Box>
             }
           >
@@ -124,7 +132,11 @@ export default function Container(
                     />
                   }
                 />
-                <ActionButtons onProceed={() => null} disableProceed={true} />
+                <ActionButtons
+                  onProceed={() => null}
+                  disableProceed={true}
+                  onSkip={props.nextStep}
+                />
               </Box>
             )}
             {showScript && (
@@ -228,6 +240,7 @@ export function DownloadScript(
       <ActionButtons
         onProceed={handleNextStep}
         disableProceed={poll.state !== 'success' || props.labels.length === 0}
+        onSkip={props.nextStep}
       />
     </Box>
   );
@@ -236,8 +249,11 @@ export function DownloadScript(
 const Heading = () => {
   return (
     <>
-      <Header>Deploy a Database Service</Header>
+      <Header>Optionally Deploy a Database Service</Header>
       <HeaderSubtitle>
+        This step is optional if you already have a Teleport Database Service
+        running.
+        <br />
         On the host where you will run the Teleport Database Service, execute
         the generated command that will install and start Teleport with the
         appropriate configuration.

--- a/packages/teleport/src/Discover/Shared/ActionButtons.tsx
+++ b/packages/teleport/src/Discover/Shared/ActionButtons.tsx
@@ -25,14 +25,17 @@ import cfg from 'teleport/config';
 
 export const ActionButtons = ({
   onProceed = null,
+  onSkip = null,
   proceedHref = '',
   disableProceed = false,
   lastStep = false,
 }: {
   onProceed?(): void;
+  onSkip?(): void;
   proceedHref?: string;
   disableProceed?: boolean;
   lastStep?: boolean;
+  allowSkip?: boolean;
 }) => {
   return (
     <Box mt={4}>
@@ -58,6 +61,11 @@ export const ActionButtons = ({
         >
           {lastStep ? 'Finish' : 'Next'}
         </ButtonPrimary>
+      )}
+      {onSkip && (
+        <ButtonSecondary width="165px" onClick={onSkip} mr={3}>
+          Skip
+        </ButtonSecondary>
       )}
       <ButtonSecondary as={NavLink} to={cfg.routes.root} mt={3} width="165px">
         Exit

--- a/packages/teleport/src/Discover/Shared/ActionButtons.tsx
+++ b/packages/teleport/src/Discover/Shared/ActionButtons.tsx
@@ -37,6 +37,8 @@ export const ActionButtons = ({
   lastStep?: boolean;
   allowSkip?: boolean;
 }) => {
+  const allowSkip = !!onSkip;
+
   return (
     <Box mt={4}>
       {proceedHref && (
@@ -62,7 +64,7 @@ export const ActionButtons = ({
           {lastStep ? 'Finish' : 'Next'}
         </ButtonPrimary>
       )}
-      {onSkip && (
+      {allowSkip && (
         <ButtonSecondary width="165px" onClick={onSkip} mr={3}>
           Skip
         </ButtonSecondary>

--- a/packages/teleport/src/services/databases/databases.test.ts
+++ b/packages/teleport/src/services/databases/databases.test.ts
@@ -113,6 +113,7 @@ test('database services fetch response', async () => {
         env: ['prod', 'env'],
         os: ['mac', 'ios', 'linux', 'windows'],
         tag: ['tag'],
+        fruit: ['apple'],
       },
     },
     {
@@ -157,7 +158,9 @@ const mockServiceResponse = {
     {
       name: 'db-service-1',
       resource_matchers: [
-        { labels: { env: ['prod', 'env'], os: ['mac', 'ios'] } },
+        {
+          labels: { env: ['prod', 'env'], os: ['mac', 'ios'], fruit: 'apple' },
+        },
         { labels: { os: ['linux', 'windows'], tag: ['tag'] } },
       ],
     },

--- a/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/packages/teleport/src/services/databases/makeDatabase.ts
@@ -54,7 +54,16 @@ function combineResourceMatcherLabels(
       if (!labelMap[key]) {
         labelMap[key] = [];
       }
-      labelMap[key] = [...labelMap[key], ...rm.labels[key]];
+
+      // The type return can be a list of strings, or
+      // just a string. We convert it to an array
+      // to keep it consistent.
+      let vals = rm.labels[key];
+      if (!Array.isArray(vals)) {
+        vals = [vals];
+      }
+
+      labelMap[key] = [...labelMap[key], ...vals];
     });
   });
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/16858

#### Description
- Fixes a bug where when we query for db service (no longer called atm), the labels return can be a `map[string]string OR []string`, so we just check if the label value is an array.
- Temporarily remove the service checker until bug is fixed: https://github.com/gravitational/teleport/issues/19919
- Because of no service checker which guaranteed that there was a active db server that can pick up the newly created database, we now leave it up to the user to add or skip installing the database service
  - If user skipped the installing step, and there was no active db service, the user will have to restart the flow at this time