### PR TITLE
Fix the caching logic for `useJoinToken`

### DIFF
--- a/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.story.tsx
+++ b/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.story.tsx
@@ -37,7 +37,7 @@ export default {
     Story => {
       // Reset request handlers added in individual stories.
       worker.resetHandlers();
-      clearCachedJoinTokenResult();
+      clearCachedJoinTokenResult(ResourceKind.Database);
       return <Story />;
     },
   ],

--- a/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/Database/DownloadScript/DownloadScript.tsx
@@ -73,7 +73,7 @@ export default function Container(
     <Validation>
       {({ validator }) => (
         <CatchError
-          onRetry={clearCachedJoinTokenResult}
+          onRetry={() => clearCachedJoinTokenResult(ResourceKind.Database)}
           fallbackFn={fbProps => (
             <Box>
               <Heading />

--- a/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -19,7 +19,7 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 
 import cfg from 'teleport/config';
 import TeleportContext from 'teleport/teleportContext';
-import { useJoinTokenValue } from 'teleport/Discover/Shared/JoinTokenContext';
+import { useJoinToken } from 'teleport/Discover/Shared/JoinTokenContext';
 import { ResourceKind } from 'teleport/Discover/Shared';
 import { resourceKindToJoinRole } from 'teleport/Discover/Shared/ResourceKind';
 
@@ -31,7 +31,9 @@ import type { Database } from '../resources';
 export function useMutualTls({ ctx, props }: Props) {
   const { attempt, run } = useAttempt('');
 
-  const prevFetchedJoinToken = useJoinTokenValue();
+  const { joinToken: prevFetchedJoinToken } = useJoinToken(
+    ResourceKind.Database
+  );
   const [joinToken, setJoinToken] = useState(prevFetchedJoinToken);
   const meta = props.agentMeta as DbMeta;
   const clusterId = ctx.storeUser.getClusterId();

--- a/packages/teleport/src/Discover/Desktop/ConnectTeleport/CreateTeleportConfigAnimation.tsx
+++ b/packages/teleport/src/Discover/Desktop/ConnectTeleport/CreateTeleportConfigAnimation.tsx
@@ -3,9 +3,10 @@ import styled from 'styled-components';
 
 import { Editor, File, Language } from 'shared/components/Editor';
 
-import { useJoinTokenValue } from 'teleport/Discover/Shared/JoinTokenContext';
+import { useJoinToken } from 'teleport/Discover/Shared/JoinTokenContext';
 
 import type { JoinToken } from 'teleport/services/joinToken';
+import { ResourceKind } from 'teleport/Discover/Shared';
 
 const pastedLines = (joinToken: JoinToken) => `version: v3
 teleport:
@@ -51,7 +52,7 @@ const states = (joinToken: JoinToken) => [
 ];
 
 export function CreateTeleportConfigAnimation() {
-  const joinToken = useJoinTokenValue();
+  const { joinToken } = useJoinToken(ResourceKind.Desktop);
 
   const [editorState, setEditorState] = useState(EditorState.Original);
 

--- a/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.story.tsx
+++ b/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.story.tsx
@@ -37,7 +37,7 @@ export default {
     Story => {
       // Reset request handlers added in individual stories.
       worker.resetHandlers();
-      clearCachedJoinTokenResult();
+      clearCachedJoinTokenResult(ResourceKind.Kubernetes);
       return <Story />;
     },
   ],

--- a/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -58,7 +58,7 @@ export default function Container(
     // This outer CatchError and Suspense handles
     // join token api fetch error and loading states.
     <CatchError
-      onRetry={clearCachedJoinTokenResult}
+      onRetry={() => clearCachedJoinTokenResult(ResourceKind.Kubernetes)}
       fallbackFn={props => (
         <Box>
           <Heading />

--- a/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.story.tsx
+++ b/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.story.tsx
@@ -37,7 +37,7 @@ export default {
     Story => {
       // Reset request handlers added in individual stories.
       worker.resetHandlers();
-      clearCachedJoinTokenResult();
+      clearCachedJoinTokenResult(ResourceKind.Server);
       return <Story />;
     },
   ],

--- a/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.tsx
+++ b/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.tsx
@@ -49,7 +49,7 @@ import type { Poll } from 'teleport/Discover/Shared/CommandWithTimer';
 export default function Container(props: AgentStepProps) {
   return (
     <CatchError
-      onRetry={clearCachedJoinTokenResult}
+      onRetry={() => clearCachedJoinTokenResult(ResourceKind.Server)}
       fallbackFn={props => (
         <Template pollState="error" nextStep={() => null}>
           <TextIcon mt={2} mb={3}>

--- a/packages/teleport/src/Discover/Shared/JoinTokenContext.tsx
+++ b/packages/teleport/src/Discover/Shared/JoinTokenContext.tsx
@@ -11,8 +11,6 @@ import type { AgentLabel } from 'teleport/services/agents';
 import type { JoinToken, JoinMethod } from 'teleport/services/joinToken';
 
 interface JoinTokenContextState {
-  joinToken: JoinToken;
-  setJoinToken: (joinToken: JoinToken) => void;
   timeout: number;
   timedOut: boolean;
   startTimer: () => void;
@@ -25,7 +23,6 @@ export function JoinTokenProvider(props: {
   timeout: number;
   children?: React.ReactNode;
 }) {
-  const [joinToken, setJoinToken] = useState<JoinToken>(null);
   const [timedOut, setTimedOut] = useState(false);
   const [timeout, setTokenTimeout] = useState<number>(null);
 
@@ -51,9 +48,7 @@ export function JoinTokenProvider(props: {
   }, [props.timeout]);
 
   return (
-    <joinTokenContext.Provider
-      value={{ joinToken, setJoinToken, timeout, startTimer, timedOut }}
-    >
+    <joinTokenContext.Provider value={{ timeout, startTimer, timedOut }}>
       {props.children}
     </joinTokenContext.Provider>
   );
@@ -75,12 +70,6 @@ let joinTokenCache = new Map<ResourceKind, CachedPromiseResult>();
 
 export function clearCachedJoinTokenResult(resourceKind: ResourceKind) {
   joinTokenCache.delete(resourceKind);
-}
-
-export function useJoinTokenValue() {
-  const tokenContext = useContext(joinTokenContext);
-
-  return tokenContext.joinToken;
 }
 
 export function useJoinToken(
@@ -120,7 +109,6 @@ export function useJoinToken(
             );
           }
           result.response = token;
-          tokenContext.setJoinToken(token);
           tokenContext.startTimer();
         })
         .catch(error => {

--- a/packages/teleport/src/Discover/Shared/PingTeleportContext.tsx
+++ b/packages/teleport/src/Discover/Shared/PingTeleportContext.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useTeleport } from 'teleport';
 import { usePoll } from 'teleport/Discover/Shared/usePoll';
 import { INTERNAL_RESOURCE_ID_LABEL_KEY } from 'teleport/services/joinToken';
-import { useJoinTokenValue } from 'teleport/Discover/Shared/JoinTokenContext';
+import { useJoinToken } from 'teleport/Discover/Shared/JoinTokenContext';
 import { ResourceKind } from 'teleport/Discover/Shared/ResourceKind';
 
 interface PingTeleportContextState<T> {
@@ -35,7 +35,7 @@ export function PingTeleportProvider<T>(props: {
   // that proxies a database that goes by this alternateSearchTerm (eg. resourceName).
   const [alternateSearchTerm, setAlternateSearchTerm] = useState('');
 
-  const joinToken = useJoinTokenValue();
+  const { joinToken } = useJoinToken(props.resourceKind);
 
   const { timedOut, result } = usePoll<T>(
     signal =>


### PR DESCRIPTION
`useJoinToken` can be called multiple times but needs to only return the current promise/cached result for the given resource type.

Before, we were clearing out the cached result when the hook was unmounted, which happens between the different steps of the desktop flow.

You can see in this video the join token ID changing between steps -

https://user-images.githubusercontent.com/7922109/212996129-106fb38b-234a-4e0e-94a4-601dc893ad8b.mov

By implementing a cache that's separated by resource type, which an expiration time that's equal to the timeout specified to the `JoinTokenProvider`, we can remove the need to clear the cache out on unmount and have the join token persist between `useJoinToken` unmounting and then being used again later in the flow.

You can see the join token ID persisting between steps after this change - 

https://user-images.githubusercontent.com/7922109/212996419-188c1238-2c48-4ec9-974b-b56bf6551efd.mov

(ignore the React development errors, they're because I'm skipping the flow too quickly and am interrupting a state change on the console animation, no biggie)

I'm keeping the context and the hook separate for now, but may revisit this if we are to use suspense for further data fetching. The hook needs to be able to throw the promise for suspense to work, so it makes sense the caching logic is kept in the hook instead of putting it in the context provider just to access it in the hook.

This will fix https://github.com/gravitational/teleport/issues/20148
