### PR TITLE
[v11] Add lazy loading for session playback

### DIFF
--- a/packages/teleport/src/Teleport.tsx
+++ b/packages/teleport/src/Teleport.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import ThemeProvider from 'design/ThemeProvider';
 
 import { Router, Route, Switch } from 'teleport/components/Router';
@@ -34,7 +34,6 @@ import AppLauncher from './AppLauncher';
 import Console from './Console';
 import DesktopSession from './DesktopSession';
 import { Discover } from './Discover';
-import Player from './Player';
 import TeleportContextProvider from './TeleportContextProvider';
 import TeleportContext from './teleportContext';
 import cfg from './config';
@@ -52,24 +51,26 @@ const Teleport: React.FC<Props> = props => {
     <CatchError>
       <ThemeProvider>
         <Router history={history}>
-          <Switch>
-            {publicRoutes()}
-            <Route path={cfg.routes.root}>
-              <Authenticated>
-                <TeleportContextProvider ctx={ctx}>
-                  <FeaturesContextProvider value={features}>
-                    <Switch>
-                      <Route
-                        path={cfg.routes.appLauncher}
-                        component={AppLauncher}
-                      />
-                      <Route>{privateRoutes()}</Route>
-                    </Switch>
-                  </FeaturesContextProvider>
-                </TeleportContextProvider>
-              </Authenticated>
-            </Route>
-          </Switch>
+          <Suspense fallback={null}>
+            <Switch>
+              {publicRoutes()}
+              <Route path={cfg.routes.root}>
+                <Authenticated>
+                  <TeleportContextProvider ctx={ctx}>
+                    <FeaturesContextProvider value={features}>
+                      <Switch>
+                        <Route
+                          path={cfg.routes.appLauncher}
+                          component={AppLauncher}
+                        />
+                        <Route>{privateRoutes()}</Route>
+                      </Switch>
+                    </FeaturesContextProvider>
+                  </TeleportContextProvider>
+                </Authenticated>
+              </Route>
+            </Switch>
+          </Suspense>
         </Router>
       </ThemeProvider>
     </CatchError>
@@ -112,6 +113,10 @@ export function renderPublicRoutes(children = []) {
     />,
   ];
 }
+
+const Player = React.lazy(
+  () => import(/* webpackChunkName: "player" */ './Player')
+);
 
 // TODO: make it lazy loadable
 export function renderPrivateRoutes(


### PR DESCRIPTION
This would fix https://github.com/gravitational/teleport/issues/20044

The immediate rendering of the `Authenticated` component in OSS means that we don't have enough time to receive a token from other tabs on the `BroadcastChannel`, so when opening a new tab (for session playback) the tab becomes unauthenticated during the initial render.

By adding lazy loading, we can delay the rendering of `Authenticated` enough (by falling back to the `Suspense` component) for the token to be received and the tab to be authenticated during the initial render.