### PR TITLE
Make support links open a new tab

### DIFF
--- a/packages/teleport/src/Support/Support.tsx
+++ b/packages/teleport/src/Support/Support.tsx
@@ -185,7 +185,7 @@ const getDownloadLink = (isCloud: boolean, isEnterprise: boolean) => {
 };
 
 const SupportLink = ({ title = '', url = '' }) => (
-  <StyledSupportLink href={url}>{title}</StyledSupportLink>
+  <StyledSupportLink href={url} target="_blank">{title}</StyledSupportLink>
 );
 
 const StyledSupportLink = styled.a.attrs({


### PR DESCRIPTION
Opens support links in new tab instead of current tab.  This is typical for help and support links.