### PR TITLE
[v10] Decode URL encoded values from AppLauncher's ARN.

### DIFF
--- a/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -43,6 +43,11 @@ export function AppLauncher() {
         fqdn = app.fqdn;
       }
 
+      // Decode URL encoded values from the ARN.
+      if (params.arn) {
+        params.arn = decodeURIComponent(params.arn);
+      }
+
       const port = location.port ? `:${location.port}` : '';
       const session = await service.createAppSession(params);
 


### PR DESCRIPTION
The new app access authentication workflow inadvertently preserves the URL encoded values present in the AWS role ARN, which are then passed directly to the webapi/sessions endpoint. As a result, Teleport RBAC doesn't properly match AWS role ARNs, as they contain (in particular) `/` characters encoded as `%2F`.