### PR TITLE
[v11] Add lazy loading for desktop sessions

### DIFF
--- a/packages/teleport/src/Teleport.tsx
+++ b/packages/teleport/src/Teleport.tsx
@@ -32,7 +32,6 @@ import Welcome from './Welcome';
 import Login, { LoginSuccess, LoginFailed } from './Login';
 import AppLauncher from './AppLauncher';
 import Console from './Console';
-import DesktopSession from './DesktopSession';
 import { Discover } from './Discover';
 import TeleportContextProvider from './TeleportContextProvider';
 import TeleportContext from './teleportContext';
@@ -116,6 +115,10 @@ export function renderPublicRoutes(children = []) {
 
 const Player = React.lazy(
   () => import(/* webpackChunkName: "player" */ './Player')
+);
+
+const DesktopSession = React.lazy(
+  () => import(/* webpackChunkName: "desktop-session" */ './DesktopSession')
 );
 
 // TODO: make it lazy loadable


### PR DESCRIPTION
As desktop sessions also start in a new tab, we should lazy load them so there's time for the broadcast channel to receive a token.

Similar to #1502 