### PR TITLE
Wait for child processes to exit before closing the app

### DIFF
--- a/packages/shared/components/AnimatedTerminal/content.ts
+++ b/packages/shared/components/AnimatedTerminal/content.ts
@@ -1,3 +1,5 @@
+import { wait } from 'shared/utils/wait';
+
 export interface BufferEntry {
   id: number;
   text: string;
@@ -18,10 +20,6 @@ export interface TerminalLine {
   delay?: number;
   hasFinished?: () => boolean;
   frames?: FrameFunction[];
-}
-
-function wait(ms: number) {
-  return new Promise(resolve => window.setTimeout(resolve, ms));
 }
 
 export async function* createTerminalContent(

--- a/packages/shared/utils/wait.ts
+++ b/packages/shared/utils/wait.ts
@@ -1,0 +1,4 @@
+/** Resolves after a given duration */
+export function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/teleterm/src/main.ts
+++ b/packages/teleterm/src/main.ts
@@ -81,7 +81,7 @@ function initializeApp(): void {
     try {
       await mainProcess.dispose();
     } catch (e) {
-      logger.error('Failed to dispose main process', e);
+      logger.error('Failed to gracefully dispose of main process', e);
     } finally {
       app.exit();
     }

--- a/packages/teleterm/src/main.ts
+++ b/packages/teleterm/src/main.ts
@@ -78,8 +78,13 @@ function initializeApp(): void {
 
     appStateFileStorage.putAllSync();
     globalShortcut.unregisterAll();
-    await mainProcess.dispose();
-    app.exit();
+    try {
+      await mainProcess.dispose();
+    } catch (e) {
+      logger.error('Failed to dispose main process', e);
+    } finally {
+      app.exit();
+    }
   });
 
   app.on('quit', () => {

--- a/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -325,7 +325,7 @@ export default class MainProcess {
    * `tsh daemon stop` program. On Unix, the standard `SIGTERM` signal is sent.
    */
   private killTshdProcess() {
-    if (this.settings.platform === 'win32') {
+    if (this.settings.platform !== 'win32') {
       this.tshdProcess.kill('SIGTERM');
       return;
     }


### PR DESCRIPTION
Requires tshd counterpart to be merged first.

Currently, the Electron app doesn't wait for child processes to exit before the main processes is killed. Because of this, the processes can't run any async cleanup functions (on Windows [even sync functions don't run](https://nodejs.org/api/child_process.html#subprocesskillsignal)). 
This fix is mainly needed to send usage events when tshd exits. Sending the events can take up to a few seconds.

On Windows, where POSIX signals do not exist, the only way to gracefully kill a process is to send Ctrl-Break to its console. This task is done by `tsh daemon stop` program.

For now, the graceful kill is applied only to tshd. In the shared process we don't have any async logic that should be run on exit.
