### PR TITLE
Fix double token creation in Desktop Discovery

### DIFF
--- a/packages/teleport/src/Apps/AddApp/useAddApp.ts
+++ b/packages/teleport/src/Apps/AddApp/useAddApp.ts
@@ -36,7 +36,7 @@ export default function useAddApp(ctx: TeleportContext) {
 
   function createToken() {
     return run(() =>
-      ctx.joinTokenService.fetchJoinToken({ roles: ['App'] }).then(setToken)
+      ctx.joinTokenService.createJoinToken({ roles: ['App'] }).then(setToken)
     );
   }
 

--- a/packages/teleport/src/Discover/Database/AddDatabaseModal/useAddDatabase.ts
+++ b/packages/teleport/src/Discover/Database/AddDatabaseModal/useAddDatabase.ts
@@ -31,7 +31,7 @@ export default function useAddDatabase(ctx: TeleportContext) {
 
   function createJoinToken() {
     return run(() =>
-      ctx.joinTokenService.fetchJoinToken({ roles: ['Db'] }).then(setToken)
+      ctx.joinTokenService.createJoinToken({ roles: ['Db'] }).then(setToken)
     );
   }
 

--- a/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
@@ -21,7 +21,7 @@ import Validation, { Validator, useRule } from 'shared/components/Validation';
 
 import { CatchError } from 'teleport/components/CatchError';
 import {
-  useJoinToken,
+  useCreateJoinToken,
   clearCachedJoinTokenResult,
 } from 'teleport/Discover/Shared/JoinTokenContext';
 import { usePingTeleport } from 'teleport/Discover/Shared/PingTeleportContext';
@@ -162,7 +162,7 @@ export function DownloadScript(
   }
 ) {
   // Fetches join token.
-  const { joinToken, reloadJoinToken, timeout } = useJoinToken(
+  const { joinToken, reloadJoinToken, timeout } = useCreateJoinToken(
     ResourceKind.Database,
     props.labels
   );

--- a/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -47,7 +47,7 @@ export function useMutualTls({ ctx, props }: Props) {
       // This also means it invalidates the existing joinToken.
       run(() =>
         ctx.joinTokenService
-          .fetchJoinToken({
+          .createJoinToken({
             roles: [resourceKindToJoinRole(ResourceKind.Database)],
             method: 'token',
           })

--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/ConnectTeleport.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/ConnectTeleport.tsx
@@ -96,10 +96,15 @@ const verticalTransitionStyles = {
 };
 
 import { State } from 'teleport/Discover/useDiscover';
+import { ResourceKind } from 'teleport/Discover/Shared';
+import { useCreateJoinToken } from 'teleport/Discover/Shared/JoinTokenContext';
 
 export function ConnectTeleport(props: State) {
   const [currentStep, setCurrentStep] = useState(StepKind.RunConfigureScript);
   const step = steps.find(s => s.kind === currentStep);
+  const { joinToken, reloadJoinToken, timeout, timedOut } = useCreateJoinToken(
+    ResourceKind.Desktop
+  );
 
   let animation;
   if (step.animation !== null) {
@@ -124,6 +129,7 @@ export function ConnectTeleport(props: State) {
                     <Suspense fallback={<Window title="Terminal" />}>
                       <RunConfigureScriptAnimation
                         isCopying={step.kind === StepKind.CopyOutput}
+                        joinToken={joinToken}
                       />
                     </Suspense>
                   )}
@@ -157,6 +163,10 @@ export function ConnectTeleport(props: State) {
                 <Suspense fallback={<RunConfigureScriptLoading />}>
                   <RunConfigureScript
                     onNext={() => setCurrentStep(StepKind.CopyOutput)}
+                    joinToken={joinToken}
+                    reloadJoinToken={reloadJoinToken}
+                    timeout={timeout}
+                    timedOut={timedOut}
                   />
                 </Suspense>
               )}

--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScript.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScript.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-
 import * as Icons from 'design/Icon';
-
 import { ButtonPrimary } from 'design/Button';
 import { Text, Box } from 'design';
 
@@ -14,24 +12,24 @@ import {
 } from 'teleport/Discover/Desktop/ConnectTeleport/Step';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import { generateCommand } from 'teleport/Discover/Shared/generateCommand';
-
 import cfg from 'teleport/config';
 import { Timeout } from 'teleport/Discover/Shared/Timeout';
-import { useJoinToken } from 'teleport/Discover/Shared/JoinTokenContext';
-import { ResourceKind } from 'teleport/Discover/Shared';
+import { JoinToken } from 'teleport/services/joinToken';
 
 import loading from './run-configure-script-loading.svg';
 
 interface RunConfigureScriptProps {
   onNext: () => void;
+  joinToken: JoinToken;
+  reloadJoinToken: () => void;
+  timeout: number;
+  timedOut: boolean;
 }
 
 export function RunConfigureScript(
   props: React.PropsWithChildren<RunConfigureScriptProps>
 ) {
-  const { joinToken, reloadJoinToken, timeout, timedOut } = useJoinToken(
-    ResourceKind.Desktop
-  );
+  const { joinToken, reloadJoinToken, timeout, timedOut } = props;
 
   let content;
   if (timedOut) {

--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScriptAnimation.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScriptAnimation.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
-
 import {
   AnimatedTerminal,
   TerminalColor,
 } from 'shared/components/AnimatedTerminal';
-
 import { KeywordHighlight } from 'shared/components/AnimatedTerminal/TerminalContent';
 
 import cfg from 'teleport/config';
-import { ResourceKind } from 'teleport/Discover/Shared';
-
 import { generateCommand } from 'teleport/Discover/Shared/generateCommand';
-import { useJoinToken } from 'teleport/Discover/Shared/JoinTokenContext';
 import { JoinToken } from 'teleport/services/joinToken';
 
 const lines = (joinToken: JoinToken) => [
@@ -87,12 +82,13 @@ const highlights: KeywordHighlight[] = [
 
 interface RunConfigureScriptAnimationProps {
   isCopying: boolean;
+  joinToken: JoinToken;
 }
 
 export function RunConfigureScriptAnimation(
   props: RunConfigureScriptAnimationProps
 ) {
-  const { joinToken } = useJoinToken(ResourceKind.Desktop);
+  const { joinToken } = props;
 
   return (
     <AnimatedTerminal

--- a/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -25,7 +25,7 @@ import { requiredField } from 'shared/components/Validation/rules';
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import { CatchError } from 'teleport/components/CatchError';
 import {
-  useJoinToken,
+  useCreateJoinToken,
   clearCachedJoinTokenResult,
 } from 'teleport/Discover/Shared/JoinTokenContext';
 import useTeleport from 'teleport/useTeleport';
@@ -126,7 +126,7 @@ export function HelmChart(
     setClusterName(c: string): void;
   }
 ) {
-  const { joinToken, reloadJoinToken, timeout } = useJoinToken(
+  const { joinToken, reloadJoinToken, timeout } = useCreateJoinToken(
     ResourceKind.Kubernetes
   );
 
@@ -292,7 +292,7 @@ teleportVersionOverride: ${data.clusterVersion}
 labels:
     teleport.internal/resource-id: ${data.resourceId}
 EOF
- 
+
 helm install teleport-agent teleport/teleport-kube-agent -f prod-cluster-values.yaml --create-namespace --namespace ${data.namespace}`;
 };
 

--- a/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.tsx
@@ -21,7 +21,7 @@ import * as Icons from 'design/Icon';
 import cfg from 'teleport/config';
 import { CatchError } from 'teleport/components/CatchError';
 import {
-  useJoinToken,
+  useCreateJoinToken,
   clearCachedJoinTokenResult,
 } from 'teleport/Discover/Shared/JoinTokenContext';
 import { usePingTeleport } from 'teleport/Discover/Shared/PingTeleportContext';
@@ -81,7 +81,7 @@ export default function Container(props: AgentStepProps) {
 
 export function DownloadScript(props: AgentStepProps) {
   // Fetches join token.
-  const { joinToken, reloadJoinToken, timeout } = useJoinToken(
+  const { joinToken, reloadJoinToken, timeout } = useCreateJoinToken(
     ResourceKind.Server
   );
   // Starts resource querying interval.

--- a/packages/teleport/src/Discover/Shared/JoinTokenContext.tsx
+++ b/packages/teleport/src/Discover/Shared/JoinTokenContext.tsx
@@ -78,7 +78,7 @@ export function useJoinTokenValue() {
   return tokenContext.joinToken;
 }
 
-export function useJoinToken(
+export function useCreateJoinToken(
   resourceKind: ResourceKind,
   suggestedAgentMatcherLabels: AgentLabel[] = [],
   joinMethod: JoinMethod = 'token'
@@ -96,7 +96,7 @@ export function useJoinToken(
 
     cachedJoinTokenResult = {
       promise: ctx.joinTokenService
-        .fetchJoinToken(
+        .createJoinToken(
           {
             roles: [resourceKindToJoinRole(resourceKind)],
             method: joinMethod,
@@ -150,6 +150,5 @@ export function useJoinToken(
 
     throw cachedJoinTokenResult.promise;
   }
-
   throw run().promise;
 }

--- a/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -26,7 +26,7 @@ test('fetchJoinToken with an empty request properly sets defaults', () => {
   jest.spyOn(api, 'post').mockResolvedValue(null);
 
   // Test with all empty fields.
-  svc.fetchJoinToken({} as any);
+  svc.createJoinToken({} as any);
   expect(api.post).toHaveBeenCalledWith(
     cfg.getJoinTokenUrl(),
     {
@@ -49,7 +49,7 @@ test('fetchJoinToken request fields are set as requested', () => {
     method: 'iam',
     suggestedAgentMatcherLabels: [{ name: 'env', value: 'dev' }],
   };
-  svc.fetchJoinToken(mock);
+  svc.createJoinToken(mock);
   expect(api.post).toHaveBeenCalledWith(
     cfg.getJoinTokenUrl(),
     {

--- a/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/packages/teleport/src/services/joinToken/joinToken.ts
@@ -23,7 +23,7 @@ import makeJoinToken from './makeJoinToken';
 import { JoinToken, JoinRule, JoinTokenRequest } from './types';
 
 class JoinTokenService {
-  fetchJoinToken(
+  createJoinToken(
     req: JoinTokenRequest,
     signal: AbortSignal = null
   ): Promise<JoinToken> {


### PR DESCRIPTION
psuedo-fixes the double token creation, however it doesn't account for the fact that we were using the thrown promises in useJoinToken to control the Suspense component